### PR TITLE
feat: document version history with auto-snapshots and restore

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ The project uses a two-branch model: `dev` (integration) and `main` (production)
 - PRs cannot be merged unless CI passes. This is enforced via GitHub branch protection rules on both `main` and `dev`.
 
 ## Active Technologies
+- TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, Supabase SSR, TipTap 3, shadcn/ui (039-document-versioning)
+- PostgreSQL via Supabase — new `document_versions` table (039-document-versioning)
 
 - TypeScript 5 / Node.js 22+ + React 19, Next.js 16 (App Router), TipTap 3 (ProseMirror), perfect-freehand (037-drawing-copy-paste)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ The project uses a two-branch model: `dev` (integration) and `main` (production)
 - PRs cannot be merged unless CI passes. This is enforced via GitHub branch protection rules on both `main` and `dev`.
 
 ## Active Technologies
+
 - TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, Supabase SSR, TipTap 3, shadcn/ui (039-document-versioning)
 - PostgreSQL via Supabase — new `document_versions` table (039-document-versioning)
 

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -163,6 +163,16 @@ Follow-up to issue #118. Guards against cursor jumps when a multi-page overflow 
 
 ---
 
+## Version History (`e2e/version-history.spec.ts`) — PLANNED
+
+- [ ] Open version history sidebar from canvas editor toolbar
+- [ ] Version sidebar shows seeded version entries with timestamps
+- [ ] Edit document → wait for idle snapshot → version appears in sidebar
+- [ ] Restore a version → document content changes and "Before restore" entry appears
+- [ ] Empty state shown for document with no versions
+
+---
+
 ## Summary
 
 | Feature             | Status      | Spec File                        | Tests     |
@@ -178,4 +188,5 @@ Follow-up to issue #118. Guards against cursor jumps when a multi-page overflow 
 | PDF Export          | Implemented | `e2e/export-pdf-*.spec.ts`       | 6/7       |
 | Real-time Sync      | Implemented | `e2e/realtime-sync.spec.ts`      | 3/3       |
 | Drawing Copy/Paste  | Implemented | `e2e/drawing-copy-paste.spec.ts` | 8/8       |
-| **Total**           |             |                                  | **75/76** |
+| Version History     | Planned     | `e2e/version-history.spec.ts`    | 0/5       |
+| **Total**           |             |                                  | **75/81** |

--- a/e2e/version-history.spec.ts
+++ b/e2e/version-history.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers/auth';
+
+// The seeded "Limits and Continuity" document has 3 version snapshots
+const SEEDED_DOC_TITLE = 'Limits and Continuity';
+
+test.describe('Version History', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('open version history sidebar from document', async ({ page }) => {
+    // Navigate to the seeded document that has versions
+    // Open Calculus I folder first
+    const folder = page.getByText('Calculus I').first();
+    await expect(folder).toBeVisible({ timeout: 10_000 });
+    await folder.click();
+
+    // Click on the document
+    const doc = page.getByText(SEEDED_DOC_TITLE).first();
+    await expect(doc).toBeVisible({ timeout: 10_000 });
+    await doc.click();
+
+    // Wait for editor to load
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 10_000,
+    });
+
+    // Click the version history button (Clock icon)
+    const historyButton = page.getByTitle('Version history');
+    await expect(historyButton).toBeVisible({ timeout: 10_000 });
+    await historyButton.click();
+
+    // Version sidebar should appear with "Version History" heading
+    await expect(page.getByText('Version History')).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test('version sidebar shows seeded version entries', async ({ page }) => {
+    // Navigate to the document with seeded versions
+    const folder = page.getByText('Calculus I').first();
+    await expect(folder).toBeVisible({ timeout: 10_000 });
+    await folder.click();
+
+    const doc = page.getByText(SEEDED_DOC_TITLE).first();
+    await expect(doc).toBeVisible({ timeout: 10_000 });
+    await doc.click();
+
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 10_000,
+    });
+
+    // Open version history
+    await page.getByTitle('Version history').click();
+    await expect(page.getByText('Version History')).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Should show "Auto-saved" labels (the 3 seeded versions all have Auto-saved triggers)
+    const autoSavedLabels = page.getByText('Auto-saved');
+    await expect(autoSavedLabels.first()).toBeVisible({ timeout: 5_000 });
+  });
+
+  test('restore a version shows "Before restore" entry', async ({ page }) => {
+    // Navigate to the document
+    const folder = page.getByText('Calculus I').first();
+    await expect(folder).toBeVisible({ timeout: 10_000 });
+    await folder.click();
+
+    const doc = page.getByText(SEEDED_DOC_TITLE).first();
+    await expect(doc).toBeVisible({ timeout: 10_000 });
+    await doc.click();
+
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 10_000,
+    });
+
+    // Open version history
+    await page.getByTitle('Version history').click();
+    await expect(page.getByText('Version History')).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // Click the first version entry to select it
+    const autoSaved = page.getByText('Auto-saved').first();
+    await expect(autoSaved).toBeVisible({ timeout: 5_000 });
+    await autoSaved.click();
+
+    // "Restore this version" button should appear
+    const restoreButton = page.getByText('Restore this version');
+    await expect(restoreButton).toBeVisible({ timeout: 5_000 });
+
+    // Click restore
+    await restoreButton.click();
+
+    // After restore, should see a "Before restore" entry in the sidebar
+    await expect(page.getByText('Before restore')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/specs/039-document-versioning/checklists/requirements.md
+++ b/specs/039-document-versioning/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Document Version History
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/039-document-versioning/contracts/server-actions.md
+++ b/specs/039-document-versioning/contracts/server-actions.md
@@ -6,20 +6,23 @@
 **Type**: Next.js Server Action (`'use server'`)
 
 **Signature**:
+
 ```typescript
 async function createVersionSnapshot(
   documentId: string,
-  trigger: 'idle' | 'periodic' | 'close'
-): Promise<{ id: string; created_at: string } | null>
+  trigger: 'idle' | 'periodic' | 'close',
+): Promise<{ id: string; created_at: string } | null>;
 ```
 
 **Behavior**:
+
 - Calls `create_document_version` RPC with the current document's content, pages, and title
 - The RPC reads the document state server-side (no client data needed beyond documentId)
 - Returns the new version's id and created_at, or null if the document doesn't exist
 - Cap enforcement (max 8) is handled inside the RPC
 
 **Error cases**:
+
 - Document not found → returns null
 - User not authenticated → throws (Supabase auth error)
 - User doesn't own document → RLS blocks the operation
@@ -31,13 +34,15 @@ async function createVersionSnapshot(
 **File**: `src/lib/queries/document-versions.ts`
 
 **Signature**:
+
 ```typescript
 async function getDocumentVersions(
-  documentId: string
-): Promise<DocumentVersion[]>
+  documentId: string,
+): Promise<DocumentVersion[]>;
 ```
 
 **Behavior**:
+
 - SELECT from `document_versions` WHERE `document_id` = documentId
 - ORDER BY `created_at DESC`
 - RLS ensures only the owner's versions are returned
@@ -50,18 +55,21 @@ async function getDocumentVersions(
 **Type**: Next.js Server Action (`'use server'`)
 
 **Signature**:
+
 ```typescript
 async function restoreDocumentVersion(
-  versionId: string
-): Promise<{ updated_at: string }>
+  versionId: string,
+): Promise<{ updated_at: string }>;
 ```
 
 **Behavior**:
+
 - Calls `restore_document_version` RPC
 - RPC atomically: snapshots current state as "before_restore" → overwrites document → prunes if > 8
 - Returns the document's new `updated_at`
 
 **Error cases**:
+
 - Version not found → throws
 - User doesn't own the version → RLS blocks
 
@@ -75,6 +83,7 @@ async function restoreDocumentVersion(
 **Purpose**: Receive `navigator.sendBeacon()` requests on page unload.
 
 **Body** (JSON):
+
 ```typescript
 {
   documentId: string;
@@ -84,6 +93,7 @@ async function restoreDocumentVersion(
 **Response**: 204 No Content (beacon callers don't read responses)
 
 **Behavior**:
+
 - Authenticates via Supabase session cookie
 - Calls the same `create_document_version` RPC with trigger = `'close'`
 - Fire-and-forget — no response body needed

--- a/specs/039-document-versioning/contracts/server-actions.md
+++ b/specs/039-document-versioning/contracts/server-actions.md
@@ -1,0 +1,89 @@
+# Server Action Contracts: Document Versioning
+
+## `createVersionSnapshot`
+
+**File**: `src/lib/actions/document-versions.ts`
+**Type**: Next.js Server Action (`'use server'`)
+
+**Signature**:
+```typescript
+async function createVersionSnapshot(
+  documentId: string,
+  trigger: 'idle' | 'periodic' | 'close'
+): Promise<{ id: string; created_at: string } | null>
+```
+
+**Behavior**:
+- Calls `create_document_version` RPC with the current document's content, pages, and title
+- The RPC reads the document state server-side (no client data needed beyond documentId)
+- Returns the new version's id and created_at, or null if the document doesn't exist
+- Cap enforcement (max 8) is handled inside the RPC
+
+**Error cases**:
+- Document not found → returns null
+- User not authenticated → throws (Supabase auth error)
+- User doesn't own document → RLS blocks the operation
+
+---
+
+## `getDocumentVersions`
+
+**File**: `src/lib/queries/document-versions.ts`
+
+**Signature**:
+```typescript
+async function getDocumentVersions(
+  documentId: string
+): Promise<DocumentVersion[]>
+```
+
+**Behavior**:
+- SELECT from `document_versions` WHERE `document_id` = documentId
+- ORDER BY `created_at DESC`
+- RLS ensures only the owner's versions are returned
+
+---
+
+## `restoreDocumentVersion`
+
+**File**: `src/lib/actions/document-versions.ts`
+**Type**: Next.js Server Action (`'use server'`)
+
+**Signature**:
+```typescript
+async function restoreDocumentVersion(
+  versionId: string
+): Promise<{ updated_at: string }>
+```
+
+**Behavior**:
+- Calls `restore_document_version` RPC
+- RPC atomically: snapshots current state as "before_restore" → overwrites document → prunes if > 8
+- Returns the document's new `updated_at`
+
+**Error cases**:
+- Version not found → throws
+- User doesn't own the version → RLS blocks
+
+---
+
+## Beacon Endpoint: `/api/version-snapshot`
+
+**File**: `src/app/api/version-snapshot/route.ts`
+**Method**: POST
+
+**Purpose**: Receive `navigator.sendBeacon()` requests on page unload.
+
+**Body** (JSON):
+```typescript
+{
+  documentId: string;
+}
+```
+
+**Response**: 204 No Content (beacon callers don't read responses)
+
+**Behavior**:
+- Authenticates via Supabase session cookie
+- Calls the same `create_document_version` RPC with trigger = `'close'`
+- Fire-and-forget — no response body needed

--- a/specs/039-document-versioning/data-model.md
+++ b/specs/039-document-versioning/data-model.md
@@ -2,25 +2,25 @@
 
 ## New Entity: `document_versions`
 
-| Column       | Type                     | Constraints                              | Description                                      |
-| ------------ | ------------------------ | ---------------------------------------- | ------------------------------------------------ |
-| `id`         | `uuid`                   | PK, default `gen_random_uuid()`          | Unique version identifier                        |
-| `document_id`| `uuid`                   | FK → `documents.id` ON DELETE CASCADE    | Parent document                                  |
-| `user_id`    | `uuid`                   | FK → `auth.users(id)`, NOT NULL          | Who created this version (for RLS)               |
-| `content`    | `jsonb`                  | NOT NULL, default `'{}'`                 | TipTap editor state snapshot                     |
-| `pages`      | `jsonb`                  | default `NULL`                           | Canvas/drawing state snapshot (null if text-only) |
-| `title`      | `text`                   | NOT NULL                                 | Document title at time of snapshot               |
-| `trigger`    | `text`                   | NOT NULL                                 | What caused the snapshot (see below)             |
-| `created_at` | `timestamptz`            | NOT NULL, default `now()`                | When the snapshot was created                    |
+| Column        | Type          | Constraints                           | Description                                       |
+| ------------- | ------------- | ------------------------------------- | ------------------------------------------------- |
+| `id`          | `uuid`        | PK, default `gen_random_uuid()`       | Unique version identifier                         |
+| `document_id` | `uuid`        | FK → `documents.id` ON DELETE CASCADE | Parent document                                   |
+| `user_id`     | `uuid`        | FK → `auth.users(id)`, NOT NULL       | Who created this version (for RLS)                |
+| `content`     | `jsonb`       | NOT NULL, default `'{}'`              | TipTap editor state snapshot                      |
+| `pages`       | `jsonb`       | default `NULL`                        | Canvas/drawing state snapshot (null if text-only) |
+| `title`       | `text`        | NOT NULL                              | Document title at time of snapshot                |
+| `trigger`     | `text`        | NOT NULL                              | What caused the snapshot (see below)              |
+| `created_at`  | `timestamptz` | NOT NULL, default `now()`             | When the snapshot was created                     |
 
 ### Trigger values
 
-| Value              | When created                                   |
-| ------------------ | ---------------------------------------------- |
-| `'idle'`           | User stopped editing for ~30 seconds           |
-| `'periodic'`       | 5-minute safety net during active editing      |
-| `'close'`          | User navigated away or closed the tab          |
-| `'before_restore'` | Automatically created before a restore action  |
+| Value              | When created                                  |
+| ------------------ | --------------------------------------------- |
+| `'idle'`           | User stopped editing for ~30 seconds          |
+| `'periodic'`       | 5-minute safety net during active editing     |
+| `'close'`          | User navigated away or closed the tab         |
+| `'before_restore'` | Automatically created before a restore action |
 
 ### Indexes
 
@@ -48,6 +48,7 @@ DELETE: auth.uid() = user_id
 **Purpose**: Atomically insert a new version and prune oldest if count exceeds 8.
 
 **Parameters**:
+
 - `p_document_id` (uuid)
 - `p_content` (jsonb)
 - `p_pages` (jsonb, nullable)
@@ -57,6 +58,7 @@ DELETE: auth.uid() = user_id
 **Returns**: The new version's `id` and `created_at`.
 
 **Logic**:
+
 1. Get `auth.uid()` as user_id
 2. INSERT new row into `document_versions`
 3. COUNT versions for this document_id
@@ -70,11 +72,13 @@ DELETE: auth.uid() = user_id
 **Purpose**: Atomically create a "before_restore" snapshot, then overwrite the document.
 
 **Parameters**:
+
 - `p_version_id` (uuid) — the version to restore
 
 **Returns**: The restored document's `updated_at`.
 
 **Logic**:
+
 1. Get `auth.uid()` as user_id
 2. SELECT the target version (verify user_id matches)
 3. SELECT the current document state (content, pages, title)

--- a/specs/039-document-versioning/data-model.md
+++ b/specs/039-document-versioning/data-model.md
@@ -1,0 +1,114 @@
+# Data Model: Document Version History
+
+## New Entity: `document_versions`
+
+| Column       | Type                     | Constraints                              | Description                                      |
+| ------------ | ------------------------ | ---------------------------------------- | ------------------------------------------------ |
+| `id`         | `uuid`                   | PK, default `gen_random_uuid()`          | Unique version identifier                        |
+| `document_id`| `uuid`                   | FK → `documents.id` ON DELETE CASCADE    | Parent document                                  |
+| `user_id`    | `uuid`                   | FK → `auth.users(id)`, NOT NULL          | Who created this version (for RLS)               |
+| `content`    | `jsonb`                  | NOT NULL, default `'{}'`                 | TipTap editor state snapshot                     |
+| `pages`      | `jsonb`                  | default `NULL`                           | Canvas/drawing state snapshot (null if text-only) |
+| `title`      | `text`                   | NOT NULL                                 | Document title at time of snapshot               |
+| `trigger`    | `text`                   | NOT NULL                                 | What caused the snapshot (see below)             |
+| `created_at` | `timestamptz`            | NOT NULL, default `now()`                | When the snapshot was created                    |
+
+### Trigger values
+
+| Value              | When created                                   |
+| ------------------ | ---------------------------------------------- |
+| `'idle'`           | User stopped editing for ~30 seconds           |
+| `'periodic'`       | 5-minute safety net during active editing      |
+| `'close'`          | User navigated away or closed the tab          |
+| `'before_restore'` | Automatically created before a restore action  |
+
+### Indexes
+
+```sql
+-- Primary query: "get all versions for this document, newest first"
+CREATE INDEX document_versions_doc_created_idx
+  ON document_versions (document_id, created_at DESC);
+
+-- Cap enforcement: "count versions for this document"
+-- (covered by the above composite index)
+```
+
+### RLS Policies
+
+```sql
+-- Users can only see their own document versions
+SELECT: auth.uid() = user_id
+INSERT: auth.uid() = user_id
+DELETE: auth.uid() = user_id
+-- No UPDATE policy — versions are immutable once created
+```
+
+### RPC Function: `create_document_version`
+
+**Purpose**: Atomically insert a new version and prune oldest if count exceeds 8.
+
+**Parameters**:
+- `p_document_id` (uuid)
+- `p_content` (jsonb)
+- `p_pages` (jsonb, nullable)
+- `p_title` (text)
+- `p_trigger` (text)
+
+**Returns**: The new version's `id` and `created_at`.
+
+**Logic**:
+1. Get `auth.uid()` as user_id
+2. INSERT new row into `document_versions`
+3. COUNT versions for this document_id
+4. If count > 8, DELETE the oldest (by `created_at ASC`, LIMIT count - 8)
+5. RETURN new version id + created_at
+
+**Security**: `SECURITY DEFINER` — function runs with owner privileges, but validates `auth.uid()` internally to ensure the user owns the document.
+
+### RPC Function: `restore_document_version`
+
+**Purpose**: Atomically create a "before_restore" snapshot, then overwrite the document.
+
+**Parameters**:
+- `p_version_id` (uuid) — the version to restore
+
+**Returns**: The restored document's `updated_at`.
+
+**Logic**:
+1. Get `auth.uid()` as user_id
+2. SELECT the target version (verify user_id matches)
+3. SELECT the current document state (content, pages, title)
+4. INSERT a "before_restore" snapshot with the current state
+5. Prune if > 8 versions
+6. UPDATE `documents` with the target version's content, pages
+7. RETURN `updated_at`
+
+## Existing Entity: `documents` (unchanged)
+
+No schema changes to the `documents` table. Versions reference documents via foreign key. The `ON DELETE CASCADE` ensures versions are cleaned up when a document is deleted.
+
+## TypeScript Types
+
+```typescript
+// New type in src/types/database.ts
+interface DocumentVersion {
+  id: string;
+  document_id: string;
+  user_id: string;
+  content: Record<string, unknown>;
+  pages: Record<string, unknown> | null;
+  title: string;
+  trigger: 'idle' | 'periodic' | 'close' | 'before_restore';
+  created_at: string;
+}
+```
+
+## Relationships
+
+```
+documents (1) ──→ (0..8) document_versions
+    │                        │
+    └── id ←── document_id ──┘
+
+    ON DELETE CASCADE: deleting a document removes all its versions
+```

--- a/specs/039-document-versioning/plan.md
+++ b/specs/039-document-versioning/plan.md
@@ -1,0 +1,87 @@
+# Implementation Plan: Document Version History
+
+**Branch**: `039-document-versioning` | **Date**: 2026-04-12 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/039-document-versioning/spec.md`
+
+## Summary
+
+Add automatic document versioning that saves up to 8 snapshots per document at smart intervals (30s idle, 5min periodic, session close). Users can browse versions in a sidebar and restore any version — with a safety snapshot always created before restore. Storage uses full JSONB snapshots in a new `document_versions` table with atomic cap enforcement via Postgres RPC.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Node.js 22+
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Supabase SSR, TipTap 3, shadcn/ui
+**Storage**: PostgreSQL via Supabase — new `document_versions` table
+**Testing**: Vitest (unit/integration), Playwright (E2E)
+**Target Platform**: Web (desktop + mobile browsers)
+**Project Type**: Web application (Next.js App Router)
+**Performance Goals**: Snapshot creation < 5s, restore < 2s
+**Constraints**: Max 8 versions per document, sendBeacon for session close
+**Scale/Scope**: Single new table, 1 RPC function, 1 API route, 1 hook, 1 sidebar component
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+| --------- | ------ | ----- |
+| I. Incremental Development | PASS | Database schema + RPC first, then hook, then UI. Each phase produces a working increment. |
+| II. Test-Driven Quality | PASS | Integration tests for migration/RPC, unit tests for hook logic, E2E for full user flow. |
+| III. Protected Branches | PASS | Feature branch `039-document-versioning` off `dev`. PR to `dev` after CI passes. |
+| IV. Migrations as Code | PASS | New migration file for `document_versions` table + RPC functions. Seed data updated. |
+| V. Interview-Ready Architecture | PASS | Covers: ring-buffer pattern, atomic RPC, sendBeacon API, JSONB snapshots vs diffs trade-off. |
+
+**Post-Phase 1 re-check**: All gates still pass. No constitution violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/039-document-versioning/
+├── plan.md
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── server-actions.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md              # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+supabase/
+├── migrations/
+│   └── YYYYMMDDHHMMSS_create_document_versions.sql  # NEW: table + RPC + RLS
+└── seed.sql                                          # MODIFIED: add sample versions
+
+src/
+├── types/
+│   └── database.ts                    # MODIFIED: add DocumentVersion type
+├── lib/
+│   ├── actions/
+│   │   └── document-versions.ts       # NEW: createVersionSnapshot, restoreDocumentVersion
+│   └── queries/
+│       └── document-versions.ts       # NEW: getDocumentVersions
+├── hooks/
+│   ├── use-version-snapshots.ts       # NEW: idle/periodic/close trigger logic
+│   └── use-document-sync.ts           # MODIFIED: wire in version snapshots
+├── components/
+│   └── version-history/
+│       └── version-sidebar.tsx        # NEW: sidebar UI
+├── app/
+│   └── api/
+│       └── version-snapshot/
+│           └── route.ts               # NEW: beacon endpoint for session close
+└── components/
+    ├── canvas/
+    │   └── canvas-editor.tsx          # MODIFIED: add version sidebar toggle
+    └── editor/
+        └── tiptap-editor.tsx          # MODIFIED: add version sidebar toggle (text docs)
+```
+
+**Structure Decision**: Follows the existing project layout. New files go in the same directories as their closest analogues (e.g., `document-versions.ts` actions next to `documents.ts` actions). The version sidebar gets its own `version-history/` component directory to keep it isolated.

--- a/specs/039-document-versioning/plan.md
+++ b/specs/039-document-versioning/plan.md
@@ -23,13 +23,13 @@ Add automatic document versioning that saves up to 8 snapshots per document at s
 
 _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
-| Principle | Status | Notes |
-| --------- | ------ | ----- |
-| I. Incremental Development | PASS | Database schema + RPC first, then hook, then UI. Each phase produces a working increment. |
-| II. Test-Driven Quality | PASS | Integration tests for migration/RPC, unit tests for hook logic, E2E for full user flow. |
-| III. Protected Branches | PASS | Feature branch `039-document-versioning` off `dev`. PR to `dev` after CI passes. |
-| IV. Migrations as Code | PASS | New migration file for `document_versions` table + RPC functions. Seed data updated. |
-| V. Interview-Ready Architecture | PASS | Covers: ring-buffer pattern, atomic RPC, sendBeacon API, JSONB snapshots vs diffs trade-off. |
+| Principle                       | Status | Notes                                                                                        |
+| ------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| I. Incremental Development      | PASS   | Database schema + RPC first, then hook, then UI. Each phase produces a working increment.    |
+| II. Test-Driven Quality         | PASS   | Integration tests for migration/RPC, unit tests for hook logic, E2E for full user flow.      |
+| III. Protected Branches         | PASS   | Feature branch `039-document-versioning` off `dev`. PR to `dev` after CI passes.             |
+| IV. Migrations as Code          | PASS   | New migration file for `document_versions` table + RPC functions. Seed data updated.         |
+| V. Interview-Ready Architecture | PASS   | Covers: ring-buffer pattern, atomic RPC, sendBeacon API, JSONB snapshots vs diffs trade-off. |
 
 **Post-Phase 1 re-check**: All gates still pass. No constitution violations.
 

--- a/specs/039-document-versioning/quickstart.md
+++ b/specs/039-document-versioning/quickstart.md
@@ -1,0 +1,56 @@
+# Quickstart: Document Version History
+
+## Prerequisites
+
+- Local Supabase running (`supabase start`)
+- `pnpm install` done
+- `.env.local` configured
+
+## Development Steps
+
+### 1. Apply the migration
+
+```bash
+supabase migration new create_document_versions
+# Write the SQL (see data-model.md)
+supabase db reset
+```
+
+### 2. Update seed data
+
+Add sample version records for the test document in `supabase/seed.sql`.
+
+### 3. New files to create
+
+```
+supabase/migrations/YYYYMMDDHHMMSS_create_document_versions.sql
+src/types/database.ts                          # Add DocumentVersion type
+src/lib/actions/document-versions.ts           # Server actions
+src/lib/queries/document-versions.ts           # Query functions
+src/hooks/use-version-snapshots.ts             # Client-side trigger logic
+src/components/version-history/version-sidebar.tsx  # UI sidebar
+src/app/api/version-snapshot/route.ts          # Beacon endpoint
+```
+
+### 4. Files to modify
+
+```
+src/hooks/use-document-sync.ts                 # Wire in version snapshot hook
+src/components/canvas/canvas-editor.tsx         # Add version sidebar toggle
+src/components/editor/tiptap-editor.tsx         # Add version sidebar toggle (text docs)
+```
+
+### 5. Run tests
+
+```bash
+pnpm test                  # Unit tests
+pnpm test:integration      # Integration tests (needs local Supabase)
+pnpm test:e2e              # E2E tests
+```
+
+## Key Decisions
+
+- **Full snapshots, not diffs** — simpler restore, negligible storage at 8-version cap
+- **Client-side triggers, server-side storage** — only the client knows when user is idle
+- **RPC for atomicity** — cap enforcement can't race across tabs
+- **sendBeacon for close** — browser guarantees delivery after page unload

--- a/specs/039-document-versioning/research.md
+++ b/specs/039-document-versioning/research.md
@@ -7,6 +7,7 @@
 **Rationale**: The existing auto-save fires every 800ms (debounced). Version snapshots need different timing (30s idle, 5min periodic). Mixing them into `useAutoSave` would couple two unrelated concerns. A separate hook tracks idle/periodic timers and calls its own server action (`createVersionSnapshot`) when triggered.
 
 **Alternatives considered**:
+
 - Postgres trigger on `documents` UPDATE — rejected because it would fire on every 800ms save, creating far too many versions. Pruning logic in a trigger adds complexity.
 - Server-side debounce — rejected because the server doesn't know when the user stopped typing; only the client has that context.
 
@@ -17,6 +18,7 @@
 **Rationale**: With a cap of 8 versions and typical document sizes of 10-100 KB, the worst case is 800 KB per document (8 × 100 KB). Even with 1,000 documents, that's 800 MB — well within Supabase Pro limits (8 GB) and manageable on free tier (500 MB) for typical usage. Full snapshots make restore trivial (single row read) and avoid the complexity of reconstructing state from diffs.
 
 **Alternatives considered**:
+
 - JSONB diff/patch (RFC 6902) — rejected: complex to implement, reconstruct, and debug. Savings not needed at this scale.
 - Supabase Storage (JSON files) — rejected: can't query metadata efficiently, harder to enforce cap atomically.
 
@@ -27,6 +29,7 @@
 **Rationale**: Using an RPC function (`create_document_version`) ensures atomicity — no race condition where two tabs both see 8 versions and both insert, ending up with 10. The function does: INSERT new version → DELETE oldest if count > 8, all in one transaction. This follows the existing pattern used by `increment_ai_usage`.
 
 **Alternatives considered**:
+
 - Client-side count check before insert — rejected: TOCTOU race with multiple tabs.
 - Postgres trigger on INSERT — viable but less explicit; RPC is the established pattern in this project.
 
@@ -37,6 +40,7 @@
 **Rationale**: Before creating a snapshot, the client compares the current `content` + `pages` JSON strings against the last snapshot's content (stored in a ref). If identical, skip. This is fast (string comparison) and avoids unnecessary DB writes. No need for cryptographic hashing at this scale.
 
 **Alternatives considered**:
+
 - Server-side hash column — adds migration complexity for minimal benefit.
 - Deep object comparison — slower and more error-prone than string comparison.
 
@@ -47,6 +51,7 @@
 **Rationale**: The AI chat sidebar already established this pattern in the codebase. Reusing it keeps the UX consistent and reduces implementation effort. The version sidebar is simpler (read-only list + restore button), so the same responsive pattern works well.
 
 **Alternatives considered**:
+
 - Modal dialog — rejected: version history benefits from staying open while viewing the document.
 - Sheet (Radix slide-over) — viable but the inline pattern is already proven for document-context panels.
 
@@ -57,5 +62,6 @@
 **Rationale**: `beforeunload` is unreliable for async operations — the browser may kill the page before a `fetch()` completes. `sendBeacon()` is designed specifically for this: it queues the request and the browser guarantees delivery even after the page unloads. This is the standard approach for analytics and save-on-exit.
 
 **Alternatives considered**:
+
 - `visibilitychange` event — good complement (fires when tab becomes hidden) but doesn't cover tab close. Use both.
 - Rely only on idle/periodic — leaves a gap if user types continuously then closes tab. `sendBeacon` closes this gap.

--- a/specs/039-document-versioning/research.md
+++ b/specs/039-document-versioning/research.md
@@ -1,0 +1,61 @@
+# Research: Document Version History
+
+## R1: Where to trigger version snapshots
+
+**Decision**: Client-side hook (`useVersionSnapshots`) separate from auto-save, calling a dedicated server action.
+
+**Rationale**: The existing auto-save fires every 800ms (debounced). Version snapshots need different timing (30s idle, 5min periodic). Mixing them into `useAutoSave` would couple two unrelated concerns. A separate hook tracks idle/periodic timers and calls its own server action (`createVersionSnapshot`) when triggered.
+
+**Alternatives considered**:
+- Postgres trigger on `documents` UPDATE — rejected because it would fire on every 800ms save, creating far too many versions. Pruning logic in a trigger adds complexity.
+- Server-side debounce — rejected because the server doesn't know when the user stopped typing; only the client has that context.
+
+## R2: Snapshot storage strategy
+
+**Decision**: Full JSONB snapshots in a `document_versions` table. No diffs.
+
+**Rationale**: With a cap of 8 versions and typical document sizes of 10-100 KB, the worst case is 800 KB per document (8 × 100 KB). Even with 1,000 documents, that's 800 MB — well within Supabase Pro limits (8 GB) and manageable on free tier (500 MB) for typical usage. Full snapshots make restore trivial (single row read) and avoid the complexity of reconstructing state from diffs.
+
+**Alternatives considered**:
+- JSONB diff/patch (RFC 6902) — rejected: complex to implement, reconstruct, and debug. Savings not needed at this scale.
+- Supabase Storage (JSON files) — rejected: can't query metadata efficiently, harder to enforce cap atomically.
+
+## R3: Cap enforcement strategy
+
+**Decision**: Postgres RPC function that atomically inserts the new version and deletes the oldest if count exceeds 8.
+
+**Rationale**: Using an RPC function (`create_document_version`) ensures atomicity — no race condition where two tabs both see 8 versions and both insert, ending up with 10. The function does: INSERT new version → DELETE oldest if count > 8, all in one transaction. This follows the existing pattern used by `increment_ai_usage`.
+
+**Alternatives considered**:
+- Client-side count check before insert — rejected: TOCTOU race with multiple tabs.
+- Postgres trigger on INSERT — viable but less explicit; RPC is the established pattern in this project.
+
+## R4: Change detection to avoid duplicate snapshots
+
+**Decision**: Hash comparison using `JSON.stringify()` equality check on client side.
+
+**Rationale**: Before creating a snapshot, the client compares the current `content` + `pages` JSON strings against the last snapshot's content (stored in a ref). If identical, skip. This is fast (string comparison) and avoids unnecessary DB writes. No need for cryptographic hashing at this scale.
+
+**Alternatives considered**:
+- Server-side hash column — adds migration complexity for minimal benefit.
+- Deep object comparison — slower and more error-prone than string comparison.
+
+## R5: Version history sidebar UI pattern
+
+**Decision**: Follow the AI Chat Panel pattern — inline on desktop (right side, fixed width), full-screen overlay on mobile. Open via a button in the document toolbar/header.
+
+**Rationale**: The AI chat sidebar already established this pattern in the codebase. Reusing it keeps the UX consistent and reduces implementation effort. The version sidebar is simpler (read-only list + restore button), so the same responsive pattern works well.
+
+**Alternatives considered**:
+- Modal dialog — rejected: version history benefits from staying open while viewing the document.
+- Sheet (Radix slide-over) — viable but the inline pattern is already proven for document-context panels.
+
+## R6: Session close snapshot via beforeunload
+
+**Decision**: Use `navigator.sendBeacon()` to fire a snapshot on page unload. Fall back to synchronous fetch if beacon is unavailable.
+
+**Rationale**: `beforeunload` is unreliable for async operations — the browser may kill the page before a `fetch()` completes. `sendBeacon()` is designed specifically for this: it queues the request and the browser guarantees delivery even after the page unloads. This is the standard approach for analytics and save-on-exit.
+
+**Alternatives considered**:
+- `visibilitychange` event — good complement (fires when tab becomes hidden) but doesn't cover tab close. Use both.
+- Rely only on idle/periodic — leaves a gap if user types continuously then closes tab. `sendBeacon` closes this gap.

--- a/specs/039-document-versioning/spec.md
+++ b/specs/039-document-versioning/spec.md
@@ -26,6 +26,7 @@ A user is editing a document and wants to see previous versions. They open a ver
 ### User Story 2 - Automatic Version Snapshots (Priority: P1)
 
 The system automatically creates version snapshots at smart intervals without user action. Snapshots are created when:
+
 - The user stops typing for ~30 seconds (idle timeout)
 - Every ~5 minutes during active editing (periodic safety net)
 - When the user navigates away from the document or closes the browser (session close)

--- a/specs/039-document-versioning/spec.md
+++ b/specs/039-document-versioning/spec.md
@@ -1,0 +1,103 @@
+# Feature Specification: Document Version History
+
+**Feature Branch**: `039-document-versioning`
+**Created**: 2026-04-12
+**Status**: Draft
+**Input**: User description: "Document version history with smart auto-snapshots and restore sidebar"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - View Version History (Priority: P1)
+
+A user is editing a document and wants to see previous versions. They open a version history sidebar that shows a chronological list of saved snapshots. Each entry shows a relative timestamp ("30 min ago", "2 hours ago") and what triggered the save ("Auto-saved", "Before restore"). The list is ordered newest-first with a maximum of 8 versions shown.
+
+**Why this priority**: Without the ability to see versions, no other versioning feature is useful. This is the foundation.
+
+**Independent Test**: Can be fully tested by opening the sidebar on a document that has saved versions and verifying the list renders with correct timestamps and labels.
+
+**Acceptance Scenarios**:
+
+1. **Given** a document with 3 saved versions, **When** the user opens the version history sidebar, **Then** they see 3 entries ordered newest-first with relative timestamps and trigger labels.
+2. **Given** a document with no saved versions, **When** the user opens the version history sidebar, **Then** they see an empty state message like "No version history yet."
+3. **Given** a document with 8 versions, **When** the user opens the version history sidebar, **Then** they see exactly 8 entries (the cap).
+
+---
+
+### User Story 2 - Automatic Version Snapshots (Priority: P1)
+
+The system automatically creates version snapshots at smart intervals without user action. Snapshots are created when:
+- The user stops typing for ~30 seconds (idle timeout)
+- Every ~5 minutes during active editing (periodic safety net)
+- When the user navigates away from the document or closes the browser (session close)
+
+Only meaningful changes trigger a snapshot — if the document content hasn't changed since the last snapshot, no new version is created.
+
+The system keeps a maximum of 8 versions per document. When a 9th snapshot would be created, the oldest version is deleted.
+
+**Why this priority**: Auto-snapshots are equally critical to viewing — without them, there's nothing to view. Combined with Story 1, this delivers a usable MVP.
+
+**Independent Test**: Can be tested by editing a document, waiting 30 seconds, and verifying a version was created in the database. Then editing more, waiting another 30 seconds, and verifying a second version appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is editing a document, **When** they stop typing for 30 seconds, **Then** a version snapshot is saved with trigger label "Auto-saved".
+2. **Given** a user is actively editing for 5+ minutes without a 30-second pause, **When** 5 minutes elapse since the last snapshot, **Then** a periodic snapshot is saved with trigger label "Auto-saved".
+3. **Given** a user is editing a document, **When** they navigate away or close the tab, **Then** a snapshot is saved with trigger label "Auto-saved".
+4. **Given** a document already has 8 versions, **When** a new snapshot is created, **Then** the oldest version is deleted and the new one is added (total remains 8).
+5. **Given** the document content has not changed since the last snapshot, **When** an idle timeout or periodic trigger fires, **Then** no new snapshot is created.
+
+---
+
+### User Story 3 - Restore a Previous Version (Priority: P2)
+
+A user selects a version from the history sidebar and restores it. The current document state is overwritten with the selected version's content. Before overwriting, the system automatically creates a snapshot of the current state labeled "Before restore" — so the user can always undo a restore by restoring the pre-restore snapshot.
+
+**Why this priority**: Viewing history is useful on its own for peace of mind, but restore is what makes it actionable. Depends on Stories 1 and 2.
+
+**Independent Test**: Can be tested by creating a document with content "Version A", editing it to "Version B" (triggering a snapshot), then restoring the "Version A" snapshot and verifying the document now shows "Version A" content and a new "Before restore" entry appears in the history.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user is viewing the version history sidebar, **When** they click a version entry, **Then** the entry is highlighted as selected.
+2. **Given** a user has selected a version, **When** they click "Restore", **Then** the document content is replaced with the selected version's content.
+3. **Given** a user clicks "Restore", **When** the restore completes, **Then** a new snapshot labeled "Before restore" is created containing the pre-restore document state.
+4. **Given** a user just restored a version, **When** they open the history sidebar, **Then** they see the "Before restore" entry at the top and can restore it to undo.
+
+---
+
+### Edge Cases
+
+- What happens when a version snapshot is triggered during an active auto-save? The snapshot waits for the auto-save to complete first, then captures the saved state.
+- What happens if the user restores a version while offline? The restore applies locally, and when connectivity returns, the auto-save persists it.
+- What happens if two browser tabs are editing the same document? Each tab manages its own version triggers independently; the version cap (8) is enforced at the database level regardless of source.
+- What happens if the user rapidly triggers multiple snapshots (e.g., stop/start typing repeatedly near the 30s boundary)? A minimum interval between snapshots (30 seconds) prevents duplicate or near-duplicate versions.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST automatically create version snapshots when the user stops editing for approximately 30 seconds.
+- **FR-002**: System MUST automatically create version snapshots every ~5 minutes during continuous active editing.
+- **FR-003**: System MUST attempt to create a version snapshot when the user navigates away from the document.
+- **FR-004**: System MUST enforce a maximum of 8 versions per document, deleting the oldest when the cap is exceeded.
+- **FR-005**: System MUST NOT create a new snapshot if the document content has not changed since the last snapshot.
+- **FR-006**: System MUST display version history in a sidebar with relative timestamps and trigger labels, ordered newest-first.
+- **FR-007**: System MUST allow users to restore any previous version, replacing the current document content.
+- **FR-008**: System MUST automatically create a "Before restore" snapshot of the current state before any restore operation.
+- **FR-009**: System MUST store both text editor content and canvas/drawing data in each version snapshot.
+- **FR-010**: Version data MUST be scoped per user — users can only see and restore their own document versions.
+
+### Key Entities
+
+- **Document Version**: A point-in-time snapshot of a document's full state. Belongs to exactly one document. Contains the text editor state, canvas/drawing state, document title at time of snapshot, what triggered the snapshot, and when it was created.
+- **Document** (existing): Extended with version history — a document has zero to eight versions.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Version snapshots are created within 5 seconds of a trigger event (idle timeout, periodic, or navigation).
+- **SC-002**: Users can view and restore any version in under 3 clicks (open sidebar, click version, click restore).
+- **SC-003**: Restoring a version completes in under 2 seconds from the user's perspective.
+- **SC-004**: No document content is ever permanently lost — every restore creates a "Before restore" snapshot first.
+- **SC-005**: Storage overhead per document stays under 1 MB for 8 versions (typical document).

--- a/specs/039-document-versioning/tasks.md
+++ b/specs/039-document-versioning/tasks.md
@@ -1,0 +1,196 @@
+# Tasks: Document Version History
+
+**Input**: Design documents from `/specs/039-document-versioning/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+**Tests**: Included — CLAUDE.md requires unit, integration, and E2E tests for every feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Database & Types)
+
+**Purpose**: Create the database schema, RPC functions, and TypeScript types that all stories depend on.
+
+- [x] T001 Create migration file with `document_versions` table, indexes, RLS policies, `create_document_version` RPC, and `restore_document_version` RPC in supabase/migrations/20260413101143_create_document_versions.sql
+- [x] T002 Add sample version records for the test document in supabase/seed.sql
+- [x] T003 Run `supabase db reset` to verify migration chain replays cleanly
+- [x] T004 Add `DocumentVersion` interface and `VersionTrigger` type to src/types/database.ts
+
+---
+
+## Phase 2: Foundational (Server Actions & Queries)
+
+**Purpose**: Core server-side infrastructure that MUST be complete before ANY user story UI can be built.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [x] T005 [P] Create `createVersionSnapshot` server action in src/lib/actions/document-versions.ts — calls `create_document_version` RPC with document's current content/pages/title
+- [x] T006 [P] Create `getDocumentVersions` query function in src/lib/queries/document-versions.ts — fetches versions for a document ordered by created_at DESC
+- [x] T007 [P] Create `restoreDocumentVersion` server action in src/lib/actions/document-versions.ts — calls `restore_document_version` RPC
+- [x] T008 [P] Create beacon endpoint POST handler in src/app/api/version-snapshot/route.ts — authenticates via Supabase cookie, calls `create_document_version` RPC with trigger='close', returns 204
+- [x] T009 Write integration tests for `create_document_version` RPC (insert, cap enforcement at 8, duplicate prevention) in src/lib/actions/__tests__/document-versions.integration.test.ts
+- [x] T010 Write integration tests for `restore_document_version` RPC (before_restore snapshot creation, document overwrite, cap enforcement) in src/lib/actions/__tests__/document-versions.integration.test.ts
+
+**Checkpoint**: Foundation ready — all server-side endpoints and queries work and are tested. User story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — View Version History (Priority: P1) MVP
+
+**Goal**: Users can open a sidebar to see a chronological list of saved version snapshots with relative timestamps and trigger labels.
+
+**Independent Test**: Open sidebar on a document with saved versions → see entries ordered newest-first with correct timestamps and labels. Empty state shown when no versions exist.
+
+### Tests for User Story 1
+
+- [x] T011 [P] [US1] Write unit test for relative timestamp formatting (e.g., "30 min ago", "2 hours ago", "Yesterday") in src/components/version-history/__tests__/version-sidebar.test.tsx
+
+### Implementation for User Story 1
+
+- [x] T012 [P] [US1] Create `VersionSidebar` component in src/components/version-history/version-sidebar.tsx — fetches versions via `fetchDocumentVersions`, renders newest-first list with relative timestamps and trigger labels, shows empty state when no versions
+- [x] T013 [US1] Add version history toggle button and sidebar integration to src/components/canvas/canvas-editor.tsx — toggle button in toolbar opens/closes `VersionSidebar` alongside the editor (follows AI Chat Panel layout pattern)
+- [x] T014 [US1] Add version history toggle button and sidebar integration to src/components/editor/tiptap-editor.tsx — same toggle for text-only documents via TiptapEditorWithVersions wrapper
+
+**Checkpoint**: User Story 1 is fully functional — users can view version history in a sidebar. The sidebar shows real data from the database (seeded or manually inserted).
+
+---
+
+## Phase 4: User Story 2 — Automatic Version Snapshots (Priority: P1) MVP
+
+**Goal**: The system automatically creates version snapshots at smart intervals (30s idle, 5min periodic, session close) without user action. Duplicate/unchanged snapshots are skipped. Cap of 8 enforced.
+
+**Independent Test**: Edit a document, wait 30 seconds, verify a version appears in the database. Edit more, wait again, verify a second version appears. Verify sidebar (from US1) shows the new entries.
+
+### Tests for User Story 2
+
+- [x] T015 [P] [US2] Write unit tests for `useVersionSnapshots` hook — idle timer fires after 30s, periodic timer fires after 5min, timers reset on activity, skip when content unchanged — in src/hooks/__tests__/use-version-snapshots.test.ts
+
+### Implementation for User Story 2
+
+- [x] T016 [US2] Create `useVersionSnapshots` hook in src/hooks/use-version-snapshots.ts — manages idle timer (30s), periodic timer (5min), change detection via JSON.stringify comparison against last snapshot ref, calls `createVersionSnapshot` server action on trigger
+- [x] T017 [US2] Add `beforeunload` and `visibilitychange` handlers to `useVersionSnapshots` for session-close snapshots — uses `navigator.sendBeacon()` to POST to /api/version-snapshot endpoint
+- [x] T018 [US2] Wire `useVersionSnapshots` into `useDocumentSync` in src/hooks/use-document-sync.ts — pass documentId, editor content getter, and pages getter; reset idle timer on each `triggerSave` call
+
+**Checkpoint**: User Story 2 is fully functional — versions are created automatically at smart intervals. Combined with US1, users can edit and then see their version history populate in real-time.
+
+---
+
+## Phase 5: User Story 3 — Restore a Previous Version (Priority: P2)
+
+**Goal**: Users can select a version from the sidebar and restore it, overwriting the current document. A "Before restore" safety snapshot is always created first.
+
+**Independent Test**: Edit document to state B, open sidebar showing snapshot of state A, click "Restore" on state A, verify document shows state A content and a new "Before restore" entry appears in the sidebar.
+
+### Tests for User Story 3
+
+- [x] T019 [P] [US3] Write integration test for restore flow — verify document content is overwritten, "before_restore" snapshot is created, sidebar reflects new state — in src/lib/actions/__tests__/document-versions.integration.test.ts
+
+### Implementation for User Story 3
+
+- [x] T020 [US3] Add restore UI to `VersionSidebar` in src/components/version-history/version-sidebar.tsx — click to select a version (highlight), show "Restore" button, call `restoreDocumentVersion` server action
+- [x] T021 [US3] Handle restore response in editor — after `restoreDocumentVersion` completes, router.refresh() reloads document content from server, refresh version list in sidebar
+- [x] T022 [US3] Wire restore into canvas-editor.tsx and tiptap-editor.tsx — VersionSidebar is mounted in DocumentWithAi and TiptapEditorWithVersions wrappers with onRestore callback
+
+**Checkpoint**: All user stories are independently functional — versions auto-save, display in sidebar, and can be restored with safety snapshots.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: E2E tests, edge case handling, and final validation.
+
+- [x] T023 Update e2e/TEST_REGISTRY.md with version history test scenarios
+- [x] T024 Write E2E Playwright test: open document → open version sidebar → verify versions appear in e2e/version-history.spec.ts
+- [x] T025 Write E2E Playwright test: restore a version → verify "Before restore" entry appears in e2e/version-history.spec.ts
+- [x] T026 Run full test suite: `pnpm test && pnpm test:integration` (E2E deferred to CI)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 completion — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 (needs `getDocumentVersions` query)
+- **US2 (Phase 4)**: Depends on Phase 2 (needs `createVersionSnapshot` action)
+- **US3 (Phase 5)**: Depends on Phase 2 (needs `restoreDocumentVersion` action) + benefits from US1 sidebar being built
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (View History)**: Can start after Phase 2 — no dependency on other stories
+- **US2 (Auto Snapshots)**: Can start after Phase 2 — no dependency on other stories (but complements US1)
+- **US3 (Restore)**: Can start after Phase 2 — builds on US1 sidebar component but adds restore functionality
+
+### Within Each User Story
+
+- Tests written before implementation (TDD where practical)
+- Core logic before UI wiring
+- Commit after each task or logical group
+
+### Parallel Opportunities
+
+- T005, T006, T007, T008 can all run in parallel (different files, no dependencies)
+- T009, T010 can run in parallel (different test cases, same file but independent)
+- T011, T012 can run in parallel (test + component in different files)
+- T015, T016 can run in parallel (test + hook in different files)
+- US1 and US2 can be worked on in parallel after Phase 2 (different components/hooks)
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Launch all server-side tasks together:
+Task: "Create createVersionSnapshot server action in src/lib/actions/document-versions.ts"
+Task: "Create getDocumentVersions query in src/lib/queries/document-versions.ts"
+Task: "Create restoreDocumentVersion server action in src/lib/actions/document-versions.ts"
+Task: "Create beacon endpoint in src/app/api/version-snapshot/route.ts"
+```
+
+## Parallel Example: US1 + US2 (after Phase 2)
+
+```bash
+# These two stories can run in parallel:
+Story 1: "VersionSidebar component + editor integration"
+Story 2: "useVersionSnapshots hook + useDocumentSync wiring"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2)
+
+1. Complete Phase 1: Setup (migration, seed, types)
+2. Complete Phase 2: Foundational (server actions, queries, tests)
+3. Complete Phase 3: US1 — View Version History
+4. Complete Phase 4: US2 — Auto Snapshots
+5. **STOP and VALIDATE**: Versions auto-save and display in sidebar
+6. Deploy/demo if ready — users get value even without restore
+
+### Incremental Delivery
+
+1. Setup + Foundational → Database ready
+2. Add US1 (View History) → Users can see versions → Deploy
+3. Add US2 (Auto Snapshots) → Versions populate automatically → Deploy
+4. Add US3 (Restore) → Users can restore versions → Deploy
+5. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- The migration (T001) includes both RPC functions upfront to avoid a second migration later
+- sendBeacon endpoint (T008) is foundational because US2 needs it for session-close triggers
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently

--- a/specs/039-document-versioning/tasks.md
+++ b/specs/039-document-versioning/tasks.md
@@ -34,8 +34,8 @@
 - [x] T006 [P] Create `getDocumentVersions` query function in src/lib/queries/document-versions.ts — fetches versions for a document ordered by created_at DESC
 - [x] T007 [P] Create `restoreDocumentVersion` server action in src/lib/actions/document-versions.ts — calls `restore_document_version` RPC
 - [x] T008 [P] Create beacon endpoint POST handler in src/app/api/version-snapshot/route.ts — authenticates via Supabase cookie, calls `create_document_version` RPC with trigger='close', returns 204
-- [x] T009 Write integration tests for `create_document_version` RPC (insert, cap enforcement at 8, duplicate prevention) in src/lib/actions/__tests__/document-versions.integration.test.ts
-- [x] T010 Write integration tests for `restore_document_version` RPC (before_restore snapshot creation, document overwrite, cap enforcement) in src/lib/actions/__tests__/document-versions.integration.test.ts
+- [x] T009 Write integration tests for `create_document_version` RPC (insert, cap enforcement at 8, duplicate prevention) in src/lib/actions/**tests**/document-versions.integration.test.ts
+- [x] T010 Write integration tests for `restore_document_version` RPC (before_restore snapshot creation, document overwrite, cap enforcement) in src/lib/actions/**tests**/document-versions.integration.test.ts
 
 **Checkpoint**: Foundation ready — all server-side endpoints and queries work and are tested. User story implementation can now begin.
 
@@ -49,7 +49,7 @@
 
 ### Tests for User Story 1
 
-- [x] T011 [P] [US1] Write unit test for relative timestamp formatting (e.g., "30 min ago", "2 hours ago", "Yesterday") in src/components/version-history/__tests__/version-sidebar.test.tsx
+- [x] T011 [P] [US1] Write unit test for relative timestamp formatting (e.g., "30 min ago", "2 hours ago", "Yesterday") in src/components/version-history/**tests**/version-sidebar.test.tsx
 
 ### Implementation for User Story 1
 
@@ -69,7 +69,7 @@
 
 ### Tests for User Story 2
 
-- [x] T015 [P] [US2] Write unit tests for `useVersionSnapshots` hook — idle timer fires after 30s, periodic timer fires after 5min, timers reset on activity, skip when content unchanged — in src/hooks/__tests__/use-version-snapshots.test.ts
+- [x] T015 [P] [US2] Write unit tests for `useVersionSnapshots` hook — idle timer fires after 30s, periodic timer fires after 5min, timers reset on activity, skip when content unchanged — in src/hooks/**tests**/use-version-snapshots.test.ts
 
 ### Implementation for User Story 2
 
@@ -89,7 +89,7 @@
 
 ### Tests for User Story 3
 
-- [x] T019 [P] [US3] Write integration test for restore flow — verify document content is overwritten, "before_restore" snapshot is created, sidebar reflects new state — in src/lib/actions/__tests__/document-versions.integration.test.ts
+- [x] T019 [P] [US3] Write integration test for restore flow — verify document content is overwritten, "before_restore" snapshot is created, sidebar reflects new state — in src/lib/actions/**tests**/document-versions.integration.test.ts
 
 ### Implementation for User Story 3
 

--- a/src/app/(dashboard)/dashboard/documents/[docId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/documents/[docId]/page.tsx
@@ -4,8 +4,7 @@ import { GraduationCap } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { AiChatWrapper } from '@/components/ai/ai-chat-wrapper';
 import { DocumentWithAi } from '@/components/ai/document-with-ai';
-import { CanvasEditor } from '@/components/canvas/canvas-editor';
-import { TiptapEditor } from '@/components/editor/tiptap-editor';
+import { TiptapEditorWithVersions } from '@/components/editor/tiptap-editor-with-versions';
 import type { Course, CourseWeek, Document } from '@/types/database';
 
 interface DocumentPageProps {
@@ -69,17 +68,13 @@ export default async function DocumentPage({ params }: DocumentPageProps) {
       )}
 
       {isTextDocument ? (
-        <div className="flex min-h-0 flex-1">
-          <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-            <TiptapEditor document={typedDocument} />
-          </div>
-          <AiChatWrapper
-            courseId={course?.id}
-            courseName={course?.name}
-            weekId={typedDocument.week_id ?? undefined}
-            weekLabel={weekLabel}
-          />
-        </div>
+        <TiptapEditorWithVersions
+          document={typedDocument}
+          courseId={course?.id}
+          courseName={course?.name}
+          weekId={typedDocument.week_id ?? undefined}
+          weekLabel={weekLabel}
+        />
       ) : (
         <DocumentWithAi
           courseId={course?.id}

--- a/src/app/api/version-snapshot/route.ts
+++ b/src/app/api/version-snapshot/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { documentId } = body as { documentId?: string };
+
+    if (!documentId) {
+      return new NextResponse(null, { status: 400 });
+    }
+
+    const supabase = await createClient();
+
+    // Fire-and-forget — beacon callers don't read responses
+    await supabase.rpc('create_document_version', {
+      p_document_id: documentId,
+      p_trigger: 'close',
+    });
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    // Beacon endpoint should never fail loudly
+    return new NextResponse(null, { status: 204 });
+  }
+}

--- a/src/components/ai/document-with-ai.tsx
+++ b/src/components/ai/document-with-ai.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 
 import { CanvasEditor } from '@/components/canvas/canvas-editor';
+import { VersionSidebar } from '@/components/version-history/version-sidebar';
 import type { Document } from '@/types/database';
 import type { AiContextItem } from './ai-chat-panel';
 
@@ -30,6 +31,7 @@ export function DocumentWithAi({
   const getDocumentTextRef = useRef<(() => string) | null>(null);
   const [contextItems, setContextItems] = useState<AiContextItem[]>([]);
   const [isAiOpen, setIsAiOpen] = useState(false);
+  const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false);
 
   const handleDocumentTextReady = useCallback((getter: () => string) => {
     getDocumentTextRef.current = getter;
@@ -69,8 +71,16 @@ export function DocumentWithAi({
           personalFileId={personalFileId}
           courseName={courseName}
           onAskAiWithContext={handleAskAiWithContext}
+          onToggleVersionHistory={() =>
+            setIsVersionHistoryOpen((prev) => !prev)
+          }
         />
       </div>
+      <VersionSidebar
+        documentId={document.id}
+        isOpen={isVersionHistoryOpen}
+        onClose={() => setIsVersionHistoryOpen(false)}
+      />
       <AiChatWrapper
         courseId={courseId}
         courseName={courseName}

--- a/src/components/canvas/canvas-editor.tsx
+++ b/src/components/canvas/canvas-editor.tsx
@@ -45,6 +45,7 @@ import {
   Sparkles,
   Download,
   Loader2,
+  Clock,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useSidebar } from '@/components/dashboard/sidebar-layout';
@@ -91,6 +92,7 @@ interface CanvasEditorProps {
       | { type: 'text'; content: string }
       | { type: 'image'; dataUrl: string },
   ) => void;
+  onToggleVersionHistory?: () => void;
 }
 
 const CANVAS_CLASSES: Record<string, string> = {
@@ -330,6 +332,7 @@ export function CanvasEditor({
   personalFileId,
   courseName,
   onAskAiWithContext,
+  onToggleVersionHistory,
 }: CanvasEditorProps) {
   const router = useRouter();
   const { isOpen: sidebarOpen, toggle: toggleSidebar } = useSidebar();
@@ -2494,10 +2497,24 @@ export function CanvasEditor({
           </>
         )}
 
-        {/* Export PDF — always visible */}
+        {/* Version History — always visible */}
+        <div className="flex-1" />
+        {onToggleVersionHistory && (
+          <button
+            onPointerDown={(e) => {
+              e.stopPropagation();
+              onToggleVersionHistory();
+            }}
+            className="flex items-center justify-center h-8 w-8 min-h-[44px] min-w-[44px] rounded-lg transition-colors hover:bg-accent/50 text-muted-foreground"
+            title="Version history"
+          >
+            <Clock className="h-4 w-4" />
+          </button>
+        )}
+
+        {/* Export PDF — hidden in text mode */}
         {activeTool !== 'text' && (
           <>
-            <div className="flex-1" />
             <button
               onPointerDown={(e) => {
                 e.stopPropagation();

--- a/src/components/editor/tiptap-editor-with-versions.tsx
+++ b/src/components/editor/tiptap-editor-with-versions.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useState } from 'react';
+import type { Document } from '@/types/database';
+import { TiptapEditor } from './tiptap-editor';
+import { VersionSidebar } from '@/components/version-history/version-sidebar';
+import { AiChatWrapper } from '@/components/ai/ai-chat-wrapper';
+
+interface TiptapEditorWithVersionsProps {
+  document: Document;
+  courseId?: string;
+  courseName?: string;
+  weekId?: string;
+  weekLabel?: string;
+}
+
+export function TiptapEditorWithVersions({
+  document,
+  courseId,
+  courseName,
+  weekId,
+  weekLabel,
+}: TiptapEditorWithVersionsProps) {
+  const [isVersionHistoryOpen, setIsVersionHistoryOpen] = useState(false);
+
+  return (
+    <div className="flex min-h-0 flex-1">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+        <TiptapEditor
+          document={document}
+          onToggleVersionHistory={() =>
+            setIsVersionHistoryOpen((prev) => !prev)
+          }
+        />
+      </div>
+      <VersionSidebar
+        documentId={document.id}
+        isOpen={isVersionHistoryOpen}
+        onClose={() => setIsVersionHistoryOpen(false)}
+      />
+      <AiChatWrapper
+        courseId={courseId}
+        courseName={courseName}
+        weekId={weekId}
+        weekLabel={weekLabel}
+      />
+    </div>
+  );
+}

--- a/src/components/editor/tiptap-editor.tsx
+++ b/src/components/editor/tiptap-editor.tsx
@@ -18,12 +18,14 @@ import { Indent } from '@/lib/editor/indent-extension';
 import { MathExpression } from '@/lib/editor/math-extension';
 import { MathInputBox } from '@/lib/editor/math-input-box';
 import { EditorToolbar } from './editor-toolbar';
+import { Clock } from 'lucide-react';
 import { toast } from 'sonner';
 import 'katex/dist/katex.min.css';
 
 interface TiptapEditorProps {
   document: Document;
   courseName?: string;
+  onToggleVersionHistory?: () => void;
 }
 
 const CANVAS_CLASSES: Record<string, string> = {
@@ -84,7 +86,11 @@ function ConnectionIndicator({
   );
 }
 
-export function TiptapEditor({ document, courseName }: TiptapEditorProps) {
+export function TiptapEditor({
+  document,
+  courseName,
+  onToggleVersionHistory,
+}: TiptapEditorProps) {
   const [title, setTitle] = useState(document.title);
   const [mathInputPosition, setMathInputPosition] = useState<{
     x: number;
@@ -230,6 +236,15 @@ export function TiptapEditor({ document, courseName }: TiptapEditorProps) {
           placeholder="Untitled"
         />
         <div className="flex items-center gap-3">
+          {onToggleVersionHistory && (
+            <button
+              onClick={onToggleVersionHistory}
+              className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-accent text-muted-foreground"
+              title="Version history"
+            >
+              <Clock className="h-4 w-4" />
+            </button>
+          )}
           <ConnectionIndicator
             status={connectionStatus}
             isLockedByRemote={isLockedByRemote}

--- a/src/components/version-history/__tests__/version-sidebar.test.tsx
+++ b/src/components/version-history/__tests__/version-sidebar.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from '../version-sidebar';
+
+describe('formatRelativeTime', () => {
+  const now = new Date('2026-04-13T12:00:00Z');
+
+  it('returns "Just now" for < 1 minute ago', () => {
+    const date = new Date('2026-04-13T11:59:30Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('Just now');
+  });
+
+  it('returns "1 min ago" for 1 minute ago', () => {
+    const date = new Date('2026-04-13T11:59:00Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('1 min ago');
+  });
+
+  it('returns "30 min ago" for 30 minutes ago', () => {
+    const date = new Date('2026-04-13T11:30:00Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('30 min ago');
+  });
+
+  it('returns "1 hour ago" for 1 hour ago', () => {
+    const date = new Date('2026-04-13T11:00:00Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('1 hour ago');
+  });
+
+  it('returns "3 hours ago" for 3 hours ago', () => {
+    const date = new Date('2026-04-13T09:00:00Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('3 hours ago');
+  });
+
+  it('returns "Yesterday" for 1 day ago', () => {
+    const date = new Date('2026-04-12T12:00:00Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('Yesterday');
+  });
+
+  it('returns "3 days ago" for 3 days ago', () => {
+    const date = new Date('2026-04-10T12:00:00Z');
+    expect(formatRelativeTime(date.toISOString(), now)).toBe('3 days ago');
+  });
+
+  it('returns formatted date for > 7 days ago', () => {
+    const date = new Date('2026-04-01T12:00:00Z');
+    const result = formatRelativeTime(date.toISOString(), now);
+    expect(result).toMatch(/Apr 1/);
+  });
+});

--- a/src/components/version-history/version-sidebar.tsx
+++ b/src/components/version-history/version-sidebar.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { X, Clock, RotateCcw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import type { DocumentVersion } from '@/types/database';
+import {
+  fetchDocumentVersions,
+  restoreDocumentVersion,
+} from '@/lib/actions/document-versions';
+
+export function formatRelativeTime(
+  isoString: string,
+  now: Date = new Date(),
+): string {
+  const date = new Date(isoString);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHours = Math.floor(diffMs / 3_600_000);
+  const diffDays = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return 'Just now';
+  if (diffMin < 60) return `${diffMin} min ago`;
+  if (diffHours < 24)
+    return `${diffHours} hour${diffHours === 1 ? '' : 's'} ago`;
+  if (diffDays === 1) return 'Yesterday';
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+const TRIGGER_LABELS: Record<string, string> = {
+  idle: 'Auto-saved',
+  periodic: 'Auto-saved',
+  close: 'Auto-saved',
+  before_restore: 'Before restore',
+};
+
+interface VersionSidebarProps {
+  documentId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onRestore?: (version: DocumentVersion) => void;
+}
+
+export function VersionSidebar({
+  documentId,
+  isOpen,
+  onClose,
+  onRestore,
+}: VersionSidebarProps) {
+  const router = useRouter();
+  const [versions, setVersions] = useState<DocumentVersion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [restoring, setRestoring] = useState(false);
+
+  const fetchVersions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchDocumentVersions(documentId);
+      setVersions(data);
+    } catch {
+      // Silently fail — sidebar just shows empty state
+    } finally {
+      setLoading(false);
+    }
+  }, [documentId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchVersions();
+    }
+  }, [isOpen, fetchVersions]);
+
+  const handleRestore = useCallback(async () => {
+    if (!selectedId) return;
+    const version = versions.find((v) => v.id === selectedId);
+    if (!version) return;
+
+    setRestoring(true);
+    try {
+      await restoreDocumentVersion(selectedId);
+      onRestore?.(version);
+      // Full page reload to pick up restored content — router.refresh()
+      // doesn't work because the editor keeps its client-side state
+      window.location.reload();
+    } catch {
+      setRestoring(false);
+    }
+  }, [selectedId, versions, onRestore, fetchVersions]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex h-full w-full flex-col border-l bg-background shadow-xl lg:static lg:z-auto lg:w-[300px] lg:shrink-0">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Clock className="h-4 w-4 text-muted-foreground" />
+          <h2 className="text-sm font-semibold">Version History</h2>
+        </div>
+        <button
+          onClick={onClose}
+          className="flex h-8 w-8 items-center justify-center rounded-md hover:bg-accent"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Version list */}
+      <div className="flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+            Loading...
+          </div>
+        ) : versions.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 px-4 text-center">
+            <Clock className="h-8 w-8 text-muted-foreground/50" />
+            <p className="text-sm text-muted-foreground">
+              No version history yet.
+            </p>
+            <p className="text-xs text-muted-foreground/70">
+              Versions are saved automatically as you edit.
+            </p>
+          </div>
+        ) : (
+          <div className="divide-y">
+            {versions.map((version) => (
+              <button
+                key={version.id}
+                onClick={() =>
+                  setSelectedId((prev) =>
+                    prev === version.id ? null : version.id,
+                  )
+                }
+                className={`w-full px-4 py-3 text-left transition-colors hover:bg-accent/50 ${
+                  selectedId === version.id
+                    ? 'bg-accent border-l-2 border-l-primary'
+                    : ''
+                }`}
+              >
+                <div className="text-sm font-medium">
+                  {formatRelativeTime(version.created_at)}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {TRIGGER_LABELS[version.trigger] ?? version.trigger}
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Restore button */}
+      {selectedId && (
+        <div className="border-t p-4">
+          <button
+            onClick={handleRestore}
+            disabled={restoring}
+            className="flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+          >
+            <RotateCcw className="h-4 w-4" />
+            {restoring ? 'Restoring...' : 'Restore this version'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/__tests__/use-version-snapshots.test.ts
+++ b/src/hooks/__tests__/use-version-snapshots.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVersionSnapshots } from '../use-version-snapshots';
+import { createVersionSnapshot } from '@/lib/actions/document-versions';
+
+// Mock the server action
+vi.mock('@/lib/actions/document-versions', () => ({
+  createVersionSnapshot: vi
+    .fn()
+    .mockResolvedValue({ id: 'v1', created_at: '2026-04-13T12:00:00Z' }),
+}));
+
+const mockCreateVersionSnapshot = vi.mocked(createVersionSnapshot);
+
+describe('useVersionSnapshots', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockCreateVersionSnapshot.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not fire immediately on mount', () => {
+    renderHook(() =>
+      useVersionSnapshots({
+        documentId: 'doc-1',
+        getContentHash: () => 'hash-1',
+      }),
+    );
+
+    expect(mockCreateVersionSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('fires after 30s idle timeout when content changes', async () => {
+    const { result } = renderHook(() =>
+      useVersionSnapshots({
+        documentId: 'doc-1',
+        getContentHash: () => 'hash-1',
+      }),
+    );
+
+    // Signal activity to start idle tracking
+    act(() => result.current.onActivity());
+
+    // Advance 30 seconds
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(mockCreateVersionSnapshot).toHaveBeenCalledWith('doc-1', 'idle');
+  });
+
+  it('resets idle timer on each activity signal', async () => {
+    const { result } = renderHook(() =>
+      useVersionSnapshots({
+        documentId: 'doc-1',
+        getContentHash: () => 'hash-changing-' + Date.now(),
+      }),
+    );
+
+    // Signal activity
+    act(() => result.current.onActivity());
+
+    // Advance 20 seconds (less than 30s)
+    act(() => vi.advanceTimersByTime(20_000));
+
+    // Signal activity again — should reset the timer
+    act(() => result.current.onActivity());
+
+    // Advance 20 more seconds (total 40s from start, but only 20s from last activity)
+    await act(async () => {
+      vi.advanceTimersByTime(20_000);
+    });
+
+    // Should NOT have fired yet (only 20s since last activity, need 30s)
+    expect(mockCreateVersionSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('skips snapshot when content has not changed', async () => {
+    const stableHash = 'stable-hash';
+
+    const { result } = renderHook(() =>
+      useVersionSnapshots({
+        documentId: 'doc-1',
+        getContentHash: () => stableHash,
+      }),
+    );
+
+    // First activity + idle → snapshot
+    act(() => result.current.onActivity());
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+    const callCountAfterFirst = mockCreateVersionSnapshot.mock.calls.length;
+
+    // Second activity + idle → same hash, should skip
+    act(() => result.current.onActivity());
+    await act(async () => {
+      vi.advanceTimersByTime(30_000);
+    });
+
+    expect(mockCreateVersionSnapshot.mock.calls.length).toBe(
+      callCountAfterFirst,
+    );
+  });
+
+  it('fires periodic snapshot after 5 minutes of continuous activity', async () => {
+    let hashCounter = 0;
+
+    const { result } = renderHook(() =>
+      useVersionSnapshots({
+        documentId: 'doc-1',
+        getContentHash: () => `hash-${hashCounter++}`,
+      }),
+    );
+
+    // Simulate continuous activity — signal every 20 seconds to prevent idle trigger
+    for (let i = 0; i < 15; i++) {
+      act(() => result.current.onActivity());
+      act(() => vi.advanceTimersByTime(20_000));
+    }
+
+    // At 5 minutes (300s), the periodic timer should have fired
+    await act(async () => {
+      vi.advanceTimersByTime(0); // flush microtasks
+    });
+
+    const periodicCalls = mockCreateVersionSnapshot.mock.calls.filter(
+      (c) => c[1] === 'periodic',
+    );
+    expect(periodicCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/hooks/use-document-sync.ts
+++ b/src/hooks/use-document-sync.ts
@@ -7,6 +7,7 @@ import {
   type SaveErrorType,
 } from './use-auto-save';
 import { useRealtimeSync, type ConnectionStatus } from './use-realtime-sync';
+import { useVersionSnapshots } from './use-version-snapshots';
 import {
   updateDocumentContent,
   updateDocumentTitle,
@@ -72,6 +73,25 @@ export function useDocumentSync({
     errorType,
     retryNow,
   } = useAutoSave(saveFn);
+
+  // Version snapshots — content hash for change detection
+  const getContentHash = useCallback(() => {
+    const content = editor ? JSON.stringify(editor.getJSON()) : '{}';
+    const pages = getPagesData?.();
+    const pagesStr = pages ? JSON.stringify(pages) : '';
+    return content + pagesStr;
+  }, [editor, getPagesData]);
+
+  const { onActivity: onVersionActivity } = useVersionSnapshots({
+    documentId,
+    getContentHash,
+  });
+
+  // Wrap triggerSave to also signal version snapshot activity
+  const triggerSaveWithVersioning = useCallback(() => {
+    triggerSave();
+    onVersionActivity();
+  }, [triggerSave, onVersionActivity]);
 
   const manualSave = useCallback(async () => {
     await flushSave();
@@ -158,7 +178,7 @@ export function useDocumentSync({
     connectionStatus,
     isLockedByRemote,
     unlockEditor,
-    triggerSave,
+    triggerSave: triggerSaveWithVersioning,
     flushSave,
     lastSaveTimestampRef,
     saveTitle,

--- a/src/hooks/use-version-snapshots.ts
+++ b/src/hooks/use-version-snapshots.ts
@@ -1,0 +1,114 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { createVersionSnapshot } from '@/lib/actions/document-versions';
+
+const IDLE_TIMEOUT_MS = 30_000; // 30 seconds
+const PERIODIC_INTERVAL_MS = 300_000; // 5 minutes
+
+interface UseVersionSnapshotsOptions {
+  documentId: string;
+  /** Returns a string that changes when document content changes. */
+  getContentHash: () => string;
+}
+
+export function useVersionSnapshots({
+  documentId,
+  getContentHash,
+}: UseVersionSnapshotsOptions) {
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const periodicTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastSnapshotHashRef = useRef<string | null>(null);
+  const getContentHashRef = useRef(getContentHash);
+  const documentIdRef = useRef(documentId);
+
+  // Keep refs in sync
+  useEffect(() => {
+    getContentHashRef.current = getContentHash;
+  }, [getContentHash]);
+
+  useEffect(() => {
+    documentIdRef.current = documentId;
+  }, [documentId]);
+
+  const trySnapshot = useCallback(
+    async (trigger: 'idle' | 'periodic' | 'close') => {
+      const hash = getContentHashRef.current();
+
+      // Skip if content hasn't changed since last snapshot
+      if (hash === lastSnapshotHashRef.current) return;
+
+      try {
+        await createVersionSnapshot(documentIdRef.current, trigger);
+        lastSnapshotHashRef.current = hash;
+      } catch {
+        // Snapshot failed — don't update hash, try again next time
+      }
+    },
+    [],
+  );
+
+  // Start periodic timer on mount
+  useEffect(() => {
+    periodicTimerRef.current = setInterval(() => {
+      trySnapshot('periodic');
+    }, PERIODIC_INTERVAL_MS);
+
+    return () => {
+      if (periodicTimerRef.current) {
+        clearInterval(periodicTimerRef.current);
+      }
+    };
+  }, [trySnapshot]);
+
+  // Called whenever the user makes an edit (from triggerSave)
+  const onActivity = useCallback(() => {
+    // Reset idle timer
+    if (idleTimerRef.current) {
+      clearTimeout(idleTimerRef.current);
+    }
+    idleTimerRef.current = setTimeout(() => {
+      trySnapshot('idle');
+    }, IDLE_TIMEOUT_MS);
+  }, [trySnapshot]);
+
+  // Session close: beforeunload + visibilitychange
+  useEffect(() => {
+    const handleBeforeUnload = () => {
+      // Use sendBeacon for reliability on page close
+      try {
+        navigator.sendBeacon(
+          '/api/version-snapshot',
+          JSON.stringify({ documentId: documentIdRef.current }),
+        );
+      } catch {
+        // Fallback — best effort
+      }
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        trySnapshot('close');
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [trySnapshot]);
+
+  // Cleanup idle timer on unmount
+  useEffect(() => {
+    return () => {
+      if (idleTimerRef.current) {
+        clearTimeout(idleTimerRef.current);
+      }
+    };
+  }, []);
+
+  return { onActivity };
+}

--- a/src/lib/actions/__tests__/document-versions.integration.test.ts
+++ b/src/lib/actions/__tests__/document-versions.integration.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Integration tests for document_versions table and version history logic.
+ *
+ * Uses the admin (service_role) client which bypasses RLS.
+ * Tests table operations, cap enforcement, cascade delete, and restore flow.
+ *
+ * Note: The create_document_version and restore_document_version RPCs use
+ * auth.uid() which requires a real auth session. Here we test the underlying
+ * table behavior directly — the RPCs are thin wrappers around these operations.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createAdminClient, TEST_USER_ID } from '@/test/supabase-client';
+
+const TEST_DOC_ID = '20000000-0000-0000-0000-000000000001'; // seeded "Limits and Continuity"
+
+let supabase: SupabaseClient;
+
+beforeAll(async () => {
+  supabase = createAdminClient();
+
+  // Clean up any test versions (keep seeded ones by deleting only non-seeded)
+  await supabase
+    .from('document_versions')
+    .delete()
+    .eq('document_id', TEST_DOC_ID)
+    .not(
+      'id',
+      'in',
+      '("90000000-0000-0000-0000-000000000001","90000000-0000-0000-0000-000000000002","90000000-0000-0000-0000-000000000003")',
+    );
+});
+
+afterAll(async () => {
+  // Clean up versions created during tests (keep seeded ones)
+  await supabase
+    .from('document_versions')
+    .delete()
+    .eq('document_id', TEST_DOC_ID)
+    .not(
+      'id',
+      'in',
+      '("90000000-0000-0000-0000-000000000001","90000000-0000-0000-0000-000000000002","90000000-0000-0000-0000-000000000003")',
+    );
+});
+
+describe('document_versions table', () => {
+  it('has seeded version records for the test document', async () => {
+    const { data, error } = await supabase
+      .from('document_versions')
+      .select('*')
+      .eq('document_id', TEST_DOC_ID)
+      .order('created_at', { ascending: false });
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(3);
+    expect(data![0].trigger).toBe('close');
+    expect(data![1].trigger).toBe('periodic');
+    expect(data![2].trigger).toBe('idle');
+  });
+
+  it('can insert a new version with correct fields', async () => {
+    const { data, error } = await supabase
+      .from('document_versions')
+      .insert({
+        document_id: TEST_DOC_ID,
+        user_id: TEST_USER_ID,
+        content: { type: 'doc', content: [] },
+        pages: null,
+        title: 'Test Version',
+        trigger: 'idle',
+      })
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).toMatchObject({
+      document_id: TEST_DOC_ID,
+      user_id: TEST_USER_ID,
+      title: 'Test Version',
+      trigger: 'idle',
+    });
+    expect(data!.id).toBeTruthy();
+    expect(data!.created_at).toBeTruthy();
+
+    // Clean up
+    await supabase.from('document_versions').delete().eq('id', data!.id);
+  });
+
+  it('stores pages JSONB when provided', async () => {
+    const pages = {
+      pages: [
+        { id: 'p1', order: 0, strokes: [], textBoxes: [], flowContent: null },
+      ],
+    };
+
+    const { data, error } = await supabase
+      .from('document_versions')
+      .insert({
+        document_id: TEST_DOC_ID,
+        user_id: TEST_USER_ID,
+        content: { type: 'doc', content: [] },
+        pages,
+        title: 'With Pages',
+        trigger: 'periodic',
+      })
+      .select()
+      .single();
+
+    expect(error).toBeNull();
+    expect(data!.pages).toEqual(pages);
+
+    // Clean up
+    await supabase.from('document_versions').delete().eq('id', data!.id);
+  });
+
+  it('orders by created_at DESC when queried', async () => {
+    const { data, error } = await supabase
+      .from('document_versions')
+      .select('created_at')
+      .eq('document_id', TEST_DOC_ID)
+      .order('created_at', { ascending: false });
+
+    expect(error).toBeNull();
+    expect(data!.length).toBeGreaterThanOrEqual(3);
+
+    // Verify descending order
+    for (let i = 1; i < data!.length; i++) {
+      expect(
+        new Date(data![i - 1].created_at).getTime(),
+      ).toBeGreaterThanOrEqual(new Date(data![i].created_at).getTime());
+    }
+  });
+});
+
+describe('cap enforcement (max 8 versions)', () => {
+  it('allows up to 8 versions per document', async () => {
+    // We already have 3 seeded versions. Insert 5 more to reach 8.
+    const inserts = Array.from({ length: 5 }, (_, i) => ({
+      document_id: TEST_DOC_ID,
+      user_id: TEST_USER_ID,
+      content: { type: 'doc', content: [{ type: 'paragraph', text: `v${i}` }] },
+      pages: null,
+      title: `Cap Test ${i}`,
+      trigger: 'idle' as const,
+    }));
+
+    const { error: insertError } = await supabase
+      .from('document_versions')
+      .insert(inserts);
+
+    expect(insertError).toBeNull();
+
+    const { data, error } = await supabase
+      .from('document_versions')
+      .select('id')
+      .eq('document_id', TEST_DOC_ID);
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(8);
+
+    // Clean up the 5 we just inserted (keep seeded)
+    await supabase
+      .from('document_versions')
+      .delete()
+      .eq('document_id', TEST_DOC_ID)
+      .not(
+        'id',
+        'in',
+        '("90000000-0000-0000-0000-000000000001","90000000-0000-0000-0000-000000000002","90000000-0000-0000-0000-000000000003")',
+      );
+  });
+});
+
+describe('cascade delete', () => {
+  it('deletes versions when the parent document is deleted', async () => {
+    // Create a temporary document
+    const { data: doc } = await supabase
+      .from('documents')
+      .insert({
+        user_id: TEST_USER_ID,
+        title: 'Temp Doc for Cascade Test',
+        content: {},
+        subject: 'other',
+        canvas_type: 'blank',
+        position: 99,
+      })
+      .select('id')
+      .single();
+
+    expect(doc).toBeTruthy();
+
+    // Insert a version for this document
+    const { data: version } = await supabase
+      .from('document_versions')
+      .insert({
+        document_id: doc!.id,
+        user_id: TEST_USER_ID,
+        content: { type: 'doc', content: [] },
+        title: 'Cascade Test Version',
+        trigger: 'idle',
+      })
+      .select('id')
+      .single();
+
+    expect(version).toBeTruthy();
+
+    // Delete the document
+    await supabase.from('documents').delete().eq('id', doc!.id);
+
+    // Verify the version is also deleted
+    const { data: orphanedVersions } = await supabase
+      .from('document_versions')
+      .select('id')
+      .eq('id', version!.id);
+
+    expect(orphanedVersions).toHaveLength(0);
+  });
+});
+
+describe('restore flow (table-level)', () => {
+  it('can overwrite document content from a version snapshot', async () => {
+    // Read the current document content
+    const { data: docBefore } = await supabase
+      .from('documents')
+      .select('content, title')
+      .eq('id', TEST_DOC_ID)
+      .single();
+
+    expect(docBefore).toBeTruthy();
+
+    // Read the oldest version (has simpler content)
+    const { data: version } = await supabase
+      .from('document_versions')
+      .select('content, pages, title')
+      .eq('id', '90000000-0000-0000-0000-000000000001')
+      .single();
+
+    expect(version).toBeTruthy();
+
+    // Simulate "before_restore" snapshot: insert current state
+    const { data: beforeRestore, error: snapshotError } = await supabase
+      .from('document_versions')
+      .insert({
+        document_id: TEST_DOC_ID,
+        user_id: TEST_USER_ID,
+        content: docBefore!.content,
+        pages: null,
+        title: docBefore!.title,
+        trigger: 'before_restore',
+      })
+      .select()
+      .single();
+
+    expect(snapshotError).toBeNull();
+    expect(beforeRestore!.trigger).toBe('before_restore');
+
+    // Overwrite document with version content
+    const { error: updateError } = await supabase
+      .from('documents')
+      .update({
+        content: version!.content,
+        pages: version!.pages,
+      })
+      .eq('id', TEST_DOC_ID);
+
+    expect(updateError).toBeNull();
+
+    // Verify the document now has the version's content
+    const { data: docAfter } = await supabase
+      .from('documents')
+      .select('content')
+      .eq('id', TEST_DOC_ID)
+      .single();
+
+    expect(docAfter!.content).toEqual(version!.content);
+
+    // Restore the original content back (cleanup)
+    await supabase
+      .from('documents')
+      .update({ content: docBefore!.content })
+      .eq('id', TEST_DOC_ID);
+
+    // Clean up the before_restore snapshot
+    await supabase
+      .from('document_versions')
+      .delete()
+      .eq('id', beforeRestore!.id);
+  });
+});

--- a/src/lib/actions/document-versions.ts
+++ b/src/lib/actions/document-versions.ts
@@ -1,0 +1,61 @@
+'use server';
+
+import { createClient } from '@/lib/supabase/server';
+import type { DocumentVersion, VersionTrigger } from '@/types/database';
+
+export async function createVersionSnapshot(
+  documentId: string,
+  trigger: Exclude<VersionTrigger, 'before_restore'>,
+): Promise<{ id: string; created_at: string } | null> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.rpc('create_document_version', {
+    p_document_id: documentId,
+    p_trigger: trigger,
+  });
+
+  if (error) {
+    // Document not found or user doesn't own it — return null instead of throwing
+    if (error.message.includes('Document not found')) return null;
+    throw new Error(error.message);
+  }
+
+  const row = data?.[0];
+  if (!row) return null;
+
+  return {
+    id: row.version_id,
+    created_at: row.version_created_at,
+  };
+}
+
+export async function restoreDocumentVersion(
+  versionId: string,
+): Promise<{ updated_at: string }> {
+  const supabase = await createClient();
+
+  const { data, error } = await supabase.rpc('restore_document_version', {
+    p_version_id: versionId,
+  });
+
+  if (error) throw new Error(error.message);
+
+  const row = data?.[0];
+  if (!row) throw new Error('Restore failed');
+
+  return { updated_at: row.doc_updated_at };
+}
+
+export async function fetchDocumentVersions(
+  documentId: string,
+): Promise<DocumentVersion[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('document_versions')
+    .select('*')
+    .eq('document_id', documentId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as DocumentVersion[];
+}

--- a/src/lib/queries/document-versions.ts
+++ b/src/lib/queries/document-versions.ts
@@ -1,0 +1,16 @@
+import { createClient } from '@/lib/supabase/server';
+import type { DocumentVersion } from '@/types/database';
+
+export async function getDocumentVersions(
+  documentId: string,
+): Promise<DocumentVersion[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from('document_versions')
+    .select('*')
+    .eq('document_id', documentId)
+    .order('created_at', { ascending: false });
+
+  if (error) throw new Error(error.message);
+  return (data ?? []) as DocumentVersion[];
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -202,3 +202,16 @@ export interface AiMessage {
   model: 'flash' | 'pro' | null;
   created_at: string;
 }
+
+export type VersionTrigger = 'idle' | 'periodic' | 'close' | 'before_restore';
+
+export interface DocumentVersion {
+  id: string;
+  document_id: string;
+  user_id: string;
+  content: Record<string, unknown>;
+  pages: Record<string, unknown> | null;
+  title: string;
+  trigger: VersionTrigger;
+  created_at: string;
+}

--- a/supabase/migrations/20260413101143_create_document_versions.sql
+++ b/supabase/migrations/20260413101143_create_document_versions.sql
@@ -1,0 +1,218 @@
+-- Document Version History
+-- ========================
+-- 1. Creates `document_versions` table to store point-in-time snapshots
+-- 2. Adds composite index for efficient "get versions by document" queries
+-- 3. Adds RLS policies so users can only access their own versions
+-- 4. Creates `create_document_version` RPC for atomic insert + cap enforcement
+-- 5. Creates `restore_document_version` RPC for atomic restore with safety snapshot
+--
+-- Design decisions:
+-- - Full JSONB snapshots (not diffs): simple restore, negligible storage at 8-version cap
+-- - Ring-buffer cap via RPC: prevents race conditions across multiple tabs
+-- - SECURITY DEFINER RPCs: bypass RLS internally but validate auth.uid()
+-- - ON DELETE CASCADE: versions auto-cleanup when a document is deleted
+--
+-- Interview concepts:
+-- - Ring buffer / circular buffer pattern for fixed-size history
+-- - Atomic operations via database functions (no TOCTOU races)
+-- - SECURITY DEFINER vs SECURITY INVOKER in PostgreSQL
+-- - Composite indexes for covering queries
+
+-- ============================================
+-- TABLE
+-- ============================================
+
+CREATE TABLE public.document_versions (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid        NOT NULL REFERENCES public.documents(id) ON DELETE CASCADE,
+  user_id     uuid        NOT NULL REFERENCES auth.users(id),
+  content     jsonb       NOT NULL DEFAULT '{}',
+  pages       jsonb       DEFAULT NULL,
+  title       text        NOT NULL,
+  trigger     text        NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- ============================================
+-- INDEXES
+-- ============================================
+
+-- Primary query: "get all versions for this document, newest first"
+-- Also covers cap enforcement COUNT queries
+CREATE INDEX document_versions_doc_created_idx
+  ON public.document_versions (document_id, created_at DESC);
+
+-- ============================================
+-- RLS POLICIES
+-- ============================================
+
+ALTER TABLE public.document_versions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own versions"
+  ON public.document_versions FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can create own versions"
+  ON public.document_versions FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete own versions"
+  ON public.document_versions FOR DELETE
+  USING (auth.uid() = user_id);
+
+-- No UPDATE policy — versions are immutable once created
+
+-- ============================================
+-- RPC: create_document_version
+-- ============================================
+-- Atomically inserts a new version snapshot and prunes the oldest
+-- if the document exceeds 8 versions. Reads the document's current
+-- state server-side so the client only needs to pass the document ID.
+
+CREATE OR REPLACE FUNCTION public.create_document_version(
+  p_document_id uuid,
+  p_trigger     text
+)
+RETURNS TABLE (version_id uuid, version_created_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id    uuid;
+  v_content    jsonb;
+  v_pages      jsonb;
+  v_title      text;
+  v_new_id     uuid;
+  v_created    timestamptz;
+  v_count      integer;
+BEGIN
+  -- 1. Get the authenticated user
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- 2. Read the current document state (also verifies ownership via user_id check)
+  SELECT d.content, d.pages, d.title
+    INTO v_content, v_pages, v_title
+    FROM public.documents d
+   WHERE d.id = p_document_id
+     AND d.user_id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Document not found';
+  END IF;
+
+  -- 3. Insert the new version
+  INSERT INTO public.document_versions (document_id, user_id, content, pages, title, trigger)
+    VALUES (p_document_id, v_user_id, v_content, v_pages, v_title, p_trigger)
+    RETURNING id, created_at INTO v_new_id, v_created;
+
+  -- 4. Count total versions for this document
+  SELECT count(*) INTO v_count
+    FROM public.document_versions
+   WHERE document_id = p_document_id;
+
+  -- 5. Prune oldest if over cap (8)
+  IF v_count > 8 THEN
+    DELETE FROM public.document_versions
+     WHERE id IN (
+       SELECT dv.id
+         FROM public.document_versions dv
+        WHERE dv.document_id = p_document_id
+        ORDER BY dv.created_at ASC
+        LIMIT v_count - 8
+     );
+  END IF;
+
+  -- 6. Return the new version info
+  RETURN QUERY SELECT v_new_id, v_created;
+END;
+$$;
+
+-- ============================================
+-- RPC: restore_document_version
+-- ============================================
+-- Atomically:
+-- 1. Creates a "before_restore" snapshot of the current document state
+-- 2. Overwrites the document with the target version's content
+-- 3. Prunes oldest versions if over cap
+
+CREATE OR REPLACE FUNCTION public.restore_document_version(
+  p_version_id uuid
+)
+RETURNS TABLE (doc_updated_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_user_id      uuid;
+  v_doc_id       uuid;
+  v_ver_content  jsonb;
+  v_ver_pages    jsonb;
+  v_cur_content  jsonb;
+  v_cur_pages    jsonb;
+  v_cur_title    text;
+  v_count        integer;
+  v_updated      timestamptz;
+BEGIN
+  -- 1. Get the authenticated user
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- 2. Read the target version (verify ownership)
+  SELECT dv.document_id, dv.content, dv.pages
+    INTO v_doc_id, v_ver_content, v_ver_pages
+    FROM public.document_versions dv
+   WHERE dv.id = p_version_id
+     AND dv.user_id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Version not found';
+  END IF;
+
+  -- 3. Read current document state for the "before_restore" snapshot
+  SELECT d.content, d.pages, d.title
+    INTO v_cur_content, v_cur_pages, v_cur_title
+    FROM public.documents d
+   WHERE d.id = v_doc_id
+     AND d.user_id = v_user_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Document not found';
+  END IF;
+
+  -- 4. Insert "before_restore" snapshot
+  INSERT INTO public.document_versions (document_id, user_id, content, pages, title, trigger)
+    VALUES (v_doc_id, v_user_id, v_cur_content, v_cur_pages, v_cur_title, 'before_restore');
+
+  -- 5. Prune if over cap
+  SELECT count(*) INTO v_count
+    FROM public.document_versions
+   WHERE document_id = v_doc_id;
+
+  IF v_count > 8 THEN
+    DELETE FROM public.document_versions
+     WHERE id IN (
+       SELECT dv.id
+         FROM public.document_versions dv
+        WHERE dv.document_id = v_doc_id
+        ORDER BY dv.created_at ASC
+        LIMIT v_count - 8
+     );
+  END IF;
+
+  -- 6. Overwrite the document with the target version's content
+  UPDATE public.documents
+     SET content = v_ver_content,
+         pages   = v_ver_pages
+   WHERE id = v_doc_id
+     AND user_id = v_user_id
+  RETURNING updated_at INTO v_updated;
+
+  -- 7. Return the new updated_at
+  RETURN QUERY SELECT v_updated;
+END;
+$$;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -492,3 +492,46 @@ VALUES (
   'pro',
   '2026-03-15 09:08:00+00'
 ) ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- DOCUMENT VERSIONS (test data for version history)
+-- ============================================
+
+-- Version 1 for "Limits and Continuity" — idle snapshot (older content)
+INSERT INTO public.document_versions (id, document_id, user_id, content, pages, title, trigger, created_at)
+VALUES (
+  '90000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000001',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Limits and Continuity"}]},{"type":"paragraph","content":[{"type":"text","text":"Draft: A limit describes the value a function approaches."}]}]}',
+  NULL,
+  'Limits and Continuity',
+  'idle',
+  '2026-04-10 14:00:00+00'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Version 2 for "Limits and Continuity" — periodic snapshot
+INSERT INTO public.document_versions (id, document_id, user_id, content, pages, title, trigger, created_at)
+VALUES (
+  '90000000-0000-0000-0000-000000000002',
+  '20000000-0000-0000-0000-000000000001',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Limits and Continuity"}]},{"type":"paragraph","content":[{"type":"text","text":"A limit describes the value a function approaches as the input approaches a given point."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Key Definitions"}]}]}',
+  NULL,
+  'Limits and Continuity',
+  'periodic',
+  '2026-04-10 14:05:00+00'
+) ON CONFLICT (id) DO NOTHING;
+
+-- Version 3 for "Limits and Continuity" — close snapshot (latest)
+INSERT INTO public.document_versions (id, document_id, user_id, content, pages, title, trigger, created_at)
+VALUES (
+  '90000000-0000-0000-0000-000000000003',
+  '20000000-0000-0000-0000-000000000001',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Limits and Continuity"}]},{"type":"paragraph","content":[{"type":"text","text":"A limit describes the value a function approaches as the input approaches a given point."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Key Definitions"}]},{"type":"bulletList","content":[{"type":"listItem","content":[{"type":"paragraph","content":[{"type":"text","text":"Limit: lim x→a f(x) = L"}]}]}]}]}',
+  NULL,
+  'Limits and Continuity',
+  'close',
+  '2026-04-10 14:30:00+00'
+) ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
## Summary

- Add automatic document versioning that saves up to 8 snapshots per document at smart intervals (30s idle, 5min periodic, session close)
- Version history sidebar (clock icon in toolbar) shows snapshots with relative timestamps
- Restore any version with a safety "Before restore" snapshot always created first

## Changes

- New `document_versions` table with atomic Postgres RPCs for cap enforcement and restore
- `useVersionSnapshots` hook for client-side trigger logic with `sendBeacon` for session close
- `VersionSidebar` component following AI Chat Panel responsive pattern
- Clock icon button in both canvas and text editor toolbars
- 13 new unit tests, 7 integration tests, 3 E2E test scenarios

## Test plan

- [x] Unit tests pass (`pnpm test` — 787 tests)
- [x] Integration tests pass (`pnpm test:integration` — 7 new tests for DB operations)
- [ ] E2E tests for version history (open sidebar, view versions, restore)
- [ ] CI passes (lint, format, build, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)