### PR TITLE
feat: unified toolbar with Read + Crop on all documents

### DIFF
--- a/src/components/canvas/canvas-editor.tsx
+++ b/src/components/canvas/canvas-editor.tsx
@@ -1462,22 +1462,20 @@ export function CanvasEditor({
             <Type className="h-4 w-4" />
             Type
           </button>
-          {materialId && (
-            <button
-              onPointerDown={(e) => {
-                e.stopPropagation();
-                setActiveTool('read');
-              }}
-              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                isReadMode
-                  ? 'bg-primary text-primary-foreground'
-                  : 'hover:bg-accent text-muted-foreground'
-              }`}
-            >
-              <BookOpen className="h-4 w-4" />
-              Read
-            </button>
-          )}
+          <button
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              setActiveTool('read');
+            }}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              isReadMode
+                ? 'bg-primary text-primary-foreground'
+                : 'hover:bg-accent text-muted-foreground'
+            }`}
+          >
+            <BookOpen className="h-4 w-4" />
+            Read
+          </button>
           <button
             onPointerDown={(e) => {
               e.stopPropagation();

--- a/src/components/canvas/canvas-page.tsx
+++ b/src/components/canvas/canvas-page.tsx
@@ -196,6 +196,35 @@ export function CanvasPage({
     [],
   );
 
+  // Listen for text selection in text boxes (Read mode on non-PDF docs)
+  useEffect(() => {
+    if (activeTool !== 'read') return;
+    // Skip if this page has a PDF text layer (PdfTextLayer handles selection)
+    if (page.pdfPage != null && materialId) return;
+
+    const handleSelectionChange = () => {
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed || !sel.rangeCount) {
+        handleTextSelected('', null);
+        return;
+      }
+      const range = sel.getRangeAt(0);
+      const layer = textLayerRef.current;
+      if (!layer || !layer.contains(range.commonAncestorContainer)) return;
+
+      const text = sel.toString().trim();
+      if (text) {
+        handleTextSelected(text, range.getBoundingClientRect());
+      } else {
+        handleTextSelected('', null);
+      }
+    };
+
+    document.addEventListener('selectionchange', handleSelectionChange);
+    return () =>
+      document.removeEventListener('selectionchange', handleSelectionChange);
+  }, [activeTool, page.pdfPage, materialId, handleTextSelected]);
+
   const isInteractionMode =
     activeTool === 'pen' ||
     activeTool === 'highlighter' ||
@@ -612,7 +641,10 @@ export function CanvasPage({
         className="absolute inset-0 overflow-hidden"
         style={{
           pointerEvents:
-            isInteractionMode || activeTool === 'read' ? 'none' : 'auto',
+            isInteractionMode ||
+            (activeTool === 'read' && page.pdfPage != null && !!materialId)
+              ? 'none'
+              : 'auto',
         }}
       >
         {/* Flow editor — hidden when page has text boxes (text was migrated) */}


### PR DESCRIPTION
One toolbar for all documents. No more materialId gating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)