### PR TITLE
fix: crop captures text content via html-to-image

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ai": "^6.0.116",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "html-to-image": "^1.11.13",
     "jspdf": "^4.2.0",
     "katex": "^0.16.37",
     "lucide-react": "^0.577.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       jspdf:
         specifier: ^4.2.0
         version: 4.2.0
@@ -4316,6 +4319,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
@@ -11077,6 +11083,8 @@ snapshots:
       '@exodus/bytes': 1.15.0(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-to-image@1.11.13: {}
 
   html-url-attributes@3.0.1: {}
 

--- a/src/components/canvas/canvas-editor.tsx
+++ b/src/components/canvas/canvas-editor.tsx
@@ -1241,7 +1241,11 @@ export function CanvasEditor({
   const pageCanvasRefsMap = useRef<
     Map<
       string,
-      { pdf: HTMLCanvasElement | null; strokes: HTMLCanvasElement | null }
+      {
+        pdf: HTMLCanvasElement | null;
+        strokes: HTMLCanvasElement | null;
+        element: HTMLDivElement | null;
+      }
     >
   >(new Map());
 
@@ -1250,10 +1254,12 @@ export function CanvasEditor({
       pageId: string,
       pdfCanvas: HTMLCanvasElement | null,
       strokesCanvas: HTMLCanvasElement | null,
+      pageElement: HTMLDivElement | null,
     ) => {
       pageCanvasRefsMap.current.set(pageId, {
         pdf: pdfCanvas,
         strokes: strokesCanvas,
+        element: pageElement,
       });
     },
     [],
@@ -1268,38 +1274,40 @@ export function CanvasEditor({
   );
 
   const handleAskAiWithRegion = useCallback(
-    (bbox: BBox, pageId: string) => {
+    async (bbox: BBox, pageId: string) => {
       const refs = pageCanvasRefsMap.current.get(pageId);
-      if (!refs) return;
+      if (!refs?.element) return;
 
-      const dpr = window.devicePixelRatio || 1;
-
-      // Create offscreen canvas at the region size
       const w = bbox.maxX - bbox.minX;
       const h = bbox.maxY - bbox.minY;
       if (w < 20 || h < 20) return;
 
-      const offscreen = window.document.createElement('canvas');
-      const outW = Math.round(w * dpr);
-      const outH = Math.round(h * dpr);
-      offscreen.width = outW;
-      offscreen.height = outH;
-
-      const ctx = offscreen.getContext('2d');
-      if (!ctx) return;
-
-      const sx = Math.round(bbox.minX * dpr);
-      const sy = Math.round(bbox.minY * dpr);
-
-      if (refs.pdf) {
-        ctx.drawImage(refs.pdf, sx, sy, outW, outH, 0, 0, outW, outH);
+      try {
+        const { toPng } = await import('html-to-image');
+        const dpr = window.devicePixelRatio || 1;
+        const dataUrl = await toPng(refs.element, {
+          pixelRatio: dpr,
+          canvasWidth: Math.round(w * dpr),
+          canvasHeight: Math.round(h * dpr),
+          width: w,
+          height: h,
+          style: {
+            transform: `translate(-${bbox.minX}px, -${bbox.minY}px)`,
+            transformOrigin: 'top left',
+          },
+          filter: (node) => {
+            // Exclude the crop overlay and floating bars from the screenshot
+            if (node instanceof HTMLElement) {
+              const z = node.style?.zIndex;
+              if (z === '8' || z === '10' || z === '100') return false;
+            }
+            return true;
+          },
+        });
+        onAskAiWithContext?.({ type: 'image', dataUrl });
+      } catch (err) {
+        console.error('Region capture failed:', err);
       }
-      if (refs.strokes) {
-        ctx.drawImage(refs.strokes, sx, sy, outW, outH, 0, 0, outW, outH);
-      }
-
-      const dataUrl = offscreen.toDataURL('image/png');
-      onAskAiWithContext?.({ type: 'image', dataUrl });
     },
     [onAskAiWithContext],
   );

--- a/src/components/canvas/canvas-page.tsx
+++ b/src/components/canvas/canvas-page.tsx
@@ -77,6 +77,7 @@ interface CanvasPageProps {
     pageId: string,
     pdfCanvas: HTMLCanvasElement | null,
     strokesCanvas: HTMLCanvasElement | null,
+    pageElement: HTMLDivElement | null,
   ) => void;
 }
 
@@ -113,6 +114,7 @@ export function CanvasPage({
   onAskAiWithRegion,
   onCanvasRefsReady,
 }: CanvasPageProps) {
+  const pageRootRef = useRef<HTMLDivElement>(null);
   const pdfCanvasRef = useRef<HTMLCanvasElement>(null);
   const committedCanvasRef = useRef<HTMLCanvasElement>(null);
   const workingCanvasRef = useRef<HTMLCanvasElement>(null);
@@ -224,6 +226,7 @@ export function CanvasPage({
       page.id,
       pdfCanvasRef.current,
       committedCanvasRef.current,
+      pageRootRef.current,
     );
   }, [page.id, onCanvasRefsReady]);
 
@@ -565,6 +568,7 @@ export function CanvasPage({
 
   return (
     <div
+      ref={pageRootRef}
       className="relative bg-white shadow-md mx-auto"
       style={{
         width: PAGE_WIDTH,


### PR DESCRIPTION
Crop now captures the full page DOM (text + strokes + PDF) instead of just canvas layers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)