### PR TITLE
feat: real-time document sync with editing lock

### DIFF
--- a/e2e/realtime-sync.spec.ts
+++ b/e2e/realtime-sync.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+
+/**
+ * Real-time sync E2E tests.
+ *
+ * These tests require:
+ * 1. A running Supabase instance (local or remote)
+ * 2. A valid test user account
+ * 3. At least one document created for the test user
+ *
+ * Set the following environment variables before running:
+ *   TEST_USER_EMAIL - email for the test account
+ *   TEST_USER_PASSWORD - password for the test account
+ *   TEST_DOC_URL - full path to the document page, e.g. /dashboard/documents/<uuid>
+ *
+ * Run with: TEST_USER_EMAIL=... TEST_USER_PASSWORD=... TEST_DOC_URL=... pnpm test:e2e -- realtime-sync
+ */
+
+const TEST_EMAIL = process.env.TEST_USER_EMAIL ?? '';
+const TEST_PASSWORD = process.env.TEST_USER_PASSWORD ?? '';
+const TEST_DOC_URL = process.env.TEST_DOC_URL ?? '';
+
+async function login(page: Page) {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill(TEST_EMAIL);
+  await page.getByLabel('Password').fill(TEST_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard**');
+}
+
+function getEditor(page: Page) {
+  return page.locator('.ProseMirror');
+}
+
+test.describe('Realtime document sync', () => {
+  test.skip(
+    !TEST_EMAIL || !TEST_PASSWORD || !TEST_DOC_URL,
+    'Skipping: TEST_USER_EMAIL, TEST_USER_PASSWORD, and TEST_DOC_URL env vars required',
+  );
+
+  let contextA: BrowserContext;
+  let contextB: BrowserContext;
+  let pageA: Page;
+  let pageB: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    // Create two separate browser contexts (simulating two tabs/devices)
+    contextA = await browser.newContext();
+    contextB = await browser.newContext();
+    pageA = await contextA.newPage();
+    pageB = await contextB.newPage();
+
+    // Log in on both contexts
+    await Promise.all([login(pageA), login(pageB)]);
+  });
+
+  test.afterAll(async () => {
+    await contextA.close();
+    await contextB.close();
+  });
+
+  test('typing in Tab A appears in Tab B with lock indicator', async () => {
+    // Navigate both tabs to the same document
+    await Promise.all([pageA.goto(TEST_DOC_URL), pageB.goto(TEST_DOC_URL)]);
+
+    // Wait for editors to load
+    await expect(getEditor(pageA)).toBeVisible();
+    await expect(getEditor(pageB)).toBeVisible();
+
+    // Wait for realtime connection (green dot)
+    await expect(pageA.locator('text=Synced')).toBeVisible({ timeout: 10000 });
+    await expect(pageB.locator('text=Synced')).toBeVisible({ timeout: 10000 });
+
+    // Type in Tab A
+    const testText = `sync-test-${Date.now()}`;
+    await getEditor(pageA).click();
+    await pageA.keyboard.press('End');
+    await pageA.keyboard.press('Enter');
+    await pageA.keyboard.type(testText);
+
+    // Wait for debounce (800ms) + network round trip
+    await pageA.waitForTimeout(3000);
+
+    // Verify the text appears in Tab B
+    await expect(getEditor(pageB)).toContainText(testText, {
+      timeout: 10000,
+    });
+
+    // Verify Tab B shows the lock indicator
+    await expect(pageB.locator('text=Editing elsewhere')).toBeVisible();
+    await expect(pageB.locator('text=Take over editing')).toBeVisible();
+
+    // Click "Take over" on Tab B and verify editor becomes editable
+    await pageB.locator('text=Take over editing').click();
+    await expect(pageB.locator('text=Editing elsewhere')).not.toBeVisible();
+    await expect(pageB.locator('text=Synced')).toBeVisible();
+  });
+});

--- a/src/components/editor/tiptap-editor.tsx
+++ b/src/components/editor/tiptap-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
@@ -9,11 +9,9 @@ import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
 import Link from '@tiptap/extension-link';
 import type { Document } from '@/types/database';
-import { useAutoSave, type SaveStatus } from '@/hooks/use-auto-save';
-import {
-  updateDocumentContent,
-  updateDocumentTitle,
-} from '@/lib/actions/documents';
+import type { SaveStatus } from '@/hooks/use-auto-save';
+import type { ConnectionStatus } from '@/hooks/use-realtime-sync';
+import { useDocumentSync } from '@/hooks/use-document-sync';
 import { AutoDirection } from '@/lib/editor/rtl-extension';
 import { EditorToolbar } from './editor-toolbar';
 
@@ -43,8 +41,41 @@ function SaveIndicator({ status }: { status: SaveStatus }) {
   return <span className={`text-sm ${colors[status]}`}>{labels[status]}</span>;
 }
 
+function ConnectionIndicator({
+  status,
+  isLockedByRemote,
+}: {
+  status: ConnectionStatus;
+  isLockedByRemote: boolean;
+}) {
+  if (isLockedByRemote) {
+    return (
+      <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+        <span className="inline-block h-2 w-2 rounded-full bg-yellow-500" />
+        Editing elsewhere
+      </span>
+    );
+  }
+
+  const config: Record<ConnectionStatus, { color: string; label: string }> = {
+    connected: { color: 'bg-green-500', label: 'Synced' },
+    connecting: { color: 'bg-yellow-500', label: 'Connecting' },
+    disconnected: { color: 'bg-red-500', label: 'Disconnected' },
+  };
+
+  const { color, label } = config[status];
+
+  return (
+    <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <span className={`inline-block h-2 w-2 rounded-full ${color}`} />
+      {label}
+    </span>
+  );
+}
+
 export function TiptapEditor({ document }: TiptapEditorProps) {
   const [title, setTitle] = useState(document.title);
+  const skipNextUpdateRef = useRef(false);
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -76,23 +107,48 @@ export function TiptapEditor({ document }: TiptapEditorProps) {
       },
     },
     onUpdate: () => {
-      trigger();
+      if (skipNextUpdateRef.current) {
+        skipNextUpdateRef.current = false;
+        return;
+      }
+      triggerSave();
     },
   });
 
-  const saveFn = useCallback(async () => {
-    if (!editor) return;
-    const content = editor.getJSON() as Record<string, unknown>;
-    await updateDocumentContent(document.id, content);
-  }, [editor, document.id]);
+  const onRemoteTitleUpdate = useCallback((remoteTitle: string) => {
+    setTitle(remoteTitle);
+  }, []);
 
-  const { status, trigger } = useAutoSave(saveFn);
+  const {
+    saveStatus,
+    connectionStatus,
+    isLockedByRemote,
+    unlockEditor,
+    triggerSave,
+    saveTitle,
+  } = useDocumentSync({
+    documentId: document.id,
+    editor,
+    onRemoteTitleUpdate,
+  });
 
   const handleTitleBlur = async () => {
     if (title !== document.title) {
-      await updateDocumentTitle(document.id, title);
+      await saveTitle(title);
     }
   };
+
+  const handleTakeOver = () => {
+    unlockEditor();
+    editor?.setEditable(true);
+    editor?.commands.focus();
+  };
+
+  // Toggle editor editability based on remote lock
+  useEffect(() => {
+    if (!editor) return;
+    editor.setEditable(!isLockedByRemote);
+  }, [editor, isLockedByRemote]);
 
   if (!editor) return null;
 
@@ -110,8 +166,27 @@ export function TiptapEditor({ document }: TiptapEditorProps) {
           className="text-xl font-semibold bg-transparent border-none outline-none flex-1"
           placeholder="Untitled"
         />
-        <SaveIndicator status={status} />
+        <div className="flex items-center gap-3">
+          <ConnectionIndicator
+            status={connectionStatus}
+            isLockedByRemote={isLockedByRemote}
+          />
+          <SaveIndicator status={saveStatus} />
+        </div>
       </div>
+
+      {/* Remote editing lock banner */}
+      {isLockedByRemote && (
+        <div className="flex items-center justify-between bg-yellow-50 border-b border-yellow-200 px-4 py-2 text-sm text-yellow-800">
+          <span>This document is being edited on another device.</span>
+          <button
+            onClick={handleTakeOver}
+            className="font-medium underline hover:text-yellow-900"
+          >
+            Take over editing
+          </button>
+        </div>
+      )}
 
       {/* Toolbar */}
       <EditorToolbar editor={editor} />

--- a/src/hooks/use-auto-save.test.ts
+++ b/src/hooks/use-auto-save.test.ts
@@ -103,6 +103,42 @@ describe('useAutoSave', () => {
     expect(result.current.status).toBe('saved');
   });
 
+  it('updates lastSaveTimestampRef when saveFn returns updated_at', async () => {
+    const saveFn = vi
+      .fn()
+      .mockResolvedValue({ updated_at: '2026-01-01T00:00:00Z' });
+    const { result } = renderHook(() => useAutoSave(saveFn, 500));
+
+    act(() => {
+      result.current.trigger();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(result.current.lastSaveTimestampRef.current).toBe(
+      '2026-01-01T00:00:00Z',
+    );
+  });
+
+  it('keeps lastSaveTimestampRef null when saveFn returns void', async () => {
+    const saveFn = vi.fn().mockResolvedValue(undefined);
+    const { result } = renderHook(() => useAutoSave(saveFn, 500));
+
+    act(() => {
+      result.current.trigger();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+      await Promise.resolve();
+    });
+
+    expect(result.current.lastSaveTimestampRef.current).toBeNull();
+  });
+
   it('sets status back to "unsaved" when save fails', async () => {
     const saveFn = vi.fn().mockRejectedValue(new Error('Save failed'));
     const { result } = renderHook(() => useAutoSave(saveFn, 500));

--- a/src/hooks/use-auto-save.ts
+++ b/src/hooks/use-auto-save.ts
@@ -2,31 +2,41 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 export type SaveStatus = 'saved' | 'saving' | 'unsaved';
 
+export interface SaveResult {
+  updated_at: string;
+}
+
 export function useAutoSave(
-  saveFn: () => Promise<void>,
+  saveFn: () => Promise<SaveResult | void>,
   debounceMs: number = 800,
 ) {
   const [status, setStatus] = useState<SaveStatus>('saved');
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const saveFnRef = useRef(saveFn);
+  const lastSaveTimestampRef = useRef<string | null>(null);
 
   useEffect(() => {
     saveFnRef.current = saveFn;
   }, [saveFn]);
 
+  const performSave = useCallback(async () => {
+    setStatus('saving');
+    try {
+      const result = await saveFnRef.current();
+      if (result?.updated_at) {
+        lastSaveTimestampRef.current = result.updated_at;
+      }
+      setStatus('saved');
+    } catch {
+      setStatus('unsaved');
+    }
+  }, []);
+
   const trigger = useCallback(() => {
     setStatus('unsaved');
     if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    timeoutRef.current = setTimeout(async () => {
-      setStatus('saving');
-      try {
-        await saveFnRef.current();
-        setStatus('saved');
-      } catch {
-        setStatus('unsaved');
-      }
-    }, debounceMs);
-  }, [debounceMs]);
+    timeoutRef.current = setTimeout(performSave, debounceMs);
+  }, [debounceMs, performSave]);
 
   const flush = useCallback(async () => {
     if (timeoutRef.current) {
@@ -34,15 +44,9 @@ export function useAutoSave(
       timeoutRef.current = null;
     }
     if (status === 'unsaved') {
-      setStatus('saving');
-      try {
-        await saveFnRef.current();
-        setStatus('saved');
-      } catch {
-        setStatus('unsaved');
-      }
+      await performSave();
     }
-  }, [status]);
+  }, [status, performSave]);
 
   // beforeunload handler
   useEffect(() => {
@@ -60,5 +64,5 @@ export function useAutoSave(
     };
   }, []);
 
-  return { status, trigger, flush };
+  return { status, trigger, flush, lastSaveTimestampRef };
 }

--- a/src/hooks/use-document-sync.ts
+++ b/src/hooks/use-document-sync.ts
@@ -1,0 +1,87 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useAutoSave, type SaveStatus } from './use-auto-save';
+import { useRealtimeSync, type ConnectionStatus } from './use-realtime-sync';
+import {
+  updateDocumentContent,
+  updateDocumentTitle,
+} from '@/lib/actions/documents';
+import type { Editor } from '@tiptap/core';
+
+interface UseDocumentSyncOptions {
+  documentId: string;
+  editor: Editor | null;
+  onRemoteTitleUpdate: (title: string) => void;
+}
+
+interface UseDocumentSyncReturn {
+  saveStatus: SaveStatus;
+  connectionStatus: ConnectionStatus;
+  isLockedByRemote: boolean;
+  unlockEditor: () => void;
+  triggerSave: () => void;
+  flushSave: () => Promise<void>;
+  lastSaveTimestampRef: React.RefObject<string | null>;
+  saveTitle: (title: string) => Promise<void>;
+}
+
+export function useDocumentSync({
+  documentId,
+  editor,
+  onRemoteTitleUpdate,
+}: UseDocumentSyncOptions): UseDocumentSyncReturn {
+  const [isLockedByRemote, setIsLockedByRemote] = useState(false);
+
+  const saveFn = useCallback(async () => {
+    if (!editor) return;
+    const content = editor.getJSON() as Record<string, unknown>;
+    return updateDocumentContent(documentId, content);
+  }, [editor, documentId]);
+
+  const {
+    status: saveStatus,
+    trigger: triggerSave,
+    flush: flushSave,
+    lastSaveTimestampRef,
+  } = useAutoSave(saveFn);
+
+  const onRemoteContentUpdate = useCallback(
+    (content: Record<string, unknown>) => {
+      if (!editor) return;
+      editor.commands.setContent(content, { emitUpdate: false });
+      setIsLockedByRemote(true);
+    },
+    [editor],
+  );
+
+  const { connectionStatus } = useRealtimeSync({
+    documentId,
+    lastSaveTimestampRef,
+    onRemoteContentUpdate,
+    onRemoteTitleUpdate,
+  });
+
+  const saveTitle = useCallback(
+    async (title: string) => {
+      const result = await updateDocumentTitle(documentId, title);
+      lastSaveTimestampRef.current = result.updated_at;
+    },
+    [documentId, lastSaveTimestampRef],
+  );
+
+  const unlockEditor = useCallback(() => {
+    setIsLockedByRemote(false);
+  }, []);
+
+  return {
+    saveStatus,
+    connectionStatus,
+    isLockedByRemote,
+    unlockEditor,
+    triggerSave,
+    flushSave,
+    lastSaveTimestampRef,
+    saveTitle,
+  };
+}

--- a/src/hooks/use-network-status.ts
+++ b/src/hooks/use-network-status.ts
@@ -1,0 +1,27 @@
+import { useSyncExternalStore } from 'react';
+
+function subscribe(callback: () => void) {
+  window.addEventListener('online', callback);
+  window.addEventListener('offline', callback);
+  return () => {
+    window.removeEventListener('online', callback);
+    window.removeEventListener('offline', callback);
+  };
+}
+
+function getSnapshot() {
+  return navigator.onLine;
+}
+
+function getServerSnapshot() {
+  return true;
+}
+
+export function useNetworkStatus() {
+  const isOnline = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    getServerSnapshot,
+  );
+  return { isOnline };
+}

--- a/src/hooks/use-realtime-sync.test.ts
+++ b/src/hooks/use-realtime-sync.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRealtimeSync } from './use-realtime-sync';
+
+// Track the postgres_changes callback and subscribe callback
+let postgresChangesCallback: (payload: unknown) => void;
+let subscribeCallback: (status: string) => void;
+
+const mockRemoveChannel = vi.fn();
+const mockSubscribe = vi.fn((cb: (status: string) => void) => {
+  subscribeCallback = cb;
+  return mockChannel;
+});
+const mockOn = vi.fn(
+  (_event: string, _filter: unknown, cb: (payload: unknown) => void) => {
+    postgresChangesCallback = cb;
+    return { subscribe: mockSubscribe };
+  },
+);
+const mockChannel = {
+  on: mockOn,
+  subscribe: mockSubscribe,
+};
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    channel: () => mockChannel,
+    removeChannel: mockRemoveChannel,
+  }),
+}));
+
+describe('useRealtimeSync', () => {
+  const defaultProps = {
+    documentId: 'doc-123',
+    lastSaveTimestampRef: { current: null } as React.RefObject<string | null>,
+    onRemoteContentUpdate: vi.fn(),
+    onRemoteTitleUpdate: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with "connecting" status', () => {
+    const { result } = renderHook(() => useRealtimeSync(defaultProps));
+    expect(result.current.connectionStatus).toBe('connecting');
+  });
+
+  it('sets status to "connected" when subscribed', () => {
+    const { result } = renderHook(() => useRealtimeSync(defaultProps));
+
+    act(() => {
+      subscribeCallback('SUBSCRIBED');
+    });
+
+    expect(result.current.connectionStatus).toBe('connected');
+  });
+
+  it('sets status to "disconnected" on channel error', () => {
+    const { result } = renderHook(() => useRealtimeSync(defaultProps));
+
+    act(() => {
+      subscribeCallback('CHANNEL_ERROR');
+    });
+
+    expect(result.current.connectionStatus).toBe('disconnected');
+  });
+
+  it('calls onRemoteContentUpdate and onRemoteTitleUpdate on remote change', () => {
+    const onContent = vi.fn();
+    const onTitle = vi.fn();
+
+    renderHook(() =>
+      useRealtimeSync({
+        ...defaultProps,
+        onRemoteContentUpdate: onContent,
+        onRemoteTitleUpdate: onTitle,
+      }),
+    );
+
+    act(() => {
+      postgresChangesCallback({
+        new: {
+          updated_at: '2026-01-01T00:00:01Z',
+          content: { type: 'doc', content: [] },
+          title: 'Remote Title',
+        },
+      });
+    });
+
+    expect(onContent).toHaveBeenCalledWith({ type: 'doc', content: [] });
+    expect(onTitle).toHaveBeenCalledWith('Remote Title');
+  });
+
+  it('ignores echo: skips update when updated_at matches lastSaveTimestamp', () => {
+    const onContent = vi.fn();
+    const onTitle = vi.fn();
+    const lastSaveRef = { current: '2026-01-01T00:00:01Z' };
+
+    renderHook(() =>
+      useRealtimeSync({
+        ...defaultProps,
+        lastSaveTimestampRef: lastSaveRef,
+        onRemoteContentUpdate: onContent,
+        onRemoteTitleUpdate: onTitle,
+      }),
+    );
+
+    act(() => {
+      postgresChangesCallback({
+        new: {
+          updated_at: '2026-01-01T00:00:01Z',
+          content: { type: 'doc' },
+          title: 'Same',
+        },
+      });
+    });
+
+    expect(onContent).not.toHaveBeenCalled();
+    expect(onTitle).not.toHaveBeenCalled();
+  });
+
+  it('cleans up channel on unmount', () => {
+    const { unmount } = renderHook(() => useRealtimeSync(defaultProps));
+    unmount();
+    expect(mockRemoveChannel).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/use-realtime-sync.ts
+++ b/src/hooks/use-realtime-sync.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+import type { RealtimeChannel } from '@supabase/supabase-js';
+
+export type ConnectionStatus = 'connected' | 'connecting' | 'disconnected';
+
+interface UseRealtimeSyncOptions {
+  documentId: string;
+  lastSaveTimestampRef: React.RefObject<string | null>;
+  onRemoteContentUpdate: (content: Record<string, unknown>) => void;
+  onRemoteTitleUpdate: (title: string) => void;
+}
+
+export function useRealtimeSync({
+  documentId,
+  lastSaveTimestampRef,
+  onRemoteContentUpdate,
+  onRemoteTitleUpdate,
+}: UseRealtimeSyncOptions) {
+  const [connectionStatus, setConnectionStatus] =
+    useState<ConnectionStatus>('connecting');
+  const channelRef = useRef<RealtimeChannel | null>(null);
+
+  // Keep callbacks in refs to avoid re-subscribing
+  const onRemoteContentRef = useRef(onRemoteContentUpdate);
+  const onRemoteTitleRef = useRef(onRemoteTitleUpdate);
+
+  useEffect(() => {
+    onRemoteContentRef.current = onRemoteContentUpdate;
+  }, [onRemoteContentUpdate]);
+
+  useEffect(() => {
+    onRemoteTitleRef.current = onRemoteTitleUpdate;
+  }, [onRemoteTitleUpdate]);
+
+  useEffect(() => {
+    const supabase = createClient();
+
+    const channel = supabase
+      .channel(`document:${documentId}`)
+      .on(
+        'postgres_changes',
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'documents',
+          filter: `id=eq.${documentId}`,
+        },
+        (payload) => {
+          const newRecord = payload.new as {
+            updated_at: string;
+            content: Record<string, unknown>;
+            title: string;
+          };
+
+          // Echo guard: if this update came from our own save, ignore it
+          if (newRecord.updated_at === lastSaveTimestampRef.current) {
+            return;
+          }
+
+          onRemoteContentRef.current(newRecord.content);
+          onRemoteTitleRef.current(newRecord.title);
+        },
+      )
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          setConnectionStatus('connected');
+        } else if (status === 'CLOSED' || status === 'CHANNEL_ERROR') {
+          setConnectionStatus('disconnected');
+        } else {
+          setConnectionStatus('connecting');
+        }
+      });
+
+    channelRef.current = channel;
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [documentId, lastSaveTimestampRef]);
+
+  return { connectionStatus };
+}

--- a/src/lib/actions/documents.ts
+++ b/src/lib/actions/documents.ts
@@ -99,20 +99,29 @@ export async function moveDocument(id: string, folderId: string | null) {
 export async function updateDocumentContent(
   id: string,
   content: Record<string, unknown>,
-) {
+): Promise<{ updated_at: string }> {
   const supabase = await createClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('documents')
     .update({ content })
-    .eq('id', id);
+    .eq('id', id)
+    .select('updated_at')
+    .single();
   if (error) throw new Error(error.message);
+  return { updated_at: data.updated_at };
 }
 
-export async function updateDocumentTitle(id: string, title: string) {
+export async function updateDocumentTitle(
+  id: string,
+  title: string,
+): Promise<{ updated_at: string }> {
   const supabase = await createClient();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('documents')
     .update({ title })
-    .eq('id', id);
+    .eq('id', id)
+    .select('updated_at')
+    .single();
   if (error) throw new Error(error.message);
+  return { updated_at: data.updated_at };
 }

--- a/supabase/migrations/00002_enable_realtime_documents.sql
+++ b/supabase/migrations/00002_enable_realtime_documents.sql
@@ -1,0 +1,1 @@
+alter publication supabase_realtime add table public.documents;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,159 @@
+-- Seed test user for local development
+-- Email: test@typenote.dev | Password: Test1234
+
+-- Insert into auth.users (Supabase auth table)
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  recovery_token
+) VALUES (
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'test@typenote.dev',
+  crypt('Test1234', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{"email":"test@typenote.dev","email_verified":true,"full_name":"Test User"}',
+  now(),
+  now(),
+  '',
+  ''
+) ON CONFLICT (id) DO NOTHING;
+
+-- Insert identity for the user
+INSERT INTO auth.identities (
+  id,
+  user_id,
+  identity_data,
+  provider,
+  provider_id,
+  last_sign_in_at,
+  created_at,
+  updated_at
+) VALUES (
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '{"sub":"ac3be77d-4566-406c-9ac0-7c410634ad41","email":"test@typenote.dev","email_verified":true}',
+  'email',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  now(),
+  now(),
+  now()
+) ON CONFLICT (provider_id, provider) DO NOTHING;
+
+-- The profile will be auto-created by the handle_new_user() trigger.
+
+-- ============================================
+-- FOLDERS (Notebooks)
+-- ============================================
+
+-- Calculus I
+INSERT INTO public.folders (id, user_id, parent_id, name, color, position)
+VALUES ('10000000-0000-0000-0000-000000000001', 'ac3be77d-4566-406c-9ac0-7c410634ad41', NULL, 'Calculus I', '#EF4444', 0)
+ON CONFLICT (id) DO NOTHING;
+
+-- Calculus II
+INSERT INTO public.folders (id, user_id, parent_id, name, color, position)
+VALUES ('10000000-0000-0000-0000-000000000002', 'ac3be77d-4566-406c-9ac0-7c410634ad41', NULL, 'Calculus II', '#F97316', 1)
+ON CONFLICT (id) DO NOTHING;
+
+-- Linear Algebra
+INSERT INTO public.folders (id, user_id, parent_id, name, color, position)
+VALUES ('10000000-0000-0000-0000-000000000003', 'ac3be77d-4566-406c-9ac0-7c410634ad41', NULL, 'Linear Algebra', '#8B5CF6', 2)
+ON CONFLICT (id) DO NOTHING;
+
+-- Data Structures
+INSERT INTO public.folders (id, user_id, parent_id, name, color, position)
+VALUES ('10000000-0000-0000-0000-000000000004', 'ac3be77d-4566-406c-9ac0-7c410634ad41', NULL, 'Data Structures', '#3B82F6', 3)
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- DOCUMENTS
+-- ============================================
+
+-- Calculus I documents
+INSERT INTO public.documents (id, user_id, folder_id, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000001',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '10000000-0000-0000-0000-000000000001',
+  'Limits and Continuity',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Limits and Continuity"}]},{"type":"paragraph","content":[{"type":"text","text":"A limit describes the value a function approaches as the input approaches a given point."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Key Definitions"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Limit:"},{"type":"text","text":" lim x\u2192a f(x) = L means f(x) gets arbitrarily close to L as x approaches a."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Continuity:"},{"type":"text","text":" f is continuous at a if lim x\u2192a f(x) = f(a)."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Squeeze Theorem:"},{"type":"text","text":" If g(x) \u2264 f(x) \u2264 h(x) and lim g(x) = lim h(x) = L, then lim f(x) = L."}]}]}]}]}',
+  'calculus',
+  'lined',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.documents (id, user_id, folder_id, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000002',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '10000000-0000-0000-0000-000000000001',
+  'Derivatives',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Derivatives"}]},{"type":"paragraph","content":[{"type":"text","text":"The derivative measures the instantaneous rate of change of a function."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Derivative Rules"}]},{"type":"orderedList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Power Rule:"},{"type":"text","text":" d/dx [x^n] = nx^(n-1)"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Product Rule:"},{"type":"text","text":" d/dx [f\u00b7g] = f\u2032g + fg\u2032"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Chain Rule:"},{"type":"text","text":" d/dx [f(g(x))] = f\u2032(g(x)) \u00b7 g\u2032(x)"}]}]}]}]}',
+  'calculus',
+  'lined',
+  1
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.documents (id, user_id, folder_id, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000003',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '10000000-0000-0000-0000-000000000001',
+  'Integration Techniques',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Integration Techniques"}]},{"type":"paragraph","content":[{"type":"text","text":"Integration is the reverse process of differentiation. Here are the main techniques:"}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Methods"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Substitution:"},{"type":"text","text":" Replace a composite expression with a single variable u."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Integration by Parts:"},{"type":"text","text":" \u222b u dv = uv - \u222b v du"}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Partial Fractions:"},{"type":"text","text":" Decompose rational functions into simpler fractions."}]}]}]}]}',
+  'calculus',
+  'lined',
+  2
+) ON CONFLICT (id) DO NOTHING;
+
+-- Calculus II documents
+INSERT INTO public.documents (id, user_id, folder_id, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000004',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '10000000-0000-0000-0000-000000000002',
+  'Sequences and Series',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Sequences and Series"}]},{"type":"paragraph","content":[{"type":"text","text":"A sequence is an ordered list of numbers. A series is the sum of a sequence."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Convergence Tests"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Ratio Test:"},{"type":"text","text":" If lim |a(n+1)/a(n)| < 1, the series converges absolutely."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Integral Test:"},{"type":"text","text":" If f is positive and decreasing, \u2211f(n) converges iff \u222bf(x)dx converges."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","marks":[{"type":"bold"}],"text":"Comparison Test:"},{"type":"text","text":" Compare with a known convergent or divergent series."}]}]}]}]}',
+  'calculus',
+  'blank',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.documents (id, user_id, folder_id, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000005',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '10000000-0000-0000-0000-000000000002',
+  'Taylor and Maclaurin Series',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Taylor and Maclaurin Series"}]},{"type":"paragraph","content":[{"type":"text","text":"A Taylor series represents a function as an infinite sum of terms calculated from the values of its derivatives at a single point."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Common Expansions"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"e^x = 1 + x + x\u00b2/2! + x\u00b3/3! + ..."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"sin(x) = x - x\u00b3/3! + x\u2075/5! - ..."}]}]},{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"cos(x) = 1 - x\u00b2/2! + x\u2074/4! - ..."}]}]}]}]}',
+  'calculus',
+  'blank',
+  1
+) ON CONFLICT (id) DO NOTHING;
+
+-- Loose document (no folder)
+INSERT INTO public.documents (id, user_id, folder_id, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000006',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  NULL,
+  'Quick Notes',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"Scratch pad for random ideas and quick notes."}]}]}',
+  'other',
+  'blank',
+  0
+) ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary
- Enable Supabase Realtime on the `documents` table for instant cross-tab/device sync
- When a remote edit is received, the editor locks to read-only with an "Editing elsewhere" banner and "Take over" button
- Auto-save returns `updated_at` for echo-guard deduplication (prevents reacting to your own saves)
- New hooks: `useRealtimeSync`, `useDocumentSync`, `useNetworkStatus`

## Test plan
- [ ] `pnpm test` — 94 tests pass (including 8 auto-save + 6 realtime-sync)
- [ ] `pnpm lint && pnpm format:check` — clean
- [ ] `pnpm build` — compiles
- [ ] Manual: open same doc in two tabs, type in Tab A → Tab B shows content + yellow "Editing elsewhere" banner
- [ ] Manual: click "Take over editing" on Tab B → editor unlocks, can type there

🤖 Generated with [Claude Code](https://claude.com/claude-code)