### PR TITLE
fix: Read mode preserves text direction and layout

### DIFF
--- a/src/components/canvas/canvas-page.tsx
+++ b/src/components/canvas/canvas-page.tsx
@@ -602,8 +602,8 @@ export function CanvasPage({
       style={{
         width: PAGE_WIDTH,
         height: PAGE_HEIGHT,
-        userSelect: activeTool === 'read' ? 'text' : 'none',
-        WebkitUserSelect: activeTool === 'read' ? 'text' : 'none',
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
       }}
     >
       {/* Layer 0: PDF background (material-backed documents only) */}
@@ -645,6 +645,8 @@ export function CanvasPage({
             (activeTool === 'read' && page.pdfPage != null && !!materialId)
               ? 'none'
               : 'auto',
+          userSelect: activeTool === 'read' ? 'text' : undefined,
+          WebkitUserSelect: activeTool === 'read' ? 'text' : undefined,
         }}
       >
         {/* Flow editor — hidden when page has text boxes (text was migrated) */}
@@ -657,6 +659,7 @@ export function CanvasPage({
             key={tb.id}
             textBox={tb}
             isSelected={selectedTextBoxIds.has(tb.id)}
+            readOnly={activeTool === 'read'}
             onContentUpdate={(id, content) =>
               onTextBoxContentUpdate?.(page.id, id, content)
             }

--- a/src/components/canvas/text-box.tsx
+++ b/src/components/canvas/text-box.tsx
@@ -16,6 +16,7 @@ import type { Editor } from '@tiptap/core';
 interface TextBoxProps {
   textBox: TextBoxData;
   isSelected: boolean;
+  readOnly?: boolean;
   onContentUpdate: (id: string, content: Record<string, unknown>) => void;
   onEditorReady?: (editor: Editor) => void;
   onHeightMeasured?: (id: string, height: number) => void;
@@ -24,6 +25,7 @@ interface TextBoxProps {
 export function TextBox({
   textBox,
   isSelected,
+  readOnly = false,
   onContentUpdate,
   onEditorReady,
   onHeightMeasured,
@@ -87,6 +89,15 @@ export function TextBox({
       onEditorReadyRef.current?.(editor);
     }
   }, [editor]);
+
+  // In Read mode, make the editor non-editable (text is selectable but not modifiable)
+  useEffect(() => {
+    if (!editor) return;
+    const shouldBeEditable = !readOnly;
+    if (editor.isEditable !== shouldBeEditable) {
+      editor.setEditable(shouldBeEditable);
+    }
+  }, [readOnly, editor]);
 
   // Auto-measure content height so the selection bbox stays tight.
   // Uses ResizeObserver to detect when content changes size.


### PR DESCRIPTION
Text boxes become readOnly in Read mode. userSelect scoped to text layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)