### PR TITLE
fix: preserve newlines in PDF export (closes #115)

### DIFF
--- a/src/components/canvas/canvas-editor.tsx
+++ b/src/components/canvas/canvas-editor.tsx
@@ -1258,6 +1258,48 @@ export function CanvasEditor({
     setCanRedoDraw(redoStackRef.current.length > 0);
   }, [historyVersion]);
 
+  // Track whether the active TipTap editor has anything to undo/redo.
+  // Subscribes to the editor's transaction events so the button stays in sync.
+  const [canUndoText, setCanUndoText] = useState(false);
+  const [canRedoText, setCanRedoText] = useState(false);
+  useEffect(() => {
+    if (!activeEditor) {
+      setCanUndoText(false);
+      setCanRedoText(false);
+      return;
+    }
+    const update = () => {
+      setCanUndoText(activeEditor.can().undo());
+      setCanRedoText(activeEditor.can().redo());
+    };
+    update();
+    activeEditor.on('transaction', update);
+    activeEditor.on('update', update);
+    return () => {
+      activeEditor.off('transaction', update);
+      activeEditor.off('update', update);
+    };
+  }, [activeEditor]);
+
+  // Combined: undo is enabled when the current mode has something to undo.
+  // - Draw modes (pen/highlighter/eraser) → use canvas action stack
+  // - Text mode → use active TipTap editor history
+  // - Select/Read modes → no undo path, disable button
+  const _isDrawingMode =
+    activeTool === 'pen' ||
+    activeTool === 'highlighter' ||
+    activeTool === 'eraser';
+  const canUndo = _isDrawingMode
+    ? canUndoDraw
+    : activeTool === 'text'
+      ? canUndoText
+      : false;
+  const canRedo = _isDrawingMode
+    ? canRedoDraw
+    : activeTool === 'text'
+      ? canRedoText
+      : false;
+
   // Delete selected objects with keyboard
   useEffect(() => {
     if (activeTool !== 'select') return;
@@ -1612,7 +1654,7 @@ export function CanvasEditor({
               e.stopPropagation();
               handleUndo();
             }}
-            disabled={isDrawMode ? !canUndoDraw : false}
+            disabled={!canUndo}
             className="flex items-center justify-center h-8 w-8 min-h-[44px] min-w-[44px] rounded-lg transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none text-muted-foreground"
             title="Undo"
           >
@@ -1623,7 +1665,7 @@ export function CanvasEditor({
               e.stopPropagation();
               handleRedo();
             }}
-            disabled={isDrawMode ? !canRedoDraw : false}
+            disabled={!canRedo}
             className="flex items-center justify-center h-8 w-8 min-h-[44px] min-w-[44px] rounded-lg transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none text-muted-foreground"
             title="Redo"
           >

--- a/src/components/canvas/canvas-editor.tsx
+++ b/src/components/canvas/canvas-editor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { Editor } from '@tiptap/core';
 import type {
   BBox,
@@ -1259,27 +1259,29 @@ export function CanvasEditor({
   }, [historyVersion]);
 
   // Track whether the active TipTap editor has anything to undo/redo.
-  // Subscribes to the editor's transaction events so the button stays in sync.
-  const [canUndoText, setCanUndoText] = useState(false);
-  const [canRedoText, setCanRedoText] = useState(false);
+  // Use a version counter bumped on editor events, then derive canUndo/canRedo
+  // during render. This avoids synchronous setState inside the effect body.
+  const [editorHistoryVersion, setEditorHistoryVersion] = useState(0);
   useEffect(() => {
-    if (!activeEditor) {
-      setCanUndoText(false);
-      setCanRedoText(false);
-      return;
-    }
-    const update = () => {
-      setCanUndoText(activeEditor.can().undo());
-      setCanRedoText(activeEditor.can().redo());
-    };
-    update();
-    activeEditor.on('transaction', update);
-    activeEditor.on('update', update);
+    if (!activeEditor) return;
+    const bump = () => setEditorHistoryVersion((v) => v + 1);
+    activeEditor.on('transaction', bump);
+    activeEditor.on('update', bump);
     return () => {
-      activeEditor.off('transaction', update);
-      activeEditor.off('update', update);
+      activeEditor.off('transaction', bump);
+      activeEditor.off('update', bump);
     };
   }, [activeEditor]);
+  const canUndoText = useMemo(
+    () => (activeEditor ? activeEditor.can().undo() : false),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeEditor, editorHistoryVersion],
+  );
+  const canRedoText = useMemo(
+    () => (activeEditor ? activeEditor.can().redo() : false),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeEditor, editorHistoryVersion],
+  );
 
   // Combined: undo is enabled when the current mode has something to undo.
   // - Draw modes (pen/highlighter/eraser) → use canvas action stack

--- a/src/lib/pdf/__tests__/preserve-empty-paragraphs.test.ts
+++ b/src/lib/pdf/__tests__/preserve-empty-paragraphs.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import { preserveEmptyParagraphs } from '../preserve-empty-paragraphs';
+
+const NBSP = '\u00a0';
+const nbspParagraph = (extra: Record<string, unknown> = {}) => ({
+  type: 'paragraph',
+  ...extra,
+  content: [{ type: 'text', text: NBSP }],
+});
+
+describe('preserveEmptyParagraphs', () => {
+  it('replaces a top-level empty paragraph with no content key', () => {
+    const input = {
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    };
+    const result = preserveEmptyParagraphs(input);
+    expect(result).toEqual({
+      type: 'doc',
+      content: [nbspParagraph()],
+    });
+  });
+
+  it('replaces a top-level empty paragraph with empty content array', () => {
+    const input = {
+      type: 'doc',
+      content: [{ type: 'paragraph', content: [] }],
+    };
+    const result = preserveEmptyParagraphs(input);
+    expect(result).toEqual({
+      type: 'doc',
+      content: [nbspParagraph({ content: undefined })],
+    });
+  });
+
+  it('leaves a non-empty paragraph unchanged', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      ],
+    };
+    const result = preserveEmptyParagraphs(input);
+    expect(result).toEqual(input);
+  });
+
+  it('replaces empty paragraphs inside list items', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'bulletList',
+          content: [
+            {
+              type: 'listItem',
+              content: [{ type: 'paragraph' }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = preserveEmptyParagraphs(input) as {
+      content: Array<{ content: Array<{ content: Array<unknown> }> }>;
+    };
+    expect(result.content[0].content[0].content[0]).toEqual(nbspParagraph());
+  });
+
+  it('replaces empty paragraphs inside blockquotes', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'blockquote',
+          content: [{ type: 'paragraph', content: [] }],
+        },
+      ],
+    };
+    const result = preserveEmptyParagraphs(input) as {
+      content: Array<{ content: Array<unknown> }>;
+    };
+    expect(result.content[0].content[0]).toEqual(
+      nbspParagraph({ content: undefined }),
+    );
+  });
+
+  it('replaces multiple consecutive empty paragraphs', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph', content: [{ type: 'text', text: 'Line 1' }] },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph', content: [{ type: 'text', text: 'Line 4' }] },
+      ],
+    };
+    const result = preserveEmptyParagraphs(input) as {
+      content: Array<unknown>;
+    };
+    expect(result.content).toHaveLength(5);
+    expect(result.content[1]).toEqual(nbspParagraph());
+    expect(result.content[2]).toEqual(nbspParagraph());
+    expect(result.content[3]).toEqual(nbspParagraph());
+  });
+
+  it('preserves attrs on replaced empty paragraphs', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          attrs: { textAlign: 'center', dir: 'rtl' },
+        },
+      ],
+    };
+    const result = preserveEmptyParagraphs(input) as {
+      content: Array<{ attrs: Record<string, unknown>; content: unknown }>;
+    };
+    expect(result.content[0].attrs).toEqual({
+      textAlign: 'center',
+      dir: 'rtl',
+    });
+    expect(result.content[0].content).toEqual([{ type: 'text', text: NBSP }]);
+  });
+
+  it('handles a document made entirely of empty paragraphs', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+        { type: 'paragraph' },
+      ],
+    };
+    const result = preserveEmptyParagraphs(input) as {
+      content: Array<unknown>;
+    };
+    expect(result.content).toEqual([
+      nbspParagraph(),
+      nbspParagraph(),
+      nbspParagraph(),
+    ]);
+  });
+
+  it('does not touch heading nodes (only paragraphs)', () => {
+    const input = {
+      type: 'doc',
+      content: [
+        { type: 'heading', attrs: { level: 1 } }, // empty heading should NOT get nbsp
+      ],
+    };
+    const result = preserveEmptyParagraphs(input);
+    expect(result).toEqual(input);
+  });
+
+  it('does not mutate the input', () => {
+    const input = {
+      type: 'doc',
+      content: [{ type: 'paragraph' }],
+    };
+    const inputClone = JSON.parse(JSON.stringify(input));
+    preserveEmptyParagraphs(input);
+    expect(input).toEqual(inputClone);
+  });
+});

--- a/src/lib/pdf/html-template.ts
+++ b/src/lib/pdf/html-template.ts
@@ -1,5 +1,6 @@
 import { generateHTML } from '@tiptap/html';
 import { Node, Extension, mergeAttributes } from '@tiptap/core';
+import { preserveEmptyParagraphs } from './preserve-empty-paragraphs';
 import StarterKit from '@tiptap/starter-kit';
 import Underline from '@tiptap/extension-underline';
 import TextAlign from '@tiptap/extension-text-align';
@@ -251,10 +252,14 @@ export function buildTextDocumentHtml(
 ): string {
   const baseUrl = typeof window !== 'undefined' ? window.location.origin : '';
 
-  // Generate HTML from TipTap JSON
+  // Generate HTML from TipTap JSON.
+  // Preserve empty paragraphs (TipTap's generateHTML strips them by default).
   let bodyHtml: string;
   try {
-    bodyHtml = generateHTML(content, extensions);
+    bodyHtml = generateHTML(
+      preserveEmptyParagraphs(content) as Record<string, unknown>,
+      extensions,
+    );
   } catch {
     // Fallback for empty or invalid content
     bodyHtml = '';
@@ -348,7 +353,13 @@ export function buildCanvasPageHtml(
       if (page.flowContent) {
         try {
           flowHtml = renderMathNodes(
-            generateHTML(page.flowContent, extensions),
+            generateHTML(
+              preserveEmptyParagraphs(page.flowContent) as Record<
+                string,
+                unknown
+              >,
+              extensions,
+            ),
           );
         } catch {
           flowHtml = '';
@@ -388,7 +399,12 @@ function renderTextBox(tb: TextBox): string {
         (tb.content as Record<string, unknown>).type === 'doc'
           ? tb.content
           : { type: 'doc', content: [tb.content] };
-      contentHtml = renderMathNodes(generateHTML(content, extensions));
+      contentHtml = renderMathNodes(
+        generateHTML(
+          preserveEmptyParagraphs(content) as Record<string, unknown>,
+          extensions,
+        ),
+      );
     } catch (e) {
       // Show error + content snapshot for debugging
       const errMsg = e instanceof Error ? e.message : String(e);
@@ -448,7 +464,13 @@ export function buildMixedDocumentHtml(
       if (page.flowContent) {
         try {
           flowHtml = renderMathNodes(
-            generateHTML(page.flowContent, extensions),
+            generateHTML(
+              preserveEmptyParagraphs(page.flowContent) as Record<
+                string,
+                unknown
+              >,
+              extensions,
+            ),
           );
         } catch {
           flowHtml = '';
@@ -470,7 +492,12 @@ export function buildMixedDocumentHtml(
   // Text content
   let textHtml = '';
   try {
-    textHtml = renderMathNodes(generateHTML(content, extensions));
+    textHtml = renderMathNodes(
+      generateHTML(
+        preserveEmptyParagraphs(content) as Record<string, unknown>,
+        extensions,
+      ),
+    );
   } catch {
     textHtml = '';
   }

--- a/src/lib/pdf/preserve-empty-paragraphs.ts
+++ b/src/lib/pdf/preserve-empty-paragraphs.ts
@@ -25,7 +25,8 @@ export function preserveEmptyParagraphs(node: unknown): unknown {
   if (n.type === 'paragraph') {
     const content = n.content as unknown[] | undefined;
     if (!Array.isArray(content) || content.length === 0) {
-      const { content: _drop, ...rest } = n;
+      const rest: Record<string, unknown> = { ...n };
+      delete rest.content;
       return { ...rest, content: [{ type: 'text', text: NBSP }] };
     }
   }

--- a/src/lib/pdf/preserve-empty-paragraphs.ts
+++ b/src/lib/pdf/preserve-empty-paragraphs.ts
@@ -1,0 +1,39 @@
+/**
+ * Preprocess a TipTap JSON document to preserve empty paragraphs in HTML output.
+ *
+ * TipTap's `generateHTML()` strips empty paragraph nodes (`{type: 'paragraph'}` or
+ * `{type: 'paragraph', content: []}`) during HTML serialization, which causes blank
+ * lines typed by users to disappear from PDF exports. This function walks the
+ * document tree and replaces every empty paragraph with a paragraph containing a
+ * non-breaking space (`\u00a0`), which survives serialization and renders as a
+ * full line of vertical space in the browser.
+ *
+ * Pure function — does not mutate the input.
+ *
+ * Issue: https://github.com/galigoldman/Typenote/issues/115
+ */
+
+const NBSP = '\u00a0';
+
+export function preserveEmptyParagraphs(node: unknown): unknown {
+  if (!node || typeof node !== 'object') return node;
+
+  const n = node as Record<string, unknown>;
+
+  // Empty paragraph: replace with one containing a non-breaking space.
+  // Preserves attrs (e.g. textAlign) but drops the empty content array.
+  if (n.type === 'paragraph') {
+    const content = n.content as unknown[] | undefined;
+    if (!Array.isArray(content) || content.length === 0) {
+      const { content: _drop, ...rest } = n;
+      return { ...rest, content: [{ type: 'text', text: NBSP }] };
+    }
+  }
+
+  // Recurse into children of any node that has a content array.
+  if (Array.isArray(n.content)) {
+    return { ...n, content: n.content.map(preserveEmptyParagraphs) };
+  }
+
+  return n;
+}


### PR DESCRIPTION
## Summary

Fixes #115 — empty lines/blank paragraphs were being stripped from PDF exports because TipTap's \`generateHTML()\` drops empty paragraphs during HTML serialization. Users who left blank lines as space for drawings ended up with collapsed text that covered their drawings.

Also fixes the undo/redo buttons being clickable in text mode with no undo history (clicking did nothing useful, just shifted the page view).

## Root cause

\`generateHTML()\` from \`@tiptap/html\` strips \`{type: 'paragraph', content: []}\` nodes during serialization (default HTML serializer behavior). The fix: preprocess the TipTap JSON tree and replace empty paragraphs with a paragraph containing a non-breaking space (\`\u00a0\`), which survives serialization and renders as one line of vertical space.

## Changes

- **\`src/lib/pdf/preserve-empty-paragraphs.ts\`** (new, ~40 lines) — pure function that walks a TipTap JSON tree and replaces every empty paragraph with one containing \`\u00a0\`. Preserves attrs, does not mutate input, recurses into lists/blockquotes.
- **\`src/lib/pdf/__tests__/preserve-empty-paragraphs.test.ts\`** (new, 10 tests) — unit tests covering top-level empties, empty content arrays, non-empty paragraphs (unchanged), nested in lists/blockquotes, consecutive empties, attrs preservation, document of only empties, headings not touched, immutability.
- **\`src/lib/pdf/html-template.ts\`** — wraps all 5 \`generateHTML()\` call sites (text-only, canvas flowContent, text boxes, mixed flowContent, mixed text content) with \`preserveEmptyParagraphs()\`.
- **\`src/components/canvas/canvas-editor.tsx\`** — subscribes to the active TipTap editor's transaction events to track \`canUndoText\`/\`canRedoText\`, combines with the existing draw-mode \`canUndoDraw\`/\`canRedoDraw\`, and drives the undo/redo button \`disabled\` state from the combined result.

## Test plan

- [x] 10 new unit tests for \`preserveEmptyParagraphs\` pass
- [x] Full unit suite passes (716 tests)
- [x] Full E2E suite passes (54 passed, 2 flaky on retry, 38 intentional CI skips, 0 failed) with clean seed
- [x] Local build passes
- [x] Lint and format clean
- [x] Manual verification on iPad — blank lines preserved in exported PDF
- [x] Undo button disabled when there's nothing to undo in text mode, enabled after typing

🤖 Generated with [Claude Code](https://claude.com/claude-code)