### PR TITLE
feat: extension readiness — gating, version handshake, manifest tightening

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -4,3 +4,11 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 # PostHog Analytics (free tier)
 NEXT_PUBLIC_POSTHOG_KEY=phc_your-posthog-project-api-key
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+
+# Moodle Chrome Extension
+# Set this to the unpacked extension ID shown in chrome://extensions after loading
+# the unpacked extension from `extension/`. In production this will be the stable
+# Chrome Web Store ID. The web app uses it to talk to the extension via
+# chrome.runtime.sendMessage(EXTENSION_ID, ...).
+# Leaving this blank is fine — the Moodle UI will simply render as "not installed".
+NEXT_PUBLIC_EXTENSION_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
 
+      - name: Build extension
+        run: cd extension && npm install && npm run build
+
       - name: E2E tests
         run: pnpm test:e2e
         env:
@@ -77,6 +80,9 @@ jobs:
           # in API routes. Forward the service-role key so SSR doesn't
           # throw "Missing SUPABASE_SERVICE_ROLE_KEY" during E2E runs.
           SUPABASE_SERVICE_ROLE_KEY: ${{ steps.supabase.outputs.SUPABASE_SERVICE_ROLE_KEY }}
+          # Pinned ID matches the "key" in extension/manifest.json — lets the
+          # dashboard recognize the unpacked extension loaded by extension-real.spec.ts.
+          NEXT_PUBLIC_EXTENSION_ID: beajdnpmcbgjfkhojoangknkeimimmfm
 
       - name: Upload Playwright report
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,9 @@ The project uses a two-branch model: `dev` (integration) and `main` (production)
 
 ## Active Technologies
 
+- TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, Tailwind 4 (`pointer-fine:` variant), Chrome Manifest V3, Vitest, Playwright (2026-05-13-extension-readiness)
+- N/A — manifest tightening + client-side gating; no schema changes (2026-05-13-extension-readiness)
+
 - TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, Tailwind CSS 4, shadcn/ui (New York), Lucide icons (041-ui-redesign)
 
 - TypeScript 5 / Node.js 22+ + React 19, Next.js 16 (App Router), Canvas 2D API (image processing), Pointer Events API (interaction) (040-image-paste-select)

--- a/docs/superpowers/plans/2026-05-13-extension-readiness.md
+++ b/docs/superpowers/plans/2026-05-13-extension-readiness.md
@@ -1,0 +1,2346 @@
+# Extension Readiness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Moodle Chrome extension installable, detectable, and gated so its UI appears only on desktop Chromium browsers — without uploading to the Chrome Web Store yet.
+
+**Architecture:** Three new units split by responsibility — a `useExtensionPlatform` hook for "is this device Chromium desktop?", an `<ExtensionGate>` wrapper that short-circuits rendering on unsupported platforms, and an upgraded `useMoodleExtension` state machine with a 2 s detection timeout and version handshake. The extension manifest tightens `host_permissions` to `optional_host_permissions` so future CWS review will pass, with a runtime per-domain permission request invoked the moment the user saves a Moodle URL.
+
+**Tech Stack:** TypeScript 5, React 19, Next.js 16 (App Router), Tailwind 4 (`pointer-fine:` variant), Vitest + Testing Library, Playwright, Chrome Manifest V3.
+
+**Spec:** [`docs/superpowers/specs/2026-05-13-extension-readiness-design.md`](../specs/2026-05-13-extension-readiness-design.md)
+
+**Branch:** `feat/extension-readiness` (already created off latest `dev` at `08c1225`; spec already committed as `a8d1011`).
+
+---
+
+## Task 1: Bootstrap — env example + CLAUDE.md entry
+
+Add the missing env variable to the example file so any developer cloning the repo knows about it, and append the standard "Active Technologies" line documenting this spec.
+
+**Files:**
+
+- Modify: `.env.local.example`
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add `NEXT_PUBLIC_EXTENSION_ID` to `.env.local.example`**
+
+Open `.env.local.example` and add at the end (after the PostHog block):
+
+```
+# Moodle Chrome Extension
+# Set this to the unpacked extension ID shown in chrome://extensions after loading
+# the unpacked extension from `extension/`. In production this will be the stable
+# Chrome Web Store ID. The web app uses it to talk to the extension via
+# chrome.runtime.sendMessage(EXTENSION_ID, ...).
+# Leaving this blank is fine — the Moodle UI will simply render as "not installed".
+NEXT_PUBLIC_EXTENSION_ID=
+```
+
+- [ ] **Step 2: Append the spec to CLAUDE.md "Active Technologies"**
+
+Open `CLAUDE.md`, find the "Active Technologies" header, and insert this entry directly under it (above the existing `041-ui-redesign` line):
+
+```markdown
+- TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, Tailwind 4 (`pointer-fine:` variant), Chrome Manifest V3, Vitest, Playwright (2026-05-13-extension-readiness)
+- N/A — manifest tightening + client-side gating; no schema changes (2026-05-13-extension-readiness)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .env.local.example CLAUDE.md
+git commit -m "chore: document NEXT_PUBLIC_EXTENSION_ID + extension-readiness in CLAUDE.md"
+```
+
+---
+
+## Task 2: Tighten extension manifest + bump version
+
+Move `<all_urls>` from required to optional host permissions, bump the manifest version, and bump the package.json version. After this, every Moodle domain the user connects must be granted at runtime via `chrome.permissions.request()`.
+
+**Files:**
+
+- Modify: `extension/manifest.json`
+- Modify: `extension/package.json`
+
+- [ ] **Step 1: Rewrite `extension/manifest.json`**
+
+Replace the entire file with:
+
+```json
+{
+  "manifest_version": 3,
+  "name": "Typenote Moodle Sync",
+  "version": "0.2.0",
+  "description": "Import course materials from Moodle into Typenote",
+  "permissions": ["storage", "scripting", "cookies", "tabs", "activeTab"],
+  "optional_host_permissions": ["<all_urls>"],
+  "background": {
+    "service_worker": "dist/service-worker.js"
+  },
+  "externally_connectable": {
+    "matches": ["http://localhost:3000/*", "https://*.typenote.app/*"]
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["dist/moodle-scraper.js"],
+      "matches": ["https://*/*", "http://*/*"]
+    }
+  ]
+}
+```
+
+The only changes from the current file: `"host_permissions": ["<all_urls>"]` becomes `"optional_host_permissions": ["<all_urls>"]`, and version `0.1.0` → `0.2.0`.
+
+- [ ] **Step 2: Bump version in `extension/package.json`**
+
+Edit `extension/package.json` and change `"version": "0.1.0"` to `"version": "0.2.0"`. No other changes.
+
+- [ ] **Step 3: Verify the extension still typechecks and builds**
+
+Run:
+
+```bash
+pnpm --filter typenote-moodle-extension typecheck
+pnpm --filter typenote-moodle-extension build
+```
+
+Both should exit 0. `extension/dist/service-worker.js` and `extension/dist/moodle-scraper.js` should exist.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extension/manifest.json extension/package.json
+git commit -m "feat(extension): move <all_urls> to optional_host_permissions; bump to 0.2.0"
+```
+
+---
+
+## Task 3: `useExtensionPlatform` hook + tests
+
+Pure feature detection: is this device a Chromium desktop browser? Uses `useSyncExternalStore` so it's SSR-safe and reacts when the user plugs in or unplugs a mouse (changes `pointer:fine`).
+
+**Files:**
+
+- Create: `src/hooks/use-extension-platform.ts`
+- Create: `src/hooks/use-extension-platform.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/hooks/use-extension-platform.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const originalMatchMedia = globalThis.window?.matchMedia;
+const originalChrome = (globalThis as Record<string, unknown>).chrome;
+
+function setPointerFine(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(pointer: fine)' ? matches : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+}
+
+function setChromeRuntime(present: boolean) {
+  if (present) {
+    (globalThis as Record<string, unknown>).chrome = {
+      runtime: { sendMessage: vi.fn() },
+    };
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+}
+
+beforeEach(() => {
+  setPointerFine(true);
+  setChromeRuntime(true);
+});
+
+afterEach(() => {
+  if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+  if (originalChrome) {
+    (globalThis as Record<string, unknown>).chrome = originalChrome;
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+});
+
+const { useExtensionPlatform } = await import('./use-extension-platform');
+
+describe('useExtensionPlatform', () => {
+  it('returns true on Chromium desktop (pointer-fine + chrome.runtime)', () => {
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(true);
+  });
+
+  it('returns false on touch-primary devices (iPad/mobile)', () => {
+    setPointerFine(false);
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(false);
+  });
+
+  it('returns false on non-Chromium desktop (no chrome.runtime)', () => {
+    setChromeRuntime(false);
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(false);
+  });
+
+  it('returns false when chrome exists but sendMessage is missing', () => {
+    (globalThis as Record<string, unknown>).chrome = { runtime: {} };
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```bash
+pnpm test src/hooks/use-extension-platform.test.ts
+```
+
+Expected: all 4 tests fail with module-resolution error (`Cannot find module './use-extension-platform'`).
+
+- [ ] **Step 3: Create `src/hooks/use-extension-platform.ts`**
+
+```ts
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+interface ExtensionPlatform {
+  isSupportedPlatform: boolean;
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === 'undefined') return false;
+  const pointerFine = window.matchMedia?.('(pointer: fine)').matches ?? false;
+  const chromeRuntime = (window as unknown as { chrome?: typeof chrome }).chrome
+    ?.runtime;
+  const hasChromeRuntime = typeof chromeRuntime?.sendMessage === 'function';
+  return pointerFine && hasChromeRuntime;
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+  const mql = window.matchMedia('(pointer: fine)');
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+}
+
+/**
+ * Returns whether the current device can host the Typenote Moodle extension.
+ * True only on Chromium-family desktop browsers with a fine pointer (mouse/trackpad).
+ * SSR-safe: returns false on the server, hydrates to the real value on the client.
+ */
+export function useExtensionPlatform(): ExtensionPlatform {
+  const isSupportedPlatform = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => false,
+  );
+  return { isSupportedPlatform };
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+Run:
+
+```bash
+pnpm test src/hooks/use-extension-platform.test.ts
+```
+
+Expected: all 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/use-extension-platform.ts src/hooks/use-extension-platform.test.ts
+git commit -m "feat: add useExtensionPlatform hook for Chromium-desktop detection"
+```
+
+---
+
+## Task 4: `<MoodleCardSkeleton>` placeholder component
+
+A pulsing card placeholder that renders while the extension PING is in flight. Replaces the current "Checking for Typenote extension..." text — quieter, no layout shift.
+
+**Files:**
+
+- Create: `src/components/dashboard/moodle-card-skeleton.tsx`
+- Create: `src/components/dashboard/moodle-card-skeleton.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/dashboard/moodle-card-skeleton.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MoodleCardSkeleton } from './moodle-card-skeleton';
+
+describe('MoodleCardSkeleton', () => {
+  it('renders a non-empty placeholder element', () => {
+    const { container } = render(<MoodleCardSkeleton />);
+    expect(container.firstChild).not.toBeNull();
+    expect(container.textContent).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+Run:
+
+```bash
+pnpm test src/components/dashboard/moodle-card-skeleton.test.tsx
+```
+
+Expected: fails with module-resolution error.
+
+- [ ] **Step 3: Create `src/components/dashboard/moodle-card-skeleton.tsx`**
+
+```tsx
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+/**
+ * Placeholder card rendered while the extension PING is in flight (≤2 s).
+ * Empty text content — the visual interest comes entirely from animated pulse blocks.
+ */
+export function MoodleCardSkeleton() {
+  return (
+    <Card aria-busy="true" aria-label="Loading Moodle integration">
+      <CardHeader>
+        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+        <div className="mt-2 h-3 w-64 animate-pulse rounded bg-muted" />
+      </CardHeader>
+      <CardContent>
+        <div className="h-8 w-28 animate-pulse rounded bg-muted" />
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+```bash
+pnpm test src/components/dashboard/moodle-card-skeleton.test.tsx
+```
+
+Expected: passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/dashboard/moodle-card-skeleton.tsx src/components/dashboard/moodle-card-skeleton.test.tsx
+git commit -m "feat: add MoodleCardSkeleton placeholder for extension-detection state"
+```
+
+---
+
+## Task 5: `<ExtensionGate>` wrapper component
+
+Renders `children` only when the platform supports the extension. Returns `null` on touch and non-Chromium so no Moodle DOM exists at all in those environments.
+
+**Files:**
+
+- Create: `src/components/dashboard/extension-gate.tsx`
+- Create: `src/components/dashboard/extension-gate.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/dashboard/extension-gate.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const originalMatchMedia = globalThis.window?.matchMedia;
+const originalChrome = (globalThis as Record<string, unknown>).chrome;
+
+function setSupported(supported: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(pointer: fine)' ? supported : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+  if (supported) {
+    (globalThis as Record<string, unknown>).chrome = {
+      runtime: { sendMessage: vi.fn() },
+    };
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+}
+
+afterEach(() => {
+  if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+  if (originalChrome) {
+    (globalThis as Record<string, unknown>).chrome = originalChrome;
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+});
+
+const { ExtensionGate } = await import('./extension-gate');
+
+describe('ExtensionGate', () => {
+  it('renders children on a supported platform', () => {
+    setSupported(true);
+    render(
+      <ExtensionGate>
+        <p>moodle ui</p>
+      </ExtensionGate>,
+    );
+    expect(screen.getByText('moodle ui')).toBeInTheDocument();
+  });
+
+  it('renders nothing on an unsupported platform', () => {
+    setSupported(false);
+    const { container } = render(
+      <ExtensionGate>
+        <p>moodle ui</p>
+      </ExtensionGate>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and confirm it fails**
+
+```bash
+pnpm test src/components/dashboard/extension-gate.test.tsx
+```
+
+Expected: fails with module-resolution error.
+
+- [ ] **Step 3: Create `src/components/dashboard/extension-gate.tsx`**
+
+```tsx
+'use client';
+
+import type { ReactNode } from 'react';
+import { useExtensionPlatform } from '@/hooks/use-extension-platform';
+
+interface ExtensionGateProps {
+  children: ReactNode;
+}
+
+/**
+ * Renders `children` only on Chromium-family desktop browsers.
+ * Silent — no fallback UI on touch/non-Chromium devices.
+ *
+ * @see useExtensionPlatform for the detection logic.
+ */
+export function ExtensionGate({ children }: ExtensionGateProps) {
+  const { isSupportedPlatform } = useExtensionPlatform();
+  if (!isSupportedPlatform) return null;
+  return <>{children}</>;
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+pnpm test src/components/dashboard/extension-gate.test.tsx
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/dashboard/extension-gate.tsx src/components/dashboard/extension-gate.test.tsx
+git commit -m "feat: add ExtensionGate wrapper for Chromium-desktop-only UI"
+```
+
+---
+
+## Task 6: Refactor `useMoodleExtension` to state machine + timeout + version handshake
+
+Convert the boolean `isInstalled`/`isChecking` to a discriminated-union `state`. Add a 2 s timeout on PING. Compare the response version against `EXPECTED_EXTENSION_VERSION = '0.2.0'`. Emit a dev-only warning when `NEXT_PUBLIC_EXTENSION_ID` is missing. **Keep the legacy `isInstalled` / `isChecking` booleans as derived values** so existing consumers don't break in this commit — they'll migrate to `state` in later tasks.
+
+**Files:**
+
+- Modify: `src/hooks/use-moodle-extension.ts`
+- Modify: `src/hooks/use-moodle-extension.test.ts`
+
+- [ ] **Step 1: Add new failing tests for state machine, timeout, version handshake, and dev warning**
+
+Append the following to `src/hooks/use-moodle-extension.test.ts` (inside the existing `describe('useMoodleExtension', () => { ... })` block, before the closing brace):
+
+```ts
+it('exposes state.status="installed" with version when ping succeeds at the expected version', async () => {
+  mockSendMessage.mockImplementation(
+    (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+      callback({ success: true, data: { version: '0.2.0' } });
+    },
+  );
+
+  const { result } = renderHook(() => useMoodleExtension());
+  await waitFor(() => expect(result.current.state.status).not.toBe('checking'));
+
+  expect(result.current.state).toEqual({
+    status: 'installed',
+    version: '0.2.0',
+  });
+  expect(result.current.isInstalled).toBe(true);
+});
+
+it('exposes state.status="version-mismatch" when ping returns a different version', async () => {
+  mockSendMessage.mockImplementation(
+    (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+      callback({ success: true, data: { version: '0.1.0' } });
+    },
+  );
+
+  const { result } = renderHook(() => useMoodleExtension());
+  await waitFor(() => expect(result.current.state.status).not.toBe('checking'));
+
+  expect(result.current.state).toEqual({
+    status: 'version-mismatch',
+    installedVersion: '0.1.0',
+  });
+  expect(result.current.isInstalled).toBe(false);
+});
+
+it('falls back to "not-installed" when the PING response is malformed', async () => {
+  mockSendMessage.mockImplementation(
+    (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+      callback({ success: true, data: {} });
+    },
+  );
+
+  const { result } = renderHook(() => useMoodleExtension());
+  await waitFor(() => expect(result.current.state.status).not.toBe('checking'));
+
+  expect(result.current.state.status).toBe('not-installed');
+});
+
+it('times out to "not-installed" after 2 seconds when the extension never responds', async () => {
+  vi.useFakeTimers();
+  mockSendMessage.mockImplementation(() => {
+    // never call the callback — simulates a hung extension
+  });
+
+  const { result } = renderHook(() => useMoodleExtension());
+
+  // Advance fake timers past the 2s timeout
+  await vi.advanceTimersByTimeAsync(2_000);
+  await waitFor(() => expect(result.current.state.status).not.toBe('checking'));
+
+  expect(result.current.state.status).toBe('not-installed');
+  vi.useRealTimers();
+});
+```
+
+Also add this test outside the `describe` block (it tests an env-var-absent path that requires a fresh module import):
+
+```ts
+describe('useMoodleExtension when NEXT_PUBLIC_EXTENSION_ID is unset', () => {
+  it('treats the extension as not-installed and warns in dev', async () => {
+    vi.stubEnv('NEXT_PUBLIC_EXTENSION_ID', '');
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    vi.resetModules();
+
+    const { useMoodleExtension: freshHook } =
+      await import('./use-moodle-extension');
+    const { result } = renderHook(() => freshHook());
+
+    await waitFor(() =>
+      expect(result.current.state.status).not.toBe('checking'),
+    );
+
+    expect(result.current.state.status).toBe('not-installed');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('NEXT_PUBLIC_EXTENSION_ID'),
+    );
+
+    warnSpy.mockRestore();
+    vi.stubEnv('NEXT_PUBLIC_EXTENSION_ID', 'test-extension-id');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm the new ones fail**
+
+```bash
+pnpm test src/hooks/use-moodle-extension.test.ts
+```
+
+Expected: the 5 new tests fail (older ones still pass). Failure messages mention `state` is undefined or `version-mismatch` not produced.
+
+- [ ] **Step 3: Rewrite `src/hooks/use-moodle-extension.ts`**
+
+Replace the whole file with:
+
+```ts
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+
+const EXTENSION_ID = process.env.NEXT_PUBLIC_EXTENSION_ID ?? '';
+export const EXPECTED_EXTENSION_VERSION = '0.2.0';
+const PING_TIMEOUT_MS = 2_000;
+
+export type ExtensionState =
+  | { status: 'checking' }
+  | { status: 'installed'; version: string }
+  | { status: 'not-installed' }
+  | { status: 'version-mismatch'; installedVersion: string };
+
+async function sendExtensionMessage<T>(message: unknown): Promise<T | null> {
+  if (!EXTENSION_ID) return null;
+  return new Promise((resolve) => {
+    try {
+      chrome.runtime.sendMessage(EXTENSION_ID, message, (response: unknown) => {
+        if (chrome.runtime.lastError) {
+          resolve(null);
+          return;
+        }
+        resolve(response as T);
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+function withTimeout<T>(
+  promise: Promise<T | null>,
+  ms: number,
+): Promise<T | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    promise.then((value) => {
+      clearTimeout(timer);
+      resolve(value);
+    });
+  });
+}
+
+export function useMoodleExtension() {
+  const [state, setState] = useState<ExtensionState>({ status: 'checking' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkExtension() {
+      if (!EXTENSION_ID) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            '[Typenote] NEXT_PUBLIC_EXTENSION_ID is not set. The Moodle extension will appear as not-installed. See .env.local.example.',
+          );
+        }
+        if (!cancelled) setState({ status: 'not-installed' });
+        return;
+      }
+
+      const response = await withTimeout(
+        sendExtensionMessage<{ success: boolean; data?: { version?: string } }>(
+          { type: 'PING' },
+        ),
+        PING_TIMEOUT_MS,
+      );
+
+      if (cancelled) return;
+
+      const version = response?.data?.version;
+      if (!response?.success || !version) {
+        setState({ status: 'not-installed' });
+        return;
+      }
+      if (version !== EXPECTED_EXTENSION_VERSION) {
+        setState({ status: 'version-mismatch', installedVersion: version });
+        return;
+      }
+      setState({ status: 'installed', version });
+    }
+
+    void checkExtension();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const ping = useCallback(async () => {
+    const response = await sendExtensionMessage<{
+      success: boolean;
+      data: { version: string };
+    }>({ type: 'PING' });
+    return response?.success ? response.data : null;
+  }, []);
+
+  const checkPermission = useCallback(async (moodleUrl: string) => {
+    const response = await sendExtensionMessage<{
+      success: boolean;
+      data: { granted: boolean };
+    }>({
+      type: 'CHECK_PERMISSION',
+      payload: { moodleUrl },
+    });
+    return response?.success === true && response.data.granted === true;
+  }, []);
+
+  const requestPermission = useCallback(async (moodleUrl: string) => {
+    const response = await sendExtensionMessage<{
+      success: boolean;
+      error?: string;
+    }>({
+      type: 'REQUEST_PERMISSION',
+      payload: { moodleUrl },
+    });
+    return response?.success === true;
+  }, []);
+
+  const checkMoodleLogin = useCallback(async (moodleUrl: string) => {
+    const response = await sendExtensionMessage<{
+      success: boolean;
+      data: { loggedIn: boolean };
+    }>({
+      type: 'CHECK_LOGIN',
+      payload: { moodleUrl },
+    });
+    if (!response?.success) return null;
+    return response.data;
+  }, []);
+
+  const scrapeCourses = useCallback(async (moodleUrl: string) => {
+    const response = await sendExtensionMessage<{
+      success: boolean;
+      data: {
+        courses: Array<{ moodleCourseId: string; name: string; url: string }>;
+      };
+      error?: string;
+    }>({
+      type: 'SCRAPE_COURSES',
+      payload: { moodleUrl },
+    });
+    if (!response) return null;
+    if (!response.success) {
+      throw new Error(
+        (response as { error?: string }).error ?? 'Scraping failed',
+      );
+    }
+    return response.data;
+  }, []);
+
+  const scrapeCourseContent = useCallback(async (courseUrl: string) => {
+    const response = await sendExtensionMessage<{
+      success: boolean;
+      data: {
+        sections: Array<{
+          moodleSectionId: string;
+          title: string;
+          position: number;
+          items: Array<{
+            type: 'file' | 'link';
+            name: string;
+            moodleUrl: string;
+            externalUrl?: string;
+            fileSize?: number;
+            mimeType?: string;
+          }>;
+        }>;
+      };
+      error?: string;
+    }>({
+      type: 'SCRAPE_COURSE_CONTENT',
+      payload: { courseUrl },
+    });
+    if (!response) return null;
+    if (!response.success) {
+      throw new Error(
+        (response as { error?: string }).error ?? 'Content scraping failed',
+      );
+    }
+    return response.data;
+  }, []);
+
+  const downloadAndUpload = useCallback(
+    async (params: {
+      moodleFileUrl: string;
+      uploadEndpoint: string;
+      authToken?: string;
+      metadata: { sectionId: string; moodleUrl: string; fileName: string };
+    }) => {
+      const response = await sendExtensionMessage<{
+        success: boolean;
+        data: {
+          contentHash: string;
+          fileSize: number;
+          mimeType: string;
+          deduplicated: boolean;
+        };
+        error?: string;
+      }>({
+        type: 'DOWNLOAD_AND_UPLOAD',
+        payload: params,
+      });
+      if (!response?.success) {
+        throw new Error(
+          (response as { error?: string })?.error ?? 'Download/upload failed',
+        );
+      }
+      return response.data;
+    },
+    [],
+  );
+
+  return {
+    state,
+    isInstalled: state.status === 'installed',
+    isChecking: state.status === 'checking',
+    ping,
+    checkPermission,
+    requestPermission,
+    checkMoodleLogin,
+    scrapeCourses,
+    scrapeCourseContent,
+    downloadAndUpload,
+  };
+}
+```
+
+- [ ] **Step 4: Run the full test file and confirm all tests pass**
+
+```bash
+pnpm test src/hooks/use-moodle-extension.test.ts
+```
+
+Expected: all tests (old + 5 new) pass.
+
+- [ ] **Step 5: Run the broader unit suite to confirm no consumer broke**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass (consumers still see `isInstalled` and `isChecking` because we kept them as derived booleans).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/use-moodle-extension.ts src/hooks/use-moodle-extension.test.ts
+git commit -m "feat: extension state machine with 2s timeout + version handshake
+
+Adds discriminated-union ExtensionState exposed alongside the existing
+isInstalled/isChecking booleans (kept as derived values for backward
+compat). PING is now bounded by a 2s timeout; version is compared
+against EXPECTED_EXTENSION_VERSION ('0.2.0'). Logs a dev-only warning
+when NEXT_PUBLIC_EXTENSION_ID is unset."
+```
+
+---
+
+## Task 7: Update `<MoodleSyncPrompt>` to render install/update/skeleton states
+
+Switch the component from `isInstalled`/`isChecking` to the new `state` discriminated union. Render the skeleton during `checking`, an Install card during `not-installed`, an Update card during `version-mismatch`, and continue to the existing flow during `installed`.
+
+**Files:**
+
+- Modify: `src/components/dashboard/moodle-sync-prompt.tsx`
+- Create: `src/components/dashboard/moodle-sync-prompt.test.tsx` (if missing) — or modify if it exists
+
+- [ ] **Step 1: Check whether a test file for `MoodleSyncPrompt` exists**
+
+```bash
+ls src/components/dashboard/moodle-sync-prompt.test.tsx 2>/dev/null || echo "not present — will be created"
+```
+
+- [ ] **Step 2: Write failing tests for the new state-driven rendering**
+
+Create or replace `src/components/dashboard/moodle-sync-prompt.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ExtensionState } from '@/hooks/use-moodle-extension';
+
+vi.mock('@/hooks/use-moodle-extension', () => ({
+  useMoodleExtension: vi.fn(),
+  EXPECTED_EXTENSION_VERSION: '0.2.0',
+}));
+
+import { useMoodleExtension } from '@/hooks/use-moodle-extension';
+import { MoodleSyncPrompt } from './moodle-sync-prompt';
+
+function setState(state: ExtensionState) {
+  vi.mocked(useMoodleExtension).mockReturnValue({
+    state,
+    isInstalled: state.status === 'installed',
+    isChecking: state.status === 'checking',
+    ping: vi.fn(),
+    checkPermission: vi.fn(),
+    requestPermission: vi.fn(),
+    checkMoodleLogin: vi.fn(),
+    scrapeCourses: vi.fn(),
+    scrapeCourseContent: vi.fn(),
+    downloadAndUpload: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('MoodleSyncPrompt', () => {
+  it('renders the skeleton while extension is checking', () => {
+    setState({ status: 'checking' });
+    const { container } = render(
+      <MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />,
+    );
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+
+  it('renders the Install card when extension is not installed', () => {
+    setState({ status: 'not-installed' });
+    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
+    expect(
+      screen.getByText(/install the typenote extension/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /install extension/i }),
+    ).toBeDisabled();
+  });
+
+  it('renders the Update card with both versions when version mismatches', () => {
+    setState({ status: 'version-mismatch', installedVersion: '0.1.0' });
+    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
+    expect(
+      screen.getByText(/update the typenote extension/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/0\.1\.0/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.2\.0/)).toBeInTheDocument();
+  });
+
+  it('renders the connection-setup card when extension is installed but not connected', () => {
+    setState({ status: 'installed', version: '0.2.0' });
+    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
+    expect(screen.getByLabelText(/moodle url/i)).toBeInTheDocument();
+  });
+
+  it('renders the Sync button when extension is installed AND connected', () => {
+    setState({ status: 'installed', version: '0.2.0' });
+    render(
+      <MoodleSyncPrompt
+        moodleConnection={{ domain: 'moodle.test.ac.il', instanceId: 'abc' }}
+        onSyncClick={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('button', { name: /sync with moodle/i }),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+```bash
+pnpm test src/components/dashboard/moodle-sync-prompt.test.tsx
+```
+
+Expected: the new "update card" and skeleton tests fail (the others may also fail depending on current output).
+
+- [ ] **Step 4: Rewrite `src/components/dashboard/moodle-sync-prompt.tsx`**
+
+Replace the entire file with:
+
+```tsx
+'use client';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  useMoodleExtension,
+  EXPECTED_EXTENSION_VERSION,
+} from '@/hooks/use-moodle-extension';
+import { MoodleCardSkeleton } from './moodle-card-skeleton';
+import { MoodleConnectionSetup } from './moodle-connection-setup';
+
+interface MoodleSyncPromptProps {
+  moodleConnection: { domain: string; instanceId: string } | null;
+  onSyncClick: () => void;
+}
+
+export function MoodleSyncPrompt({
+  moodleConnection,
+  onSyncClick,
+}: MoodleSyncPromptProps) {
+  const { state } = useMoodleExtension();
+
+  if (state.status === 'checking') {
+    return <MoodleCardSkeleton />;
+  }
+
+  if (state.status === 'not-installed') {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Moodle Integration</CardTitle>
+          <CardDescription>
+            Install the Typenote extension to sync your Moodle courses and
+            materials automatically.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" size="sm" disabled>
+            Install Extension
+          </Button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Coming soon to the Chrome Web Store. Refresh this page after
+            installing.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (state.status === 'version-mismatch') {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Moodle Integration</CardTitle>
+          <CardDescription>
+            Update the Typenote extension to continue syncing. Installed
+            version: <strong>{state.installedVersion}</strong>. Required:{' '}
+            <strong>{EXPECTED_EXTENSION_VERSION}</strong>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" size="sm" disabled>
+            Update Extension
+          </Button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Refresh this page after updating.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // state.status === 'installed'
+  if (!moodleConnection) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Moodle Integration</CardTitle>
+          <CardDescription>
+            Enter your Moodle URL to start syncing courses.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <MoodleConnectionSetup />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Moodle Integration</CardTitle>
+        <CardDescription>
+          Connected to <strong>{moodleConnection.domain}</strong>. Sync your
+          courses and materials.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button size="sm" onClick={onSyncClick}>
+          Sync with Moodle
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Run the tests and confirm they pass**
+
+```bash
+pnpm test src/components/dashboard/moodle-sync-prompt.test.tsx
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/dashboard/moodle-sync-prompt.tsx src/components/dashboard/moodle-sync-prompt.test.tsx
+git commit -m "feat: render install/update/skeleton states in MoodleSyncPrompt"
+```
+
+---
+
+## Task 8: Wrap Moodle entry points with `<ExtensionGate>`
+
+The dashboard currently renders `<MoodleSyncPromptWrapper>` unconditionally. Wrap it in `<ExtensionGate>` so iPad/mobile/Firefox/Safari users see no Moodle UI at all.
+
+**Files:**
+
+- Modify: `src/components/dashboard/moodle-sync-prompt-wrapper.tsx`
+
+- [ ] **Step 1: Read the current wrapper to understand its shape**
+
+```bash
+cat src/components/dashboard/moodle-sync-prompt-wrapper.tsx
+```
+
+- [ ] **Step 2: Wrap the returned JSX in `<ExtensionGate>`**
+
+Edit `src/components/dashboard/moodle-sync-prompt-wrapper.tsx`. Find the `import` block and add:
+
+```tsx
+import { ExtensionGate } from './extension-gate';
+```
+
+Then wrap the existing return expression. The component currently returns something like:
+
+```tsx
+return (
+  <>
+    <MoodleSyncPrompt … />
+    {open && <MoodleSyncDialog … />}
+  </>
+);
+```
+
+Replace the outer wrapper so it becomes:
+
+```tsx
+return (
+  <ExtensionGate>
+    <MoodleSyncPrompt … />
+    {open && <MoodleSyncDialog … />}
+  </ExtensionGate>
+);
+```
+
+(Preserve all existing props and conditional logic exactly — only the wrapping element changes.)
+
+- [ ] **Step 3: Verify by running the full unit suite**
+
+```bash
+pnpm test
+```
+
+Expected: all existing tests pass. (No new tests in this task — gating coverage comes via Playwright in Task 14.)
+
+- [ ] **Step 4: Manually smoke-test in dev**
+
+```bash
+pnpm dev
+```
+
+Open `http://localhost:3000/dashboard` in Chrome. The Moodle card should still appear (you're on Chromium desktop). Open Chrome DevTools → Device Toolbar → select iPad Pro 11 → reload. The Moodle card should disappear.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/dashboard/moodle-sync-prompt-wrapper.tsx
+git commit -m "feat: gate Moodle UI behind ExtensionGate (hide on touch/non-Chromium)"
+```
+
+---
+
+## Task 9: `<MoodleConnectionSetup>` — request permission on save + show banner if missing
+
+When the user enters a Moodle URL and clicks Connect, immediately call `requestPermission(origin)` so Chrome shows its native permission prompt. If granted, save. If denied, surface a toast. Additionally, on mount: if a connection already exists, run `checkPermission` and show a "Grant access to {domain}" banner if it returns false.
+
+**Files:**
+
+- Modify: `src/components/dashboard/moodle-connection-setup.tsx`
+- Modify: `src/components/dashboard/moodle-connection-setup.test.tsx`
+
+- [ ] **Step 1: Replace `src/components/dashboard/moodle-connection-setup.test.tsx` with the new test suite**
+
+The existing test file has 4 tests against the old `isInstalled`/`isChecking` API; we replace it wholesale so the file matches the new state-machine API and adds permission-flow coverage. Overwrite the file with:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/hooks/use-moodle-extension', () => ({
+  useMoodleExtension: vi.fn(),
+  EXPECTED_EXTENSION_VERSION: '0.2.0',
+}));
+
+vi.mock('@/lib/actions/moodle-sync', () => ({
+  saveMoodleConnection: vi.fn(),
+  removeMoodleConnection: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import {
+  useMoodleExtension,
+  type ExtensionState,
+} from '@/hooks/use-moodle-extension';
+import { MoodleConnectionSetup } from './moodle-connection-setup';
+import { saveMoodleConnection } from '@/lib/actions/moodle-sync';
+
+const mockUseMoodleExtension = useMoodleExtension as ReturnType<typeof vi.fn>;
+
+function mockExtension(
+  state: ExtensionState,
+  overrides: {
+    requestPermission?: ReturnType<typeof vi.fn>;
+    checkPermission?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  mockUseMoodleExtension.mockReturnValue({
+    state,
+    isInstalled: state.status === 'installed',
+    isChecking: state.status === 'checking',
+    requestPermission:
+      overrides.requestPermission ?? vi.fn().mockResolvedValue(true),
+    checkPermission:
+      overrides.checkPermission ?? vi.fn().mockResolvedValue(true),
+    ping: vi.fn(),
+    checkMoodleLogin: vi.fn(),
+    scrapeCourses: vi.fn(),
+    scrapeCourseContent: vi.fn(),
+    downloadAndUpload: vi.fn(),
+  });
+}
+
+describe('MoodleConnectionSetup', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders nothing while the extension is still being checked', () => {
+    mockExtension({ status: 'checking' });
+    const { container } = render(<MoodleConnectionSetup />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the extension is not installed', () => {
+    mockExtension({ status: 'not-installed' });
+    const { container } = render(<MoodleConnectionSetup />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows URL input when extension is installed and no connection saved', () => {
+    mockExtension({ status: 'installed', version: '0.2.0' });
+    render(<MoodleConnectionSetup />);
+    expect(screen.getByLabelText(/moodle url/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /connect/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows current connection when one is provided', () => {
+    mockExtension({ status: 'installed', version: '0.2.0' });
+    render(
+      <MoodleConnectionSetup
+        currentConnection={{ domain: 'moodle.test.ac.il', instanceId: '123' }}
+      />,
+    );
+    expect(screen.getByText(/moodle\.test\.ac\.il/i)).toBeInTheDocument();
+    expect(screen.getByText(/disconnect/i)).toBeInTheDocument();
+  });
+
+  it('calls requestPermission with the Moodle origin on Connect', async () => {
+    const requestPermission = vi.fn().mockResolvedValue(true);
+    mockExtension(
+      { status: 'installed', version: '0.2.0' },
+      { requestPermission },
+    );
+    vi.mocked(saveMoodleConnection).mockResolvedValue(undefined);
+
+    render(<MoodleConnectionSetup />);
+    await userEvent.type(
+      screen.getByLabelText(/moodle url/i),
+      'https://moodle.test.ac.il',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(requestPermission).toHaveBeenCalledWith(
+        'https://moodle.test.ac.il',
+      );
+    });
+    expect(saveMoodleConnection).toHaveBeenCalledWith('moodle.test.ac.il');
+  });
+
+  it('shows permission-required error when the user denies the Chrome prompt', async () => {
+    const requestPermission = vi.fn().mockResolvedValue(false);
+    mockExtension(
+      { status: 'installed', version: '0.2.0' },
+      { requestPermission },
+    );
+
+    render(<MoodleConnectionSetup />);
+    await userEvent.type(
+      screen.getByLabelText(/moodle url/i),
+      'https://moodle.test.ac.il',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => expect(requestPermission).toHaveBeenCalled());
+    expect(saveMoodleConnection).not.toHaveBeenCalled();
+    expect(screen.getByText(/permission required/i)).toBeInTheDocument();
+  });
+
+  it('renders the Grant Access banner when an existing connection lacks permission', async () => {
+    const checkPermission = vi.fn().mockResolvedValue(false);
+    mockExtension(
+      { status: 'installed', version: '0.2.0' },
+      { checkPermission },
+    );
+
+    render(
+      <MoodleConnectionSetup
+        currentConnection={{ domain: 'moodle.test.ac.il', instanceId: '123' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(checkPermission).toHaveBeenCalledWith('https://moodle.test.ac.il');
+    });
+    expect(
+      screen.getByRole('button', {
+        name: /grant access to moodle\.test\.ac\.il/i,
+      }),
+    ).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail**
+
+```bash
+pnpm test src/components/dashboard/moodle-connection-setup.test.tsx
+```
+
+Expected: most tests fail — the file references the new `state` API and behaviors that don't exist yet in the component.
+
+- [ ] **Step 3: Rewrite `src/components/dashboard/moodle-connection-setup.tsx`**
+
+Replace the entire file with:
+
+```tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useMoodleExtension } from '@/hooks/use-moodle-extension';
+import {
+  saveMoodleConnection,
+  removeMoodleConnection,
+} from '@/lib/actions/moodle-sync';
+import { toast } from 'sonner';
+
+interface MoodleConnectionSetupProps {
+  currentConnection?: {
+    domain: string;
+    instanceId: string;
+  } | null;
+}
+
+export function MoodleConnectionSetup({
+  currentConnection,
+}: MoodleConnectionSetupProps) {
+  const { state, checkPermission, requestPermission } = useMoodleExtension();
+  const [url, setUrl] = useState(
+    currentConnection?.domain ? `https://${currentConnection.domain}` : '',
+  );
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [permissionMissing, setPermissionMissing] = useState(false);
+
+  // On mount with an existing connection, verify the extension still has host permission.
+  useEffect(() => {
+    if (!currentConnection || state.status !== 'installed') return;
+    let cancelled = false;
+    checkPermission(`https://${currentConnection.domain}`).then((granted) => {
+      if (!cancelled) setPermissionMissing(!granted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentConnection, state.status, checkPermission]);
+
+  if (state.status === 'checking') {
+    return null;
+  }
+
+  // Parent (MoodleSyncPrompt) only renders us when state === 'installed', but be safe.
+  if (state.status !== 'installed') {
+    return null;
+  }
+
+  async function handleSave() {
+    setError(null);
+    setSaving(true);
+    try {
+      let domain: string;
+      try {
+        const parsed = new URL(url.startsWith('http') ? url : `https://${url}`);
+        const basePath = parsed.pathname
+          .replace(
+            /\/(my|course|login|mod|lib|theme|admin|message|calendar|user|badges|grade|report|backup|blocks|question|tag|cohort|enrol|webservice|auth|completion|files|search)\b.*/,
+            '',
+          )
+          .replace(/\/+$/, '');
+        domain = parsed.host + basePath;
+      } catch {
+        setError('Please enter a valid URL');
+        setSaving(false);
+        return;
+      }
+
+      if (!domain || domain.length < 3) {
+        setError('Please enter a valid Moodle URL');
+        setSaving(false);
+        return;
+      }
+
+      const granted = await requestPermission(`https://${domain}`);
+      if (!granted) {
+        setError(
+          'Permission required. Allow access to this Moodle domain in the popup, or click Connect again.',
+        );
+        setSaving(false);
+        return;
+      }
+
+      await saveMoodleConnection(domain);
+      setPermissionMissing(false);
+      toast.success('Moodle connection saved');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to save connection',
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleGrantExisting() {
+    if (!currentConnection) return;
+    const granted = await requestPermission(
+      `https://${currentConnection.domain}`,
+    );
+    if (granted) {
+      setPermissionMissing(false);
+      toast.success(`Access granted to ${currentConnection.domain}`);
+    } else {
+      toast.error('Permission required. Try again from chrome://extensions.');
+    }
+  }
+
+  async function handleRemove() {
+    try {
+      await removeMoodleConnection();
+      setUrl('');
+      setPermissionMissing(false);
+      toast.success('Moodle connection removed');
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to remove connection',
+      );
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="moodle-url">Moodle URL</Label>
+        <div className="flex gap-2">
+          <Input
+            id="moodle-url"
+            placeholder="moodle.university.ac.il/2026"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            disabled={saving}
+          />
+          <Button onClick={handleSave} disabled={saving || !url.trim()}>
+            {saving ? 'Saving...' : currentConnection ? 'Update' : 'Connect'}
+          </Button>
+        </div>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </div>
+
+      {currentConnection && (
+        <div className="flex items-center justify-between rounded-md border px-3 py-2">
+          <span className="text-sm">
+            Connected to <strong>{currentConnection.domain}</strong>
+          </span>
+          <Button variant="ghost" size="sm" onClick={handleRemove}>
+            Disconnect
+          </Button>
+        </div>
+      )}
+
+      {currentConnection && permissionMissing && (
+        <div className="flex items-center justify-between rounded-md border border-amber-400/40 bg-amber-50 dark:bg-amber-950/30 px-3 py-2">
+          <p className="text-sm">
+            The extension needs access to{' '}
+            <strong>{currentConnection.domain}</strong> to sync.
+          </p>
+          <Button size="sm" onClick={handleGrantExisting}>
+            Grant access to {currentConnection.domain}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the tests and confirm they pass**
+
+```bash
+pnpm test src/components/dashboard/moodle-connection-setup.test.tsx
+```
+
+Expected: all tests (existing + 3 new) pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/dashboard/moodle-connection-setup.tsx src/components/dashboard/moodle-connection-setup.test.tsx
+git commit -m "feat: request per-domain Moodle permission on save; show banner if missing"
+```
+
+---
+
+## Task 10: `<MoodleSyncDialog>` — wrap debug payload + show network-error message
+
+Two cosmetic-but-meaningful changes: hide the raw "Page: '…' (N cards)" debug payload behind `<details>` so users don't see noise, and recognize network failures so the error reads "Couldn't reach {domain}..." instead of a raw "fetch failed" string.
+
+**Files:**
+
+- Modify: `src/components/dashboard/moodle-sync-dialog.tsx`
+
+- [ ] **Step 1: Add the `isNetworkError` helper alongside `isAuthError`**
+
+In `src/components/dashboard/moodle-sync-dialog.tsx` find this block (around line 67):
+
+```ts
+const AUTH_ERROR_PATTERNS = [
+  '403',
+  'forbidden',
+  'unauthorized',
+  'login required',
+  'session expired',
+];
+
+function isAuthError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return AUTH_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+```
+
+Add immediately after it:
+
+```ts
+const NETWORK_ERROR_PATTERNS = ['network', 'fetch', 'timeout', 'offline'];
+
+function isNetworkError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return NETWORK_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+```
+
+- [ ] **Step 2: Track network errors in component state**
+
+In the component body (with the other `useState` calls around line 99-106), add:
+
+```ts
+const [networkError, setNetworkError] = useState(false);
+```
+
+- [ ] **Step 3: Set it in the existing error catch blocks**
+
+Find the catch block at the end of `loadCourses` (around line 320-326) and update it from:
+
+```ts
+} catch (err) {
+  const message =
+    err instanceof Error ? err.message : 'Failed to load courses';
+  setError(message);
+  setAuthError(isAuthError(message));
+  setPhase('error');
+}
+```
+
+to:
+
+```ts
+} catch (err) {
+  const message =
+    err instanceof Error ? err.message : 'Failed to load courses';
+  setError(message);
+  setAuthError(isAuthError(message));
+  setNetworkError(isNetworkError(message) && !isAuthError(message));
+  setPhase('error');
+}
+```
+
+Apply the same `setNetworkError(...)` line to the catch block in `handlePreviewContent` (around line 429) and the one in `handleSync` (around line 560).
+
+- [ ] **Step 4: Wrap the raw debug payload in `<details>`**
+
+Find this block around line 290:
+
+```ts
+if (scrapeResult.courses.length === 0) {
+  const debug = (scrapeResult as Record<string, unknown>)._debug as
+    | { title: string; url: string; cardCount: number }
+    | undefined;
+  setError(
+    `No courses found. ` +
+      (debug
+        ? `Page: "${debug.title}" at ${debug.url} (${debug.cardCount} cards)`
+        : 'No debug info available.'),
+  );
+  setPhase('error');
+  return;
+}
+```
+
+Replace the `setError` call with:
+
+```ts
+setError('No courses found on Moodle.');
+const debug = (scrapeResult as Record<string, unknown>)._debug as
+  | { title: string; url: string; cardCount: number }
+  | undefined;
+if (debug) {
+  setDebugInfo(
+    `Page: "${debug.title}" at ${debug.url} (${debug.cardCount} cards)`,
+  );
+}
+```
+
+And introduce state for `debugInfo`:
+
+```ts
+const [debugInfo, setDebugInfo] = useState<string | null>(null);
+```
+
+(Add this `useState` alongside the others.)
+
+- [ ] **Step 5: Update the error-rendering block to use the new state**
+
+Find the error-rendering JSX near the end (around line 869-892):
+
+```tsx
+{error && phase !== 'select-content' && (
+  <div className="space-y-2">
+    <p
+      className="text-sm text-destructive whitespace-pre-wrap"
+      role="alert"
+    >
+      {error}
+    </p>
+    {authError && (
+      <p className="text-xs text-muted-foreground">
+        Your Moodle session may have expired.{' '}
+        <a … >Re-log into Moodle</a> and try again.
+      </p>
+    )}
+  </div>
+)}
+```
+
+Replace it with:
+
+```tsx
+{
+  error && phase !== 'select-content' && (
+    <div className="space-y-2">
+      <p className="text-sm text-destructive whitespace-pre-wrap" role="alert">
+        {networkError && !authError
+          ? `Couldn't reach ${moodleConnection.domain}. Check your internet and try again.`
+          : error}
+      </p>
+      {authError && (
+        <p className="text-xs text-muted-foreground">
+          Your Moodle session may have expired.{' '}
+          <a
+            href={`https://${moodleConnection.domain}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            Re-log into Moodle
+          </a>{' '}
+          and try again.
+        </p>
+      )}
+      {debugInfo && (
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer">Debug info</summary>
+          <pre className="mt-1 whitespace-pre-wrap">{debugInfo}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Reset `networkError` and `debugInfo` in `loadCourses` (so retries clear them)**
+
+In `loadCourses` at the top, where it currently sets `setError(null); setAuthError(false);`, add two lines:
+
+```ts
+setNetworkError(false);
+setDebugInfo(null);
+```
+
+- [ ] **Step 7: Run the full unit suite**
+
+```bash
+pnpm test
+```
+
+Expected: all tests pass (no test changes — these are mostly cosmetic improvements; existing test coverage in `moodle-sync-dialog.test.tsx` if any continues to apply).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/dashboard/moodle-sync-dialog.tsx
+git commit -m "feat: friendlier network-error message + debug payload behind <details>"
+```
+
+---
+
+## Task 11: `<MoodleSyncDialog>` — "Retry failed" button after partial sync
+
+Track failed download jobs in state and let the user re-run just those without restarting the whole sync.
+
+**Files:**
+
+- Modify: `src/components/dashboard/moodle-sync-dialog.tsx`
+
+- [ ] **Step 1: Add failed-jobs state**
+
+Near the other `useState` declarations around line 130, add:
+
+```ts
+const [failedJobs, setFailedJobs] = useState<
+  Array<{ moodleUrl: string; fileName: string; sectionId: string }>
+>([]);
+```
+
+- [ ] **Step 2: Track failed jobs in `handleSync`**
+
+Inside the `for (const job of fileJobs)` loop in `handleSync` (around line 525), change the `catch` block from:
+
+```ts
+} catch (dlErr) {
+  failed++;
+  if (errors.length < 3) {
+    errors.push(
+      `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
+    );
+  }
+}
+```
+
+to:
+
+```ts
+} catch (dlErr) {
+  failed++;
+  if (errors.length < 3) {
+    errors.push(
+      `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
+    );
+  }
+  setFailedJobs((prev) => [...prev, job]);
+}
+```
+
+Also clear `failedJobs` at the start of `handleSync` (right after `setError(null)`):
+
+```ts
+setFailedJobs([]);
+```
+
+- [ ] **Step 3: Extract the per-job download loop into a helper inside the component**
+
+Above `handleSync`, add:
+
+```ts
+async function runDownloadJobs(
+  jobs: Array<{ moodleUrl: string; fileName: string; sectionId: string }>,
+  authToken: string | undefined,
+  uploadEndpoint: string,
+): Promise<{
+  downloaded: number;
+  failed: number;
+  failedJobs: typeof jobs;
+  errors: string[];
+}> {
+  let downloaded = 0;
+  let failed = 0;
+  const errors: string[] = [];
+  const newFailed: typeof jobs = [];
+
+  for (const job of jobs) {
+    try {
+      await downloadAndUpload({
+        moodleFileUrl: job.moodleUrl,
+        uploadEndpoint,
+        authToken,
+        metadata: {
+          sectionId: job.sectionId,
+          moodleUrl: job.moodleUrl,
+          fileName: job.fileName,
+        },
+      });
+      downloaded++;
+    } catch (dlErr) {
+      failed++;
+      if (errors.length < 3) {
+        errors.push(
+          `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
+        );
+      }
+      newFailed.push(job);
+    }
+    setProgress(`Downloading files... (${downloaded + failed}/${jobs.length})`);
+  }
+  return { downloaded, failed, failedJobs: newFailed, errors };
+}
+```
+
+Then replace the inline download loop in `handleSync` with a call to this helper, and update `setFailedJobs(result.failedJobs)` from the return value.
+
+- [ ] **Step 4: Add a `handleRetryFailed` function**
+
+Below `handleSync`:
+
+```ts
+async function handleRetryFailed() {
+  if (failedJobs.length === 0) return;
+  setPhase('syncing');
+  setError(null);
+  setProgress(`Retrying ${failedJobs.length} failed file(s)...`);
+
+  const {
+    data: { session },
+  } = await supabaseRef.current.auth.getSession();
+  const authToken = session?.access_token;
+  const uploadEndpoint = `${window.location.origin}/api/moodle/upload`;
+
+  const result = await runDownloadJobs(failedJobs, authToken, uploadEndpoint);
+  setDownloadedCount((prev) => prev + result.downloaded);
+  setFailedCount(result.failed);
+  setFailedJobs(result.failedJobs);
+  if (result.errors.length > 0) {
+    setError(
+      `${result.failed} file(s) still failed:\n${result.errors.join('\n')}`,
+    );
+  } else {
+    setError(null);
+  }
+  setPhase('done');
+}
+```
+
+- [ ] **Step 5: Add the "Retry failed" button to the `done` footer**
+
+Find the `done` phase footer (around line 917):
+
+```tsx
+{
+  phase === 'done' && (
+    <Button onClick={() => onOpenChange(false)}>Close</Button>
+  );
+}
+```
+
+Replace with:
+
+```tsx
+{
+  phase === 'done' && (
+    <div className="flex gap-2">
+      {failedJobs.length > 0 && (
+        <Button variant="outline" onClick={handleRetryFailed}>
+          Retry failed ({failedJobs.length})
+        </Button>
+      )}
+      <Button onClick={() => onOpenChange(false)}>Close</Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run the full unit suite**
+
+```bash
+pnpm test
+```
+
+Expected: passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/dashboard/moodle-sync-dialog.tsx
+git commit -m "feat: 'Retry failed' button re-runs only the failed download jobs"
+```
+
+---
+
+## Task 12: `<MoodleSyncDialog>` — Grant Permission fallback when revoked mid-flow
+
+If a user revokes per-domain permission via `chrome://extensions` while the dialog is open, the next scrape call throws a permission error. Catch it and offer an inline "Grant Permission" button that calls `requestPermission` and retries.
+
+**Files:**
+
+- Modify: `src/components/dashboard/moodle-sync-dialog.tsx`
+
+- [ ] **Step 1: Add a `isPermissionError` helper alongside the others**
+
+Just below `isNetworkError` (from Task 10):
+
+```ts
+const PERMISSION_ERROR_PATTERNS = [
+  'permission',
+  'host not allowed',
+  'no access',
+];
+
+function isPermissionError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return PERMISSION_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+```
+
+- [ ] **Step 2: Track permission errors in state and pull in `requestPermission`**
+
+In the component body, add:
+
+```ts
+const [permissionError, setPermissionError] = useState(false);
+```
+
+And update the destructure of `useMoodleExtension` at the top of the component (around line 95) from:
+
+```ts
+const { scrapeCourses, scrapeCourseContent, downloadAndUpload } =
+  useMoodleExtension();
+```
+
+to:
+
+```ts
+const {
+  scrapeCourses,
+  scrapeCourseContent,
+  downloadAndUpload,
+  requestPermission,
+} = useMoodleExtension();
+```
+
+- [ ] **Step 3: Set `permissionError` in the catch blocks**
+
+In each of the three catch blocks (`loadCourses`, `handlePreviewContent`, `handleSync`), add a line:
+
+```ts
+setPermissionError(isPermissionError(message) && !isAuthError(message));
+```
+
+(directly below the existing `setNetworkError` line from Task 10).
+
+Also reset it at the top of `loadCourses`:
+
+```ts
+setPermissionError(false);
+```
+
+- [ ] **Step 4: Add a "Grant Permission" handler**
+
+Below the existing handlers:
+
+```ts
+async function handleGrantPermission() {
+  const granted = await requestPermission(`https://${moodleConnection.domain}`);
+  if (granted) {
+    setPermissionError(false);
+    loadCourses();
+  } else {
+    setError(
+      `Permission still denied for ${moodleConnection.domain}. Try granting via chrome://extensions.`,
+    );
+  }
+}
+```
+
+- [ ] **Step 5: Render the Grant Permission button when the error fires**
+
+Inside the error-rendering JSX (the block you modified in Task 10), below the `authError` section and before the `debugInfo` block, add:
+
+```tsx
+{
+  permissionError && (
+    <div className="flex items-center gap-2">
+      <p className="text-xs text-muted-foreground flex-1">
+        The extension lost access to {moodleConnection.domain}. Grant permission
+        again to continue.
+      </p>
+      <Button size="sm" onClick={handleGrantPermission}>
+        Grant Permission
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run the full unit suite**
+
+```bash
+pnpm test
+```
+
+Expected: passes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/dashboard/moodle-sync-dialog.tsx
+git commit -m "feat: 'Grant Permission' fallback when host permission is revoked mid-flow"
+```
+
+---
+
+## Task 13: Playwright spec — Moodle UI hidden on touch viewport
+
+One spec, two assertions: card hidden on iPad viewport, visible on desktop viewport. Doesn't load the real extension — it tests the gating layer, not the sync flow.
+
+**Files:**
+
+- Create: `e2e/moodle-touch-gating.spec.ts`
+- Modify: `e2e/TEST_REGISTRY.md`
+
+- [ ] **Step 1: Create `e2e/moodle-touch-gating.spec.ts`**
+
+```ts
+import { test, expect, devices } from '@playwright/test';
+import { login } from './helpers/auth';
+
+const MOODLE_CARD_TEXT = /moodle integration/i;
+
+test.describe('Moodle UI — touch / non-Chromium gating', () => {
+  test('Moodle card is hidden on iPad viewport (pointer: coarse)', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      ...devices['iPad Pro 11'],
+    });
+    const page = await context.newPage();
+    await login(page);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(MOODLE_CARD_TEXT)).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test('Moodle card is visible on desktop viewport (pointer: fine)', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    await login(page);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Either the install card, update card, or connected card — any state is fine.
+    await expect(page.getByText(MOODLE_CARD_TEXT)).toBeVisible();
+
+    await context.close();
+  });
+});
+```
+
+- [ ] **Step 2: Add an entry to `e2e/TEST_REGISTRY.md`**
+
+Open `e2e/TEST_REGISTRY.md` and add a new section (following the existing pattern for sections like "Auth" and "Documents"):
+
+```markdown
+## Moodle Extension Gating (`e2e/moodle-touch-gating.spec.ts`) — IMPLEMENTED
+
+- [x] Moodle card is hidden on iPad viewport (pointer: coarse)
+- [x] Moodle card is visible on desktop viewport (pointer: fine)
+
+---
+```
+
+Place it alphabetically (or following the existing section order).
+
+- [ ] **Step 3: Run the new spec**
+
+```bash
+pnpm test:e2e e2e/moodle-touch-gating.spec.ts
+```
+
+Expected: both tests pass. (If the desktop test fails because `NEXT_PUBLIC_EXTENSION_ID` is unset and the install card text doesn't include "Moodle Integration" — check that the test selector matches the heading you produced in Task 7.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/moodle-touch-gating.spec.ts e2e/TEST_REGISTRY.md
+git commit -m "test: e2e gating — Moodle UI hidden on touch, visible on desktop"
+```
+
+---
+
+## Task 14: Write `extension/QUICKSTART.md`
+
+A single document covering: local setup, a 10-step smoke flow, and a 3-flow pre-release manual checklist for real-credentials testing. This is what makes the extension reproducibly verifiable.
+
+**Files:**
+
+- Create: `extension/QUICKSTART.md`
+
+- [ ] **Step 1: Create the file**
+
+````markdown
+# Typenote Moodle Extension — Quickstart
+
+This guide walks you through building, loading, and verifying the extension end-to-end on your machine. The full automated suite covers gating logic and unit-level behavior; the steps below cover the real-Chrome-extension flow that can't be automated cheaply.
+
+## Prerequisites
+
+- pnpm, Node 22+
+- Google Chrome (or another Chromium-family browser — Edge, Brave, Arc all work)
+- A real Moodle account at a university you can log into
+
+## Build & load (one-time)
+
+1. **Build the extension bundle.**
+   ```bash
+   pnpm --filter typenote-moodle-extension build
+   ```
+````
+
+Produces `extension/dist/service-worker.js` and `extension/dist/moodle-scraper.js`.
+
+2. **Open `chrome://extensions`** in Chrome.
+
+3. **Enable "Developer mode"** (toggle, top right).
+
+4. **Click "Load unpacked"** and select the `extension/` folder from this repo. The extension card should appear with name "Typenote Moodle Sync" and version `0.2.0`.
+
+5. **Copy the extension ID** shown on the card (a 32-character lowercase string).
+
+6. **Add it to `.env.local`:**
+
+   ```
+   NEXT_PUBLIC_EXTENSION_ID=<paste-the-id-here>
+   ```
+
+7. **Restart `pnpm dev`** (the env var is read at startup, not per-request).
+
+## 10-step smoke checklist
+
+After the one-time setup, run through this list. Each step lists the _expected_ outcome — flag any deviation.
+
+1. `pnpm dev` → open `http://localhost:3000/dashboard` → log in.
+   **Expect:** A "Moodle Integration" card on the dashboard with a URL input.
+
+2. Open DevTools → Device Toolbar → select **iPad Pro 11** → reload.
+   **Expect:** The Moodle card disappears entirely (touch gating).
+
+3. Switch back to a desktop viewport → reload.
+   **Expect:** The Moodle card reappears.
+
+4. Enter your real Moodle URL (e.g. `moodle.runi.ac.il/2026`) → click **Connect**.
+   **Expect:** Chrome shows a native permission popup asking access to `https://moodle.runi.ac.il/*`. Click **Allow**.
+
+5. The card should now say "Connected to moodle.runi.ac.il" with a **Sync with Moodle** button.
+
+6. Open `moodle.runi.ac.il` in another tab → log in to your Moodle account.
+
+7. Return to the Typenote tab → click **Sync with Moodle**.
+   **Expect:** A dialog opens, scrapes courses, and shows a course list with status badges ("New", "Synced", etc.).
+
+8. Select **one course** → click **Preview Content**.
+   **Expect:** Section/file list appears, with files already in the registry shown as "synced".
+
+9. Select **one small file** in a section → click **Sync Selected**.
+   **Expect:** Progress text "Downloading files... (1/1)" → "Successfully synced 1 course" with `1 file downloaded`.
+
+10. Check Supabase Storage (Studio at `http://localhost:54323`) → bucket `moodle-materials` → the new file should be present.
+
+If all 10 pass, the happy path is healthy.
+
+## Pre-release manual checklist (real-credentials only)
+
+These exercise the failure paths. Run them before bumping to a new release.
+
+### A. Auth expiry mid-sync
+
+1. Start a sync (open the dialog, get to the course-selection phase).
+2. In your other Moodle tab, log out.
+3. Continue the sync. **Expect:** the dialog surfaces "Your Moodle session may have expired" with a "Re-log into Moodle" link.
+
+### B. Permission revocation mid-flow
+
+1. Start a sync.
+2. Open `chrome://extensions` → Typenote Moodle Sync → "Details" → toggle "Site access" off for your Moodle domain.
+3. Retry the sync. **Expect:** the dialog shows the inline "Grant Permission" button. Click it → native popup → Allow → sync resumes.
+
+### C. Large-course download with intentional flake
+
+1. Sync a course with 20+ files.
+2. Mid-download, kill your network briefly (e.g. macOS Network → toggle Wi-Fi off for 5 s, then on).
+3. **Expect:** some files fail. After the run completes, the "done with errors" screen shows a **Retry failed (N)** button. Click it. **Expect:** failures retry; on success the screen flips to clean success.
+
+---
+
+## Troubleshooting
+
+- **"Install Extension" card stays visible even after loading the unpacked extension.**
+  `NEXT_PUBLIC_EXTENSION_ID` isn't matching the unpacked ID. Recopy from `chrome://extensions` and restart `pnpm dev`.
+
+- **Permission popup never appears.**
+  The manifest probably wasn't rebuilt after a change. Run `pnpm --filter typenote-moodle-extension build` and reload the extension at `chrome://extensions`.
+
+- **"Update Extension" card.**
+  The loaded extension's manifest `version` doesn't match `EXPECTED_EXTENSION_VERSION` in `src/hooks/use-moodle-extension.ts`. Rebuild the extension or update the constant in lockstep.
+
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add extension/QUICKSTART.md
+git commit -m "docs(extension): quickstart with smoke checklist and pre-release manual flows"
+````
+
+---
+
+## Task 15: Final verification sweep
+
+Run all three test layers per CLAUDE.md, build the production bundle, and walk through the smoke checklist one time end-to-end.
+
+- [ ] **Step 1: Run the unit suite**
+
+```bash
+pnpm test
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Run the integration suite**
+
+```bash
+pnpm test:integration
+```
+
+Expected: all green.
+
+- [ ] **Step 3: Run the E2E suite (Playwright)**
+
+```bash
+pnpm test:e2e
+```
+
+Expected: all green, including the new `moodle-touch-gating.spec.ts`.
+
+- [ ] **Step 4: Run the production build to catch any TypeScript/lint regression**
+
+```bash
+pnpm build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Manually walk steps 1–10 of `extension/QUICKSTART.md` once**
+
+Confirm each step's expected outcome matches reality.
+
+- [ ] **Step 6: Push the branch and open a PR against `dev`**
+
+```bash
+git push -u origin feat/extension-readiness
+gh pr create --base dev --title "feat: extension readiness — gating, version handshake, manifest tightening" --body "$(cat <<'EOF'
+## Summary
+
+- Gates the Moodle UI behind `<ExtensionGate>` so it only renders on Chromium-family desktop browsers (silent hide on touch/non-Chromium).
+- Upgrades `useMoodleExtension` to a discriminated-union state machine with a 2s detection timeout and a version handshake against `EXPECTED_EXTENSION_VERSION` (`0.2.0`).
+- Tightens `extension/manifest.json` — `<all_urls>` moves from `host_permissions` to `optional_host_permissions`. The connection setup now requests per-domain permission at runtime via `chrome.permissions.request()`.
+- Adds `MoodleCardSkeleton` + new install/update card UI for the new detection states.
+- Adds `<details>`-wrapped debug payload, friendlier network-error messaging, a "Retry failed" button, and a "Grant Permission" fallback inside `<MoodleSyncDialog>`.
+
+## Out of scope (deferred)
+
+- Actual Chrome Web Store upload + listing.
+- Wiring the "Install Extension" button to a real CWS URL.
+- Auto-detection after install (today: refresh).
+
+## Test plan
+
+- [x] `pnpm test` — unit
+- [x] `pnpm test:integration` — integration
+- [x] `pnpm test:e2e` — including new `moodle-touch-gating.spec.ts`
+- [x] `pnpm build` — production
+- [x] Manual: 10-step smoke flow in `extension/QUICKSTART.md`
+
+Spec: `docs/superpowers/specs/2026-05-13-extension-readiness-design.md`
+Plan: `docs/superpowers/plans/2026-05-13-extension-readiness.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Confirm CI passes on the PR**
+
+Watch the GitHub Actions checks on the PR page. All required checks (lint, format, unit, integration, build, E2E) must pass before merging.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Goals (gating, bounded detection, manifest tightening, local-dev path) → tasks 8/13/3/5/6/9 (gating), 6 (bounded detection), 2 (manifest), 14 (local-dev). Non-goals (CWS upload, install URL wiring, auto-detect) → explicitly noted in PR description.
+- **State matrix coverage:** Level 1 (platform) → tasks 3+5+8. Level 2 (extension detection) → tasks 6+7. Level 3 (connection + permission) → task 9. Level 4 (login) → unchanged from current code; surfaced in dialog. Level 5 (sync dialog) → tasks 10–12.
+- **Error handling coverage:** Class A (detection) → task 6. Class B (permission) → tasks 9, 12. Class C (login & scrape) → task 10. Class D (download/upload) → task 11.
+- **Verification coverage:** Vitest → tasks 3, 4, 5, 6, 7, 9. Playwright → task 13. Manual smoke + pre-release → task 14.
+- **Type consistency:** `ExtensionState` shape and `EXPECTED_EXTENSION_VERSION` constant defined in task 6, referenced consistently in tasks 7, 9, 12, 14.
+- **No placeholders:** every code step includes the full content. The one exception is task 9 step 1, which asks the engineer to read the existing test file before adapting the new test cases — necessary because the existing test scaffolding pattern may differ.

--- a/docs/superpowers/specs/2026-05-13-extension-readiness-design.md
+++ b/docs/superpowers/specs/2026-05-13-extension-readiness-design.md
@@ -1,0 +1,214 @@
+# Extension Readiness — Design
+
+**Date:** 2026-05-13
+**Status:** Draft
+**Branch:** `feat/extension-readiness`
+
+## Context
+
+The Moodle Chrome extension lives at `extension/` and was scaffolded as part of spec `004-moodle-import-sync`. It is structurally complete (Manifest V3 service worker, content scripts, full message protocol) but has never been verified end-to-end and is not production-ready in three concrete ways:
+
+1. **No platform gating.** The web app renders the Moodle UI on every device. On iPad/mobile, `chrome.runtime` is `undefined`, so detection silently fails and the user sees a disabled "Install Extension" card — broken-looking, not hidden.
+2. **Manifest is too permissive for the Chrome Web Store.** `host_permissions: ["<all_urls>"]` is a major review red flag. The service worker already implements `chrome.permissions.request()` per-origin (`REQUEST_PERMISSION` handler), but no UI calls it — the extension currently relies on the manifest-granted `<all_urls>`.
+3. **Detection is fragile.** No timeout on PING, no version handshake, no install URL, and `NEXT_PUBLIC_EXTENSION_ID` is missing from `.env.local.example`. A developer setting up the project locally hits a silent dead-end.
+
+This spec covers making the extension installable, detectable, and gated correctly on supported platforms only. It does **not** cover the Chrome Web Store upload itself or an in-app "Install now" call-to-action — both deferred.
+
+## Goals
+
+- Moodle UI is visible **only** on desktop Chromium browsers (pointer-fine input + `chrome.runtime` present).
+- Extension detection is bounded (2 s), deterministic, and gracefully handles four classes of failure.
+- Manifest is tightened so a future CWS submission has a high chance of approval on first review.
+- A local-dev path is documented so anyone can load and verify the extension in ~10 minutes.
+
+## Non-Goals (explicitly deferred)
+
+- Actual Chrome Web Store upload + listing.
+- Wiring the "Install Extension" button to a real CWS URL.
+- Auto-detection after install (today requires page refresh; documented as such).
+- Persistent per-file failure logs for retried downloads.
+- E2E coverage of the real sync flow (requires loading a real extension into Playwright — non-trivial; user explicitly opted for the minimal gating-only Playwright spec).
+
+## Architecture
+
+Three units, single-responsibility each. The split keeps "what platform is this?" separate from "what is the extension doing?", so either can be changed without touching the other.
+
+### `src/hooks/use-extension-platform.ts` _(new)_
+
+Returns `{ isSupportedPlatform: boolean }`. Pure feature detection. Two checks:
+
+- `window.matchMedia('(pointer: fine)').matches` — skips touch-primary devices (iPad, phones, touch-only Chromebooks).
+- `typeof window.chrome?.runtime?.sendMessage === 'function'` — skips Firefox, Safari, and any environment without the Chrome extension messaging API.
+
+SSR-safe: returns `false` on the server, hydrates to the real value on the client. No `useEffect` setState — uses `useSyncExternalStore` so there's no hydration flash.
+
+### `src/components/dashboard/extension-gate.tsx` _(new)_
+
+```tsx
+<ExtensionGate>{children}</ExtensionGate>
+```
+
+Renders `children` only when `useExtensionPlatform().isSupportedPlatform` is `true`. The CSS layer also applies a `hidden pointer-fine:block` (or equivalent Tailwind 4) class so the children never paint on mobile during hydration. Belt-and-suspenders: CSS hides on mobile even if the JS gate hasn't run yet.
+
+### `src/hooks/use-moodle-extension.ts` _(modified)_
+
+State machine moves from the current `{ isInstalled, isChecking }` shape to a discriminated union:
+
+```ts
+type ExtensionState =
+  | { status: 'checking' }
+  | { status: 'installed'; version: string }
+  | { status: 'not-installed' }
+  | { status: 'version-mismatch'; installedVersion: string };
+```
+
+PING is wrapped in a 2-second timeout. The response's `version` is compared against `EXPECTED_EXTENSION_VERSION` (constant in the hook, set to `'0.2.0'`) by exact string equality at v0 — we'll move to semver comparison once we ship a 1.x. Dev-only `console.warn` if `NEXT_PUBLIC_EXTENSION_ID` is missing.
+
+### Interview-driven note
+
+The architecture choice here is a textbook _separation of concerns_: the "is this a supported platform?" question is data-independent of "is the extension installed and what version?". One hook per question, one component for composition. If we ever support a Firefox build of the extension, only `useExtensionPlatform` changes — `useMoodleExtension` doesn't notice.
+
+## State matrix
+
+Five levels, evaluated top-down. The first level that does not pass short-circuits everything below it.
+
+| Level | Condition                                            | UI                                                                                                             |
+| ----- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ----------- |
+| 1     | Touch / non-Chromium                                 | Nothing (silent hide via CSS + JS)                                                                             |
+| 2a    | `status: 'checking'`                                 | `<MoodleCardSkeleton>` — pulsing placeholder                                                                   |
+| 2b    | `status: 'not-installed'`                            | "Install the Typenote extension to sync Moodle" card; install button disabled (placeholder for future CWS URL) |
+| 2c    | `status: 'version-mismatch'`                         | "Update the Typenote extension" card showing both installed and required versions                              |
+| 3a    | Extension installed, no `moodle_connections` row     | URL input + Connect (existing `<MoodleConnectionSetup>` shape)                                                 |
+| 3b    | Connection saved, no host permission for that origin | Inline "Grant access to `{domain}`" + button → `requestPermission()`                                           |
+| 3c    | Connection saved + permission granted                | Continue to Level 4                                                                                            |
+| 4a    | User clicks Sync, login check in flight              | Inline spinner on Sync button                                                                                  |
+| 4b    | Not logged in                                        | "Log into Moodle to continue" + new-tab link to `{moodleUrl}/login` + hint to refresh after login              |
+| 4c    | Logged in                                            | Existing `<MoodleSyncDialog>` opens — Level 5                                                                  |
+| 5     | Sync dialog (unchanged)                              | Existing `scraping → comparing → select-courses → scraping-content → select-content → syncing → done           | error` flow |
+
+**No re-check / re-detect buttons anywhere.** Detection runs on mount; users refresh the page after installing the extension or logging into Moodle. This is a deliberate simplification (less state, fewer affordances to test).
+
+## Manifest changes (CWS readiness)
+
+`extension/manifest.json`:
+
+- Move `"host_permissions": ["<all_urls>"]` → `"optional_host_permissions": ["<all_urls>"]`. This is the single most important change for review approval.
+- Keep `permissions: ["storage", "scripting", "cookies", "tabs", "activeTab"]`. Each is justified by code already in the repo:
+  - `cookies` — `MoodleSession` quick-check at `extension/src/background/service-worker.ts:223`.
+  - `scripting` — content-script injection via `chrome.scripting.executeScript`.
+  - `tabs` — `getOrCreateMoodleTab` (background tab lifecycle).
+  - `storage` — extension preferences.
+  - `activeTab` — `executeScript` permission on the user-activated tab.
+- Bump manifest `version` to `0.2.0` (the permission-model change is a breaking API contract).
+
+### Behavior change
+
+After the user enters their Moodle URL in `<MoodleConnectionSetup>`, the component calls `requestPermission(origin)` from `useMoodleExtension` immediately. Chrome displays its native permission dialog asking for access to `https://{domain}/*`.
+
+- If the user declines → save is blocked, toast explains why, button re-enables.
+- If the user accepts → connection saves, user proceeds to sync.
+
+This is the only meaningful UX addition in the connection setup flow.
+
+## Error handling
+
+Four classes, mapped to where they fire in code today vs. what changes.
+
+### A. Detection failures (Level 2)
+
+| Failure                              | Cause                                                              | UX                                                                                                  |
+| ------------------------------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_EXTENSION_ID` missing   | env var not loaded                                                 | Dev: `console.warn` so it's obvious. Prod: silently treated as `not-installed` (users never hit it) |
+| Extension not installed              | `chrome.runtime.lastError` set with "Receiving end does not exist" | `not-installed` card                                                                                |
+| Extension installed but unresponsive | Promise hangs                                                      | 2-second timeout → `not-installed` (logged)                                                         |
+| Malformed PING response              | `success !== true` or missing `data.version`                       | `not-installed` (logged)                                                                            |
+
+### B. Permission failures (Level 3)
+
+| Failure                                                   | Symptom                                                                      | UX                                                                                                                               |
+| --------------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| User declines Chrome permission prompt                    | Service worker returns `{ success: false, error: "User denied permission" }` | Banner stays; toast: "Permission required to sync with {domain}"; button re-enables                                              |
+| User revokes permission later (via `chrome://extensions`) | Next scrape call fails with permission error inside `executeScript`          | `<MoodleSyncDialog>` catches it → inline "Grant Permission" fallback button reruns `requestPermission` and retries the operation |
+| Invalid origin string                                     | Service worker `catch` returns `{ success: false, error: String(err) }`      | Toast surfaces the message                                                                                                       |
+
+### C. Moodle login & scrape failures (Levels 4–5)
+
+The existing `isAuthError` regex at `moodle-sync-dialog.tsx:67` (matches `403`, `forbidden`, `unauthorized`, `login required`, `session expired`) stays untouched. Two additions:
+
+1. **New `isNetworkError` helper, parallel to `isAuthError`** — matches `network`, `fetch`, `timeout` in the error message. When it fires (and `isAuthError` does not), surface: "Couldn't reach `{domain}`. Check your internet and try again." Keeping these as two separate functions matters: a network failure and an auth failure want different recovery affordances, and conflating them would muddy both the error display logic and any future telemetry.
+2. **Debug payload UX** — the raw debug object surfaced at `moodle-sync-dialog.tsx:295` ("Page: '…' at … (N cards)") is useful for development but ugly for users. Wrap it in a `<details><summary>Debug info</summary>…</details>` so it stays available without dominating the alert.
+
+### D. Download/upload failures (mid-sync)
+
+Existing per-file error collection at `moodle-sync-dialog.tsx:539` (first 3 errors shown on the "done with errors" screen) stays. One addition:
+
+- **"Retry failed (N)" button** on the `done` screen when `failedCount > 0`. Re-runs only the failed jobs (kept in state as `failedJobs: typeof fileJobs`). On retry, the counts update in place; if retry succeeds, the card flips to a clean success state.
+
+Persistent per-file error logs (so users see _what_ failed after closing the dialog) are deferred.
+
+## Verification strategy
+
+Three layers, matching the user's choice of "unit tests + one Playwright gating test + manual checklist".
+
+### Automated — runs in CI
+
+**Vitest** (new and extended):
+
+- `src/hooks/use-extension-platform.test.ts` — table-driven, stubs `window.chrome` and `matchMedia('(pointer: fine)')`. Covers: Chromium-desktop, Firefox-desktop, Safari-desktop, iPad-Chrome, Android-Chrome.
+- `src/components/dashboard/extension-gate.test.tsx` — renders children only when supported; otherwise returns `null`.
+- `src/hooks/use-moodle-extension.test.ts` (extend) — adds: 2 s timeout fires, version-mismatch path, malformed-response path.
+
+**Playwright** (one new spec, `e2e/moodle-touch-gating.spec.ts`):
+
+1. Log in with the shared helper from `e2e/helpers/auth.ts`.
+2. Set viewport to Playwright's iPad device descriptor (touch + coarse pointer).
+3. Assert the Moodle card is not visible.
+4. Reset viewport to desktop.
+5. Assert the Moodle card IS visible in some state (the install card is fine — we're testing the gate, not the contents).
+
+This is registered in `e2e/TEST_REGISTRY.md` per CLAUDE.md requirement.
+
+### Semi-automated — local smoke (`extension/QUICKSTART.md`)
+
+A 10-step build → load → connect → sync flow, each step paired with an expected outcome. Anyone (you, future contributors) should be able to follow it in under 10 minutes and either confirm "✅ works" or land on a specific step that broke.
+
+### Manual — requires real Moodle credentials
+
+Three pre-release flows captured in the same `extension/QUICKSTART.md` under a "Before release" section:
+
+1. **Auth expiry mid-sync** — start a sync; log out of Moodle in another tab; confirm the error path triggers `isAuthError` and shows the "Re-log into Moodle" affordance.
+2. **Permission revocation** — start a sync; revoke at `chrome://extensions`; confirm the "Grant Permission" fallback fires.
+3. **Large course** — sync a course with 20+ files. Confirm download progress, confirm files appear in Supabase Storage, confirm "Retry failed" works if a file flakes.
+
+These cannot be automated without real credentials; documenting them keeps them from being forgotten.
+
+## Files touched
+
+**New:**
+
+- `src/hooks/use-extension-platform.ts`
+- `src/hooks/use-extension-platform.test.ts`
+- `src/components/dashboard/extension-gate.tsx`
+- `src/components/dashboard/extension-gate.test.tsx`
+- `src/components/dashboard/moodle-card-skeleton.tsx`
+- `e2e/moodle-touch-gating.spec.ts`
+- `extension/QUICKSTART.md`
+
+**Modified:**
+
+- `extension/manifest.json` — permission model + version bump
+- `extension/package.json` — version bump
+- `src/hooks/use-moodle-extension.ts` — state machine + timeout + version check
+- `src/hooks/use-moodle-extension.test.ts` — extended cases
+- `src/components/dashboard/moodle-sync-prompt-wrapper.tsx` — wrap with `<ExtensionGate>`; branch on state
+- `src/components/dashboard/moodle-sync-prompt.tsx` — receive state via props; render install/update card
+- `src/components/dashboard/moodle-connection-setup.tsx` — call `requestPermission()` after URL save; show permission banner
+- `src/components/dashboard/moodle-sync-dialog.tsx` — add network-error message; wrap debug payload in `<details>`; add "Retry failed" button + state; add "Grant Permission" fallback
+- `.env.local.example` — add `NEXT_PUBLIC_EXTENSION_ID` with explanatory comment
+- `e2e/TEST_REGISTRY.md` — register new gating spec
+- `CLAUDE.md` — append "Active Technologies" line for this spec
+
+## Open questions for plan / implementation
+
+- Naming: `<ExtensionGate>` is generic. If we add other Chromium-only features later (e.g., a Drive extension), the name is right; if not, `<MoodleGate>` is more honest. Default to `<ExtensionGate>` for forward-compat.
+- `EXPECTED_EXTENSION_VERSION` exact-match vs. minimum: starting with exact-match; can swap to semver comparison when we ship anything beyond `0.2.0`.

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -171,6 +171,13 @@ context-menu entry point works end-to-end.
 
 ---
 
+## Moodle Extension Gating (`e2e/moodle-touch-gating.spec.ts`) — IMPLEMENTED
+
+- [x] Moodle card is hidden on iPad viewport (pointer: coarse)
+- [x] Moodle card is visible on desktop viewport (pointer: fine)
+
+---
+
 ## Version History (`e2e/version-history.spec.ts`) — PLANNED
 
 - [ ] Open version history sidebar from canvas editor toolbar
@@ -196,9 +203,11 @@ context-menu entry point works end-to-end.
 | PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`          | 6/7       |
 | Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`         | 3/3       |
 | Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`    | 8/8       |
+| Moodle Ext Gating     | Implemented | `e2e/moodle-touch-gating.spec.ts`   | 2/2       |
+| Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`        | 3/3       |
 | Version History       | Planned     | `e2e/version-history.spec.ts`       | 0/5       |
 | PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts` | 8/8       |
-| **Total**             |             |                                     | **83/89** |
+| **Total**             |             |                                     | **88/94** |
 
 ---
 

--- a/e2e/extension-real.spec.ts
+++ b/e2e/extension-real.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect, chromium, type BrowserContext } from '@playwright/test';
+import * as path from 'path';
+
+const EXTENSION_PATH = path.resolve(__dirname, '..', 'extension');
+const EXPECTED_VERSION = '0.2.0';
+const PINNED_EXTENSION_ID = 'beajdnpmcbgjfkhojoangknkeimimmfm';
+// CI's webServer serves on localhost:3000; locally override via PLAYWRIGHT_BASE_URL
+// to point at a deployed instance.
+const DASHBOARD_BASE_URL =
+  process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+
+async function launchWithExtension(): Promise<BrowserContext> {
+  const args = [
+    `--disable-extensions-except=${EXTENSION_PATH}`,
+    `--load-extension=${EXTENSION_PATH}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+  ];
+  // Linux CI runners have no X server; Chrome's new headless mode is the only
+  // way to run MV3 extensions without a display (old --headless skips them).
+  if (process.env.CI) args.push('--headless=new');
+
+  return await chromium.launchPersistentContext('', {
+    headless: false,
+    args,
+  });
+}
+
+async function getServiceWorker(context: BrowserContext) {
+  let [sw] = context.serviceWorkers();
+  if (!sw) {
+    sw = await context.waitForEvent('serviceworker', { timeout: 20_000 });
+  }
+  return sw;
+}
+
+// Service worker registration sometimes takes longer than the 30s default.
+test.setTimeout(60_000);
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Typenote Moodle Extension — real extension load', () => {
+  test('service worker registers with the pinned extension ID', async () => {
+    const context = await launchWithExtension();
+    try {
+      const sw = await getServiceWorker(context);
+      const swUrl = new URL(sw.url());
+      expect(swUrl.protocol).toBe('chrome-extension:');
+      expect(swUrl.hostname).toBe(PINNED_EXTENSION_ID);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('PING from an allowed origin returns version 0.2.0', async () => {
+    const context = await launchWithExtension();
+    try {
+      const sw = await getServiceWorker(context);
+      const extensionId = new URL(sw.url()).hostname;
+
+      const page = await context.newPage();
+
+      // Manifest's externally_connectable allows http://localhost:3000/*.
+      // Intercept that URL and serve a page that runs chrome.runtime.sendMessage,
+      // so the request's origin satisfies the manifest without a real server.
+      await context.route('http://localhost:3000/__test', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: `<!doctype html><html><body><script>
+            window.__pingResult = null;
+            window.__pingError = null;
+            try {
+              chrome.runtime.sendMessage(
+                ${JSON.stringify(extensionId)},
+                { type: 'PING' },
+                (response) => {
+                  if (chrome.runtime.lastError) {
+                    window.__pingError = chrome.runtime.lastError.message;
+                  } else {
+                    window.__pingResult = response;
+                  }
+                }
+              );
+            } catch (e) {
+              window.__pingError = String(e);
+            }
+          </script></body></html>`,
+        });
+      });
+
+      await page.goto('http://localhost:3000/__test', { timeout: 10_000 });
+      await page.waitForFunction(
+        () => {
+          type W = { __pingResult?: unknown; __pingError?: unknown };
+          const w = window as unknown as W;
+          return w.__pingResult !== null || w.__pingError !== null;
+        },
+        undefined,
+        { timeout: 10_000 },
+      );
+
+      const result = await page.evaluate(() => ({
+        ok: (window as unknown as { __pingResult?: unknown }).__pingResult,
+        err: (window as unknown as { __pingError?: unknown }).__pingError,
+      }));
+
+      expect(result.err).toBeNull();
+      expect(result.ok).toEqual({
+        success: true,
+        data: { version: EXPECTED_VERSION },
+      });
+    } finally {
+      await context.close();
+    }
+  });
+
+  test('remote dashboard recognizes the extension after login', async () => {
+    const context = await launchWithExtension();
+    try {
+      // Service worker must be up before the dashboard pings it.
+      await getServiceWorker(context);
+
+      // Headless Chromium reports `pointer: coarse` (no physical mouse), which
+      // makes useExtensionPlatform() gate the Moodle card OUT. Force the
+      // pointer-fine match so the card renders on headless CI runs.
+      await context.addInitScript(() => {
+        const real = window.matchMedia.bind(window);
+        window.matchMedia = (query: string) => {
+          if (query.includes('pointer: fine')) {
+            return {
+              matches: true,
+              media: query,
+              addEventListener: () => {},
+              removeEventListener: () => {},
+              addListener: () => {},
+              removeListener: () => {},
+              dispatchEvent: () => false,
+              onchange: null,
+            } as MediaQueryList;
+          }
+          return real(query);
+        };
+      });
+
+      const page = await context.newPage();
+      await page.goto(`${DASHBOARD_BASE_URL}/login`);
+      await page.getByLabel('Email').fill('test@typenote.dev');
+      await page.getByLabel('Password').fill('Test1234');
+      await page.getByRole('button', { name: /sign in/i }).click();
+      await page.waitForURL('**/dashboard**', { timeout: 15_000 });
+
+      // The card title is always present; the body distinguishes states.
+      // 'not-installed' shows the "Install Extension" disabled button.
+      // 'installed' shows either MoodleConnectionSetup or "Sync with Moodle".
+      await expect(page.getByText(/moodle integration/i).first()).toBeVisible({
+        timeout: 10_000,
+      });
+      // The skeleton resolves within ~2s (PING_TIMEOUT_MS). Wait for either
+      // a real installed state or a definitive not-installed state.
+      await page.waitForFunction(
+        () => {
+          const text = document.body.innerText;
+          return (
+            /install extension/i.test(text) ||
+            /sync with moodle/i.test(text) ||
+            /enter your moodle url/i.test(text) ||
+            /update extension/i.test(text)
+          );
+        },
+        undefined,
+        { timeout: 10_000 },
+      );
+
+      const installButtonCount = await page
+        .getByRole('button', { name: /^install extension$/i })
+        .count();
+      const updateButtonCount = await page
+        .getByRole('button', { name: /^update extension$/i })
+        .count();
+
+      expect(installButtonCount).toBe(0); // would mean not-installed
+      expect(updateButtonCount).toBe(0); // would mean version-mismatch
+    } finally {
+      await context.close();
+    }
+  });
+});

--- a/e2e/moodle-touch-gating.spec.ts
+++ b/e2e/moodle-touch-gating.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect, devices } from '@playwright/test';
+import { login } from './helpers/auth';
+
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const MOODLE_CARD_TEXT = /moodle integration/i;
+
+test.describe('Moodle UI — touch / non-Chromium gating', () => {
+  test('Moodle card is hidden on iPad viewport (pointer: coarse)', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      ...devices['iPad Pro 11'],
+      baseURL: BASE_URL,
+    });
+    const page = await context.newPage();
+    await login(page);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(MOODLE_CARD_TEXT)).toHaveCount(0);
+
+    await context.close();
+  });
+
+  test('Moodle card is visible on desktop viewport (pointer: fine)', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext({
+      viewport: { width: 1440, height: 900 },
+      baseURL: BASE_URL,
+    });
+    // Stub window.chrome.runtime.sendMessage so useExtensionPlatform() sees a
+    // Chromium-family desktop environment. Without an actual Chrome extension
+    // loaded, Playwright's Chromium does not expose window.chrome at all.
+    await context.addInitScript(() => {
+      Object.defineProperty(window, 'chrome', {
+        value: {
+          runtime: {
+            sendMessage: () => {},
+          },
+        },
+        writable: true,
+      });
+    });
+    const page = await context.newPage();
+    await login(page);
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Either the install card, update card, or connected card — any state is fine.
+    await expect(page.getByText(MOODLE_CARD_TEXT)).toBeVisible();
+
+    await context.close();
+  });
+});

--- a/extension/QUICKSTART.md
+++ b/extension/QUICKSTART.md
@@ -1,0 +1,103 @@
+# Typenote Moodle Extension — Quickstart
+
+This guide walks you through building, loading, and verifying the extension end-to-end on your machine. The full automated suite covers gating logic and unit-level behavior; the steps below cover the real-Chrome-extension flow that can't be automated cheaply.
+
+## Prerequisites
+
+- pnpm, Node 22+
+- Google Chrome (or another Chromium-family browser — Edge, Brave, Arc all work)
+- A real Moodle account at a university you can log into
+
+## Build & load (one-time)
+
+1. **Build the extension bundle.**
+
+   ```bash
+   (cd extension && npm install && npm run build)
+   ```
+
+   First run installs the extension's own devDeps (esbuild, @types/chrome, typescript). Subsequent runs just rebuild. Produces `extension/dist/background/service-worker.js` and `extension/dist/content/moodle-scraper.js`.
+
+2. **Open `chrome://extensions`** in Chrome.
+
+3. **Enable "Developer mode"** (toggle, top right).
+
+4. **Click "Load unpacked"** and select the `extension/` folder from this repo. The extension card should appear with name "Typenote Moodle Sync" and version `0.2.0`.
+
+5. **Copy the extension ID** shown on the card (a 32-character lowercase string).
+
+6. **Add it to `.env.local`:**
+
+   ```
+   NEXT_PUBLIC_EXTENSION_ID=<paste-the-id-here>
+   ```
+
+7. **Restart `pnpm dev`** (the env var is read at startup, not per-request).
+
+## 10-step smoke checklist
+
+After the one-time setup, run through this list. Each step lists the _expected_ outcome — flag any deviation.
+
+1. `pnpm dev` → open `http://localhost:3000/dashboard` → log in.
+   **Expect:** A "Moodle Integration" card on the dashboard with a URL input.
+
+2. Open DevTools → Device Toolbar → select **iPad Pro 11** → reload.
+   **Expect:** The Moodle card disappears entirely (touch gating).
+
+3. Switch back to a desktop viewport → reload.
+   **Expect:** The Moodle card reappears.
+
+4. Enter your real Moodle URL (e.g. `moodle.runi.ac.il/2026`) → click **Connect**.
+   **Expect:** Chrome shows a native permission popup asking access to `https://moodle.runi.ac.il/*`. Click **Allow**.
+
+5. The card should now say "Connected to moodle.runi.ac.il" with a **Sync with Moodle** button.
+
+6. Open `moodle.runi.ac.il` in another tab → log in to your Moodle account.
+
+7. Return to the Typenote tab → click **Sync with Moodle**.
+   **Expect:** A dialog opens, scrapes courses, and shows a course list with status badges ("New", "Synced", etc.).
+
+8. Select **one course** → click **Preview Content**.
+   **Expect:** Section/file list appears, with files already in the registry shown as "synced".
+
+9. Select **one small file** in a section → click **Sync Selected**.
+   **Expect:** Progress text "Downloading files... (1/1)" → "Successfully synced 1 course" with `1 file downloaded`.
+
+10. Check Supabase Storage (Studio at `http://localhost:54323`) → bucket `moodle-materials` → the new file should be present.
+
+If all 10 pass, the happy path is healthy.
+
+## Pre-release manual checklist (real-credentials only)
+
+These exercise the failure paths. Run them before bumping to a new release.
+
+### A. Auth expiry mid-sync
+
+1. Start a sync (open the dialog, get to the course-selection phase).
+2. In your other Moodle tab, log out.
+3. Continue the sync. **Expect:** the dialog surfaces "Your Moodle session may have expired" with a "Re-log into Moodle" link.
+
+### B. Permission revocation mid-flow
+
+1. Start a sync.
+2. Open `chrome://extensions` → Typenote Moodle Sync → "Details" → toggle "Site access" off for your Moodle domain.
+3. Retry the sync. **Expect:** the dialog shows the inline "Grant Permission" button. Click it → native popup → Allow → sync resumes.
+
+### C. Large-course download with intentional flake
+
+1. Sync a course with 20+ files.
+2. Mid-download, kill your network briefly (e.g. macOS Network → toggle Wi-Fi off for 5 s, then on).
+3. **Expect:** some files fail. After the run completes, the "done with errors" screen shows a **Retry failed (N)** button. Click it. **Expect:** failures retry; on success the screen flips to clean success.
+
+---
+
+## Troubleshooting
+
+- **"Install Extension" card stays visible even after loading the unpacked extension.**
+  `NEXT_PUBLIC_EXTENSION_ID` isn't matching the unpacked ID. Recopy from `chrome://extensions` and restart `pnpm dev`.
+
+- **Permission popup never appears.**
+  The manifest probably wasn't rebuilt after a change. Run `(cd extension && npm run build)` and reload the extension at `chrome://extensions`.
+
+- **"Update Extension" card.**
+  The loaded extension's manifest `version` doesn't match `EXPECTED_EXTENSION_VERSION` in `src/hooks/use-moodle-extension.ts`. Rebuild the extension or update the constant in lockstep.

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,19 +1,25 @@
 {
   "manifest_version": 3,
   "name": "Typenote Moodle Sync",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Import course materials from Moodle into Typenote",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmAsETPFXkIxxNHGIsBGrtCXNqx3OSLT/BDLyd22QD6Es4IwKlMN3Png15xHpOB+RRaExNC0DtyW73/dnvSEJRJD8vTWV6JWijUeKRP2BGwk06kLTwz0u+RETLJRRvvnfgUh+WiaeX+hFZlfpFXo5zSJP6EhmZq4Asxhc0MIDyAD5JlLtgivQhy3CoFz8eyiAFcziwSKobnUVaEAm96ayjVStCyrayoz676estF5yNRSii/E5XCNdFGVbuiD70wjF3NH2KdxQm1JiGXUrZyefCtVO0cHov5akc+TWT1YIvBrcYaHuXFN/Uf4oJgzhkj9l5uEDPWdx3ajiv1WXbZirmQIDAQAB",
   "permissions": ["storage", "scripting", "cookies", "tabs", "activeTab"],
-  "host_permissions": ["<all_urls>"],
+  "optional_host_permissions": ["<all_urls>"],
   "background": {
-    "service_worker": "dist/service-worker.js"
+    "service_worker": "dist/background/service-worker.js"
   },
   "externally_connectable": {
-    "matches": ["http://localhost:3000/*", "https://*.typenote.app/*"]
+    "matches": [
+      "http://localhost:3000/*",
+      "http://localhost:3001/*",
+      "http://151.145.83.151:3001/*",
+      "https://*.typenote.app/*"
+    ]
   },
   "web_accessible_resources": [
     {
-      "resources": ["dist/moodle-scraper.js"],
+      "resources": ["dist/content/moodle-scraper.js"],
       "matches": ["https://*/*", "http://*/*"]
     }
   ]

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typenote-moodle-extension",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "esbuild src/background/service-worker.ts src/content/moodle-scraper.ts --bundle --outdir=dist --sourcemap --watch",

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -19,7 +19,7 @@ import type {
   ScrapedCourseContentData,
 } from '../types/messages';
 
-const EXTENSION_VERSION = '0.1.0';
+const EXTENSION_VERSION = '0.2.0';
 
 // Listen for messages from the Typenote web app
 chrome.runtime.onMessageExternal.addListener(

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,7 @@ const nextConfig: NextConfig = {
     '192.168.*.*',
     '10.*.*.*',
     '172.16-31.*.*',
+    '151.145.83.151',
   ],
   async rewrites() {
     return [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000';
+const isLocalBase = /^https?:\/\/(localhost|127\.0\.0\.1)/i.test(BASE_URL);
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -8,7 +11,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:3000',
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     locale: 'en-US',
@@ -28,9 +31,11 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
-  },
+  webServer: isLocalBase
+    ? {
+        command: 'pnpm dev',
+        url: BASE_URL,
+        reuseExistingServer: !process.env.CI,
+      }
+    : undefined,
 });

--- a/src/components/dashboard/extension-gate.test.tsx
+++ b/src/components/dashboard/extension-gate.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const originalMatchMedia = globalThis.window?.matchMedia;
+const originalChrome = (globalThis as Record<string, unknown>).chrome;
+
+function setSupported(supported: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(pointer: fine)' ? supported : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+  if (supported) {
+    (globalThis as Record<string, unknown>).chrome = {
+      runtime: { sendMessage: vi.fn() },
+    };
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+}
+
+afterEach(() => {
+  if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+  if (originalChrome) {
+    (globalThis as Record<string, unknown>).chrome = originalChrome;
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+});
+
+const { ExtensionGate } = await import('./extension-gate');
+
+describe('ExtensionGate', () => {
+  it('renders children on a supported platform', () => {
+    setSupported(true);
+    render(
+      <ExtensionGate>
+        <p>moodle ui</p>
+      </ExtensionGate>,
+    );
+    expect(screen.getByText('moodle ui')).toBeInTheDocument();
+  });
+
+  it('renders nothing on an unsupported platform', () => {
+    setSupported(false);
+    const { container } = render(
+      <ExtensionGate>
+        <p>moodle ui</p>
+      </ExtensionGate>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/dashboard/extension-gate.tsx
+++ b/src/components/dashboard/extension-gate.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useExtensionPlatform } from '@/hooks/use-extension-platform';
+
+interface ExtensionGateProps {
+  children: ReactNode;
+}
+
+/**
+ * Renders `children` only on Chromium-family desktop browsers.
+ * Silent — no fallback UI on touch/non-Chromium devices.
+ *
+ * @see useExtensionPlatform for the detection logic.
+ */
+export function ExtensionGate({ children }: ExtensionGateProps) {
+  const { isSupportedPlatform } = useExtensionPlatform();
+  if (!isSupportedPlatform) return null;
+  return <>{children}</>;
+}

--- a/src/components/dashboard/moodle-card-skeleton.test.tsx
+++ b/src/components/dashboard/moodle-card-skeleton.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MoodleCardSkeleton } from './moodle-card-skeleton';
+
+describe('MoodleCardSkeleton', () => {
+  it('renders a non-empty placeholder element', () => {
+    const { container } = render(<MoodleCardSkeleton />);
+    expect(container.firstChild).not.toBeNull();
+    expect(container.textContent).toBe('');
+  });
+});

--- a/src/components/dashboard/moodle-card-skeleton.tsx
+++ b/src/components/dashboard/moodle-card-skeleton.tsx
@@ -1,0 +1,19 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+
+/**
+ * Placeholder card rendered while the extension PING is in flight (≤2 s).
+ * Empty text content — the visual interest comes entirely from animated pulse blocks.
+ */
+export function MoodleCardSkeleton() {
+  return (
+    <Card aria-busy="true" aria-label="Loading Moodle integration">
+      <CardHeader>
+        <div className="h-4 w-40 animate-pulse rounded bg-muted" />
+        <div className="mt-2 h-3 w-64 animate-pulse rounded bg-muted" />
+      </CardHeader>
+      <CardContent>
+        <div className="h-8 w-28 animate-pulse rounded bg-muted" />
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/moodle-connection-setup.test.tsx
+++ b/src/components/dashboard/moodle-connection-setup.test.tsx
@@ -1,69 +1,81 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
-import { MoodleConnectionSetup } from './moodle-connection-setup';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-// Mock the hook
 vi.mock('@/hooks/use-moodle-extension', () => ({
   useMoodleExtension: vi.fn(),
+  EXPECTED_EXTENSION_VERSION: '0.2.0',
 }));
 
-// Mock server actions
 vi.mock('@/lib/actions/moodle-sync', () => ({
   saveMoodleConnection: vi.fn(),
   removeMoodleConnection: vi.fn(),
 }));
 
-// Mock sonner
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
 
-import { useMoodleExtension } from '@/hooks/use-moodle-extension';
+import {
+  useMoodleExtension,
+  type ExtensionState,
+} from '@/hooks/use-moodle-extension';
+import { MoodleConnectionSetup } from './moodle-connection-setup';
+import { saveMoodleConnection } from '@/lib/actions/moodle-sync';
 
 const mockUseMoodleExtension = useMoodleExtension as ReturnType<typeof vi.fn>;
+
+function mockExtension(
+  state: ExtensionState,
+  overrides: {
+    requestPermission?: ReturnType<typeof vi.fn>;
+    checkPermission?: ReturnType<typeof vi.fn>;
+  } = {},
+) {
+  mockUseMoodleExtension.mockReturnValue({
+    state,
+    isInstalled: state.status === 'installed',
+    isChecking: state.status === 'checking',
+    requestPermission:
+      overrides.requestPermission ?? vi.fn().mockResolvedValue(true),
+    checkPermission:
+      overrides.checkPermission ?? vi.fn().mockResolvedValue(true),
+    ping: vi.fn(),
+    checkMoodleLogin: vi.fn(),
+    scrapeCourses: vi.fn(),
+    scrapeCourseContent: vi.fn(),
+    downloadAndUpload: vi.fn(),
+  });
+}
 
 describe('MoodleConnectionSetup', () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it('shows loading state while checking extension', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: false,
-      isChecking: true,
-    });
-
-    render(<MoodleConnectionSetup />);
-    expect(screen.getByText(/checking/i)).toBeInTheDocument();
+  it('renders nothing while the extension is still being checked', () => {
+    mockExtension({ status: 'checking' });
+    const { container } = render(<MoodleConnectionSetup />);
+    expect(container.firstChild).toBeNull();
   });
 
-  it('shows install prompt when extension not installed', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: false,
-      isChecking: false,
-    });
-
-    render(<MoodleConnectionSetup />);
-    expect(screen.getByText(/extension required/i)).toBeInTheDocument();
+  it('renders nothing when the extension is not installed', () => {
+    mockExtension({ status: 'not-installed' });
+    const { container } = render(<MoodleConnectionSetup />);
+    expect(container.firstChild).toBeNull();
   });
 
-  it('shows URL input when extension is installed', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: true,
-      isChecking: false,
-    });
-
+  it('shows URL input when extension is installed and no connection saved', () => {
+    mockExtension({ status: 'installed', version: '0.2.0' });
     render(<MoodleConnectionSetup />);
-    expect(screen.getByPlaceholderText(/moodle/i)).toBeInTheDocument();
-    expect(screen.getByText(/connect/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/moodle url/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /connect/i }),
+    ).toBeInTheDocument();
   });
 
-  it('shows current connection when provided', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: true,
-      isChecking: false,
-    });
-
+  it('shows current connection when one is provided', () => {
+    mockExtension({ status: 'installed', version: '0.2.0' });
     render(
       <MoodleConnectionSetup
         currentConnection={{ domain: 'moodle.test.ac.il', instanceId: '123' }}
@@ -71,5 +83,70 @@ describe('MoodleConnectionSetup', () => {
     );
     expect(screen.getByText(/moodle\.test\.ac\.il/i)).toBeInTheDocument();
     expect(screen.getByText(/disconnect/i)).toBeInTheDocument();
+  });
+
+  it('calls requestPermission with the Moodle origin on Connect', async () => {
+    const requestPermission = vi.fn().mockResolvedValue(true);
+    mockExtension(
+      { status: 'installed', version: '0.2.0' },
+      { requestPermission },
+    );
+    vi.mocked(saveMoodleConnection).mockResolvedValue(undefined);
+
+    render(<MoodleConnectionSetup />);
+    await userEvent.type(
+      screen.getByLabelText(/moodle url/i),
+      'https://moodle.test.ac.il',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => {
+      expect(requestPermission).toHaveBeenCalledWith(
+        'https://moodle.test.ac.il',
+      );
+    });
+    expect(saveMoodleConnection).toHaveBeenCalledWith('moodle.test.ac.il');
+  });
+
+  it('shows permission-required error when the user denies the Chrome prompt', async () => {
+    const requestPermission = vi.fn().mockResolvedValue(false);
+    mockExtension(
+      { status: 'installed', version: '0.2.0' },
+      { requestPermission },
+    );
+
+    render(<MoodleConnectionSetup />);
+    await userEvent.type(
+      screen.getByLabelText(/moodle url/i),
+      'https://moodle.test.ac.il',
+    );
+    await userEvent.click(screen.getByRole('button', { name: /connect/i }));
+
+    await waitFor(() => expect(requestPermission).toHaveBeenCalled());
+    expect(saveMoodleConnection).not.toHaveBeenCalled();
+    expect(screen.getByText(/permission required/i)).toBeInTheDocument();
+  });
+
+  it('renders the Grant Access banner when an existing connection lacks permission', async () => {
+    const checkPermission = vi.fn().mockResolvedValue(false);
+    mockExtension(
+      { status: 'installed', version: '0.2.0' },
+      { checkPermission },
+    );
+
+    render(
+      <MoodleConnectionSetup
+        currentConnection={{ domain: 'moodle.test.ac.il', instanceId: '123' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(checkPermission).toHaveBeenCalledWith('https://moodle.test.ac.il');
+    });
+    expect(
+      screen.getByRole('button', {
+        name: /grant access to moodle\.test\.ac\.il/i,
+      }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/moodle-connection-setup.tsx
+++ b/src/components/dashboard/moodle-connection-setup.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -21,45 +21,42 @@ interface MoodleConnectionSetupProps {
 export function MoodleConnectionSetup({
   currentConnection,
 }: MoodleConnectionSetupProps) {
-  const { isInstalled, isChecking } = useMoodleExtension();
+  const { state, checkPermission, requestPermission } = useMoodleExtension();
   const [url, setUrl] = useState(
     currentConnection?.domain ? `https://${currentConnection.domain}` : '',
   );
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [permissionMissing, setPermissionMissing] = useState(false);
 
-  if (isChecking) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        Checking for Typenote extension...
-      </p>
-    );
+  // On mount with an existing connection, verify the extension still has host permission.
+  useEffect(() => {
+    if (!currentConnection || state.status !== 'installed') return;
+    let cancelled = false;
+    checkPermission(`https://${currentConnection.domain}`).then((granted) => {
+      if (!cancelled) setPermissionMissing(!granted);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentConnection, state.status, checkPermission]);
+
+  if (state.status === 'checking') {
+    return null;
   }
 
-  if (!isInstalled) {
-    return (
-      <div className="rounded-lg border border-dashed p-4 text-center">
-        <p className="text-sm font-medium">
-          Typenote Moodle Extension Required
-        </p>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Install the browser extension to sync your Moodle courses.
-        </p>
-        {/* TODO: Add Chrome Web Store link when published */}
-      </div>
-    );
+  // Parent (MoodleSyncPrompt) only renders us when state === 'installed', but be safe.
+  if (state.status !== 'installed') {
+    return null;
   }
 
   async function handleSave() {
     setError(null);
     setSaving(true);
-
     try {
-      // Parse and validate URL — keep host + base path (e.g. moodle.runi.ac.il/2026)
       let domain: string;
       try {
         const parsed = new URL(url.startsWith('http') ? url : `https://${url}`);
-        // Strip known Moodle paths to extract just the base prefix
         const basePath = parsed.pathname
           .replace(
             /\/(my|course|login|mod|lib|theme|admin|message|calendar|user|badges|grade|report|backup|blocks|question|tag|cohort|enrol|webservice|auth|completion|files|search)\b.*/,
@@ -79,7 +76,17 @@ export function MoodleConnectionSetup({
         return;
       }
 
+      const granted = await requestPermission(`https://${domain}`);
+      if (!granted) {
+        setError(
+          'Permission required. Allow access to this Moodle domain in the popup, or click Connect again.',
+        );
+        setSaving(false);
+        return;
+      }
+
       await saveMoodleConnection(domain);
+      setPermissionMissing(false);
       toast.success('Moodle connection saved');
     } catch (err) {
       setError(
@@ -90,10 +97,24 @@ export function MoodleConnectionSetup({
     }
   }
 
+  async function handleGrantExisting() {
+    if (!currentConnection) return;
+    const granted = await requestPermission(
+      `https://${currentConnection.domain}`,
+    );
+    if (granted) {
+      setPermissionMissing(false);
+      toast.success(`Access granted to ${currentConnection.domain}`);
+    } else {
+      toast.error('Permission required. Try again from chrome://extensions.');
+    }
+  }
+
   async function handleRemove() {
     try {
       await removeMoodleConnection();
       setUrl('');
+      setPermissionMissing(false);
       toast.success('Moodle connection removed');
     } catch (err) {
       toast.error(
@@ -128,6 +149,18 @@ export function MoodleConnectionSetup({
           </span>
           <Button variant="ghost" size="sm" onClick={handleRemove}>
             Disconnect
+          </Button>
+        </div>
+      )}
+
+      {currentConnection && permissionMissing && (
+        <div className="flex items-center justify-between rounded-md border border-amber-400/40 bg-amber-50 dark:bg-amber-950/30 px-3 py-2">
+          <p className="text-sm">
+            The extension needs access to{' '}
+            <strong>{currentConnection.domain}</strong> to sync.
+          </p>
+          <Button size="sm" onClick={handleGrantExisting}>
+            Grant access to {currentConnection.domain}
           </Button>
         </div>
       )}

--- a/src/components/dashboard/moodle-sync-dialog.test.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.test.tsx
@@ -271,7 +271,7 @@ describe('MoodleSyncDialog', () => {
   it('shows error and retry button on scrape failure', async () => {
     const mockScrape = vi
       .fn()
-      .mockRejectedValue(new Error('Extension timeout'));
+      .mockRejectedValue(new Error('Extension crashed'));
     mockUseMoodleExtension.mockReturnValue({
       scrapeCourses: mockScrape,
     });
@@ -285,10 +285,172 @@ describe('MoodleSyncDialog', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent('Extension timeout');
+      expect(screen.getByRole('alert')).toHaveTextContent('Extension crashed');
     });
 
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it('shows friendly network message when error matches network patterns', async () => {
+    const mockScrape = vi.fn().mockRejectedValue(new Error('fetch failed'));
+    mockUseMoodleExtension.mockReturnValue({
+      scrapeCourses: mockScrape,
+    });
+
+    render(
+      <MoodleSyncDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        moodleConnection={mockConnection}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /Couldn't reach moodle\.test\.ac\.il/i,
+      );
+    });
+  });
+
+  it('shows Retry failed button after partial sync and re-runs only failed jobs', async () => {
+    const user = userEvent.setup();
+    const mockScrape = vi.fn().mockResolvedValue(mockScrapedCourses);
+    const mockScrapeContent = vi.fn().mockResolvedValue({
+      sections: [
+        {
+          moodleSectionId: 'sec-1',
+          title: 'Week 1',
+          position: 0,
+          items: [
+            {
+              type: 'file' as const,
+              name: 'good.pdf',
+              moodleUrl: 'https://moodle.test.ac.il/file/good',
+            },
+            {
+              type: 'file' as const,
+              name: 'bad.pdf',
+              moodleUrl: 'https://moodle.test.ac.il/file/bad',
+            },
+          ],
+        },
+      ],
+    });
+    // First call: good succeeds, bad fails. Second call (retry): bad succeeds.
+    const mockDownloadAndUpload = vi
+      .fn()
+      .mockResolvedValueOnce(undefined) // good.pdf
+      .mockRejectedValueOnce(new Error('network exploded')) // bad.pdf
+      .mockResolvedValueOnce(undefined); // bad.pdf retry
+    mockUseMoodleExtension.mockReturnValue({
+      scrapeCourses: mockScrape,
+      scrapeCourseContent: mockScrapeContent,
+      downloadAndUpload: mockDownloadAndUpload,
+    });
+    mockCompare.mockResolvedValue(mockComparisons);
+    mockSync.mockResolvedValue({
+      syncedCount: 1,
+      courses: [
+        {
+          moodleCourseId: 'CS101',
+          sections: [
+            {
+              id: 'section-db-1',
+              moodleSectionId: 'sec-1',
+              items: [
+                { moodleUrl: 'https://moodle.test.ac.il/file/good' },
+                { moodleUrl: 'https://moodle.test.ac.il/file/bad' },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <MoodleSyncDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        moodleConnection={mockConnection}
+      />,
+    );
+
+    // Wait for course list, then preview content
+    await waitFor(() => {
+      expect(screen.getByText('Intro to CS')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /preview content/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('good.pdf')).toBeInTheDocument();
+      expect(screen.getByText('bad.pdf')).toBeInTheDocument();
+    });
+
+    // Trigger sync
+    await user.click(screen.getByRole('button', { name: /sync selected/i }));
+
+    // Wait for done phase with retry button
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /retry failed \(1\)/i }),
+      ).toBeInTheDocument();
+    });
+
+    // downloadAndUpload was called twice (one per file)
+    expect(mockDownloadAndUpload).toHaveBeenCalledTimes(2);
+
+    // Click retry — should re-run only the failed job (bad.pdf)
+    await user.click(screen.getByRole('button', { name: /retry failed/i }));
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: /retry failed/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    // 3rd call should be only for bad.pdf
+    expect(mockDownloadAndUpload).toHaveBeenCalledTimes(3);
+    const thirdCallArg = mockDownloadAndUpload.mock.calls[2][0];
+    expect(thirdCallArg.moodleFileUrl).toBe(
+      'https://moodle.test.ac.il/file/bad',
+    );
+
+    // Close button should still be present (footer Close, not the dialog X)
+    expect(
+      screen.getAllByRole('button', { name: /close/i }).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows Grant Permission button when scrape fails with permission error', async () => {
+    const user = userEvent.setup();
+    const mockScrape = vi
+      .fn()
+      .mockRejectedValue(new Error('permission denied for host'));
+    const mockRequestPermission = vi.fn().mockResolvedValue(true);
+    mockUseMoodleExtension.mockReturnValue({
+      scrapeCourses: mockScrape,
+      requestPermission: mockRequestPermission,
+    });
+
+    render(
+      <MoodleSyncDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        moodleConnection={mockConnection}
+      />,
+    );
+
+    // Grant Permission button shows on the permission-error path
+    const grantButton = await screen.findByRole('button', {
+      name: /grant permission/i,
+    });
+    expect(grantButton).toBeInTheDocument();
+
+    // Clicking it calls requestPermission with the correct origin
+    await user.click(grantButton);
+    expect(mockRequestPermission).toHaveBeenCalledWith(
+      'https://moodle.test.ac.il',
+    );
   });
 
   it('disables sync button when no courses are selected', async () => {

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -77,6 +77,24 @@ function isAuthError(message: string): boolean {
   return AUTH_ERROR_PATTERNS.some((p) => lower.includes(p));
 }
 
+const NETWORK_ERROR_PATTERNS = ['network', 'fetch', 'timeout', 'offline'];
+
+function isNetworkError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return NETWORK_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+
+const PERMISSION_ERROR_PATTERNS = [
+  'permission',
+  'host not allowed',
+  'no access',
+];
+
+function isPermissionError(message: string): boolean {
+  const lower = message.toLowerCase();
+  return PERMISSION_ERROR_PATTERNS.some((p) => lower.includes(p));
+}
+
 const STATUS_BADGE_MAP: Record<
   CourseComparisonStatus,
   { label: string; variant: 'default' | 'secondary' | 'outline' }
@@ -92,8 +110,12 @@ export function MoodleSyncDialog({
   onOpenChange,
   moodleConnection,
 }: MoodleSyncDialogProps) {
-  const { scrapeCourses, scrapeCourseContent, downloadAndUpload } =
-    useMoodleExtension();
+  const {
+    scrapeCourses,
+    scrapeCourseContent,
+    downloadAndUpload,
+    requestPermission,
+  } = useMoodleExtension();
   const supabaseRef = useRef(createClient());
 
   const [phase, setPhase] = useState<DialogPhase>('scraping');
@@ -103,6 +125,9 @@ export function MoodleSyncDialog({
   );
   const [error, setError] = useState<string | null>(null);
   const [authError, setAuthError] = useState(false);
+  const [networkError, setNetworkError] = useState(false);
+  const [permissionError, setPermissionError] = useState(false);
+  const [debugInfo, setDebugInfo] = useState<string | null>(null);
   const [progress, setProgress] = useState('');
 
   // Phase 2: content selection
@@ -130,6 +155,9 @@ export function MoodleSyncDialog({
   const [downloadedCount, setDownloadedCount] = useState(0);
   const [failedCount, setFailedCount] = useState(0);
   const [totalFileJobs, setTotalFileJobs] = useState(0);
+  const [failedJobs, setFailedJobs] = useState<
+    Array<{ moodleUrl: string; fileName: string; sectionId: string }>
+  >([]);
 
   // ---- Helpers for content selection ----
   function sectionKey(courseId: string, sectionId: string) {
@@ -268,6 +296,9 @@ export function MoodleSyncDialog({
   const loadCourses = useCallback(async () => {
     setError(null);
     setAuthError(false);
+    setNetworkError(false);
+    setPermissionError(false);
+    setDebugInfo(null);
     setCourses([]);
     setSelectedCourseIds(new Set());
 
@@ -288,15 +319,15 @@ export function MoodleSyncDialog({
       }
 
       if (scrapeResult.courses.length === 0) {
+        setError('No courses found on Moodle.');
         const debug = (scrapeResult as Record<string, unknown>)._debug as
           | { title: string; url: string; cardCount: number }
           | undefined;
-        setError(
-          `No courses found. ` +
-            (debug
-              ? `Page: "${debug.title}" at ${debug.url} (${debug.cardCount} cards)`
-              : 'No debug info available.'),
-        );
+        if (debug) {
+          setDebugInfo(
+            `Page: "${debug.title}" at ${debug.url} (${debug.cardCount} cards)`,
+          );
+        }
         setPhase('error');
         return;
       }
@@ -322,6 +353,8 @@ export function MoodleSyncDialog({
         err instanceof Error ? err.message : 'Failed to load courses';
       setError(message);
       setAuthError(isAuthError(message));
+      setNetworkError(isNetworkError(message) && !isAuthError(message));
+      setPermissionError(isPermissionError(message) && !isAuthError(message));
       setPhase('error');
     }
   }, [scrapeCourses, moodleConnection.domain]);
@@ -431,14 +464,61 @@ export function MoodleSyncDialog({
         err instanceof Error ? err.message : 'Failed to scrape content';
       setError(message);
       setAuthError(isAuthError(message));
+      setNetworkError(isNetworkError(message) && !isAuthError(message));
+      setPermissionError(isPermissionError(message) && !isAuthError(message));
       setPhase('error');
     }
   }
 
   // ---- Phase 3: Sync selected content ----
+  async function runDownloadJobs(
+    jobs: Array<{ moodleUrl: string; fileName: string; sectionId: string }>,
+    authToken: string | undefined,
+    uploadEndpoint: string,
+  ): Promise<{
+    downloaded: number;
+    failed: number;
+    failedJobs: typeof jobs;
+    errors: string[];
+  }> {
+    let downloaded = 0;
+    let failed = 0;
+    const errors: string[] = [];
+    const newFailed: typeof jobs = [];
+
+    for (const job of jobs) {
+      try {
+        await downloadAndUpload({
+          moodleFileUrl: job.moodleUrl,
+          uploadEndpoint,
+          authToken,
+          metadata: {
+            sectionId: job.sectionId,
+            moodleUrl: job.moodleUrl,
+            fileName: job.fileName,
+          },
+        });
+        downloaded++;
+      } catch (dlErr) {
+        failed++;
+        if (errors.length < 3) {
+          errors.push(
+            `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
+          );
+        }
+        newFailed.push(job);
+      }
+      setProgress(
+        `Downloading files... (${downloaded + failed}/${jobs.length})`,
+      );
+    }
+    return { downloaded, failed, failedJobs: newFailed, errors };
+  }
+
   async function handleSync() {
     setPhase('syncing');
     setError(null);
+    setFailedJobs([]);
     setProgress('Saving to registry...');
 
     try {
@@ -514,7 +594,6 @@ export function MoodleSyncDialog({
       let failed = 0;
       const errors: string[] = [];
       if (fileJobs.length > 0) {
-        // Get auth token for extension → API upload
         const {
           data: { session },
         } = await supabaseRef.current.auth.getSession();
@@ -522,32 +601,15 @@ export function MoodleSyncDialog({
         const uploadEndpoint = `${window.location.origin}/api/moodle/upload`;
 
         setProgress(`Downloading files... (0/${fileJobs.length})`);
-        for (const job of fileJobs) {
-          try {
-            // Extension downloads from Moodle (with cookies) and uploads directly to our API
-            await downloadAndUpload({
-              moodleFileUrl: job.moodleUrl,
-              uploadEndpoint,
-              authToken,
-              metadata: {
-                sectionId: job.sectionId,
-                moodleUrl: job.moodleUrl,
-                fileName: job.fileName,
-              },
-            });
-            downloaded++;
-          } catch (dlErr) {
-            failed++;
-            if (errors.length < 3) {
-              errors.push(
-                `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
-              );
-            }
-          }
-          setProgress(
-            `Downloading files... (${downloaded + failed}/${fileJobs.length})`,
-          );
-        }
+        const dlResult = await runDownloadJobs(
+          fileJobs,
+          authToken,
+          uploadEndpoint,
+        );
+        downloaded = dlResult.downloaded;
+        failed = dlResult.failed;
+        errors.push(...dlResult.errors);
+        setFailedJobs(dlResult.failedJobs);
       }
 
       setSyncedCount(result.syncedCount);
@@ -561,8 +623,50 @@ export function MoodleSyncDialog({
       const message = err instanceof Error ? err.message : 'Sync failed';
       setError(message);
       setAuthError(isAuthError(message));
+      setNetworkError(isNetworkError(message) && !isAuthError(message));
+      setPermissionError(isPermissionError(message) && !isAuthError(message));
       setPhase('error');
     }
+  }
+
+  async function handleGrantPermission() {
+    const granted = await requestPermission(
+      `https://${moodleConnection.domain}`,
+    );
+    if (granted) {
+      setPermissionError(false);
+      loadCourses();
+    } else {
+      setError(
+        `Permission still denied for ${moodleConnection.domain}. Try granting via chrome://extensions.`,
+      );
+    }
+  }
+
+  async function handleRetryFailed() {
+    if (failedJobs.length === 0) return;
+    setPhase('syncing');
+    setError(null);
+    setProgress(`Retrying ${failedJobs.length} failed file(s)...`);
+
+    const {
+      data: { session },
+    } = await supabaseRef.current.auth.getSession();
+    const authToken = session?.access_token;
+    const uploadEndpoint = `${window.location.origin}/api/moodle/upload`;
+
+    const result = await runDownloadJobs(failedJobs, authToken, uploadEndpoint);
+    setDownloadedCount((prev) => prev + result.downloaded);
+    setFailedCount(result.failed);
+    setFailedJobs(result.failedJobs);
+    if (result.errors.length > 0) {
+      setError(
+        `${result.failed} file(s) still failed:\n${result.errors.join('\n')}`,
+      );
+    } else {
+      setError(null);
+    }
+    setPhase('done');
   }
 
   // ---- Render ----
@@ -872,7 +976,9 @@ export function MoodleSyncDialog({
                 className="text-sm text-destructive whitespace-pre-wrap"
                 role="alert"
               >
-                {error}
+                {networkError && !authError
+                  ? `Couldn't reach ${moodleConnection.domain}. Check your internet and try again.`
+                  : error}
               </p>
               {authError && (
                 <p className="text-xs text-muted-foreground">
@@ -887,6 +993,23 @@ export function MoodleSyncDialog({
                   </a>{' '}
                   and try again.
                 </p>
+              )}
+              {permissionError && (
+                <div className="flex items-center gap-2">
+                  <p className="text-xs text-muted-foreground flex-1">
+                    The extension lost access to {moodleConnection.domain}.
+                    Grant permission again to continue.
+                  </p>
+                  <Button size="sm" onClick={handleGrantPermission}>
+                    Grant Permission
+                  </Button>
+                </div>
+              )}
+              {debugInfo && (
+                <details className="text-xs text-muted-foreground">
+                  <summary className="cursor-pointer">Debug info</summary>
+                  <pre className="mt-1 whitespace-pre-wrap">{debugInfo}</pre>
+                </details>
               )}
             </div>
           )}
@@ -915,7 +1038,14 @@ export function MoodleSyncDialog({
             </div>
           )}
           {phase === 'done' && (
-            <Button onClick={() => onOpenChange(false)}>Close</Button>
+            <div className="flex gap-2">
+              {failedJobs.length > 0 && (
+                <Button variant="outline" onClick={handleRetryFailed}>
+                  Retry failed ({failedJobs.length})
+                </Button>
+              )}
+              <Button onClick={() => onOpenChange(false)}>Close</Button>
+            </div>
           )}
           {phase === 'error' && (
             <Button variant="outline" onClick={loadCourses}>

--- a/src/components/dashboard/moodle-sync-prompt-wrapper.tsx
+++ b/src/components/dashboard/moodle-sync-prompt-wrapper.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { MoodleSyncPrompt } from './moodle-sync-prompt';
 import { MoodleSyncDialog } from './moodle-sync-dialog';
+import { ExtensionGate } from './extension-gate';
 
 interface MoodleSyncPromptWrapperProps {
   moodleConnection: { domain: string; instanceId: string } | null;
@@ -18,7 +19,7 @@ export function MoodleSyncPromptWrapper({
   }
 
   return (
-    <>
+    <ExtensionGate>
       <MoodleSyncPrompt
         moodleConnection={moodleConnection}
         onSyncClick={handleSyncClick}
@@ -30,6 +31,6 @@ export function MoodleSyncPromptWrapper({
           moodleConnection={moodleConnection}
         />
       )}
-    </>
+    </ExtensionGate>
   );
 }

--- a/src/components/dashboard/moodle-sync-prompt.test.tsx
+++ b/src/components/dashboard/moodle-sync-prompt.test.tsx
@@ -1,134 +1,79 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import { MoodleSyncPrompt } from './moodle-sync-prompt';
+import { render, screen } from '@testing-library/react';
+import type { ExtensionState } from '@/hooks/use-moodle-extension';
 
-// Mock the hook
 vi.mock('@/hooks/use-moodle-extension', () => ({
   useMoodleExtension: vi.fn(),
-}));
-
-// Mock the MoodleConnectionSetup component (avoids needing to mock its server action imports)
-vi.mock('./moodle-connection-setup', () => ({
-  MoodleConnectionSetup: () => (
-    <div data-testid="moodle-connection-setup">Moodle Connection Setup</div>
-  ),
+  EXPECTED_EXTENSION_VERSION: '0.2.0',
 }));
 
 import { useMoodleExtension } from '@/hooks/use-moodle-extension';
+import { MoodleSyncPrompt } from './moodle-sync-prompt';
 
-const mockUseMoodleExtension = useMoodleExtension as ReturnType<typeof vi.fn>;
+function setState(state: ExtensionState) {
+  vi.mocked(useMoodleExtension).mockReturnValue({
+    state,
+    isInstalled: state.status === 'installed',
+    isChecking: state.status === 'checking',
+    ping: vi.fn(),
+    checkPermission: vi.fn(),
+    requestPermission: vi.fn(),
+    checkMoodleLogin: vi.fn(),
+    scrapeCourses: vi.fn(),
+    scrapeCourseContent: vi.fn(),
+    downloadAndUpload: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any);
+}
 
-const mockConnection = { domain: 'moodle.test.ac.il', instanceId: 'inst-123' };
+beforeEach(() => vi.clearAllMocks());
 
 describe('MoodleSyncPrompt', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-  });
-
-  it('renders nothing while checking extension', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: false,
-      isChecking: true,
-      checkMoodleLogin: vi.fn(),
-    });
-
+  it('renders the skeleton while extension is checking', () => {
+    setState({ status: 'checking' });
     const { container } = render(
-      <MoodleSyncPrompt moodleConnection={null} onSyncClick={vi.fn()} />,
+      <MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />,
     );
-    expect(container.innerHTML).toBe('');
+    expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
   });
 
-  it('shows install message when extension is not installed', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: false,
-      isChecking: false,
-      checkMoodleLogin: vi.fn(),
-    });
-
-    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={vi.fn()} />);
+  it('renders the Install card when extension is not installed', () => {
+    setState({ status: 'not-installed' });
+    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
     expect(
-      screen.getByText(/install the typenote browser extension/i),
+      screen.getByText(/install the typenote extension/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/install extension/i)).toBeInTheDocument();
-  });
-
-  it('shows setup message when extension is installed but no connection', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: true,
-      isChecking: false,
-    });
-
-    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={vi.fn()} />);
     expect(
-      screen.getByText(/enter your moodle url to start syncing courses/i),
+      screen.getByRole('button', { name: /install extension/i }),
+    ).toBeDisabled();
+  });
+
+  it('renders the Update card with both versions when version mismatches', () => {
+    setState({ status: 'version-mismatch', installedVersion: '0.1.0' });
+    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
+    expect(
+      screen.getByText(/update the typenote extension/i),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('moodle-connection-setup')).toBeInTheDocument();
+    expect(screen.getByText(/0\.1\.0/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.2\.0/)).toBeInTheDocument();
   });
 
-  it('shows sync button immediately when extension is installed and connection exists', () => {
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: true,
-      isChecking: false,
-    });
-
-    render(
-      <MoodleSyncPrompt
-        moodleConnection={mockConnection}
-        onSyncClick={vi.fn()}
-      />,
-    );
-
-    expect(screen.getByText(/connected to/i)).toBeInTheDocument();
-    expect(screen.getByText('moodle.test.ac.il')).toBeInTheDocument();
-    expect(screen.getByText(/sync with moodle/i)).toBeInTheDocument();
+  it('renders the connection-setup card when extension is installed but not connected', () => {
+    setState({ status: 'installed', version: '0.2.0' });
+    render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
+    expect(screen.getByLabelText(/moodle url/i)).toBeInTheDocument();
   });
 
-  it('shows sync button when extension is installed, connection exists, and logged in', async () => {
-    const mockCheckLogin = vi.fn().mockResolvedValue({ loggedIn: true });
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: true,
-      isChecking: false,
-      checkMoodleLogin: mockCheckLogin,
-    });
-
+  it('renders the Sync button when extension is installed AND connected', () => {
+    setState({ status: 'installed', version: '0.2.0' });
     render(
       <MoodleSyncPrompt
-        moodleConnection={mockConnection}
-        onSyncClick={vi.fn()}
+        moodleConnection={{ domain: 'moodle.test.ac.il', instanceId: 'abc' }}
+        onSyncClick={() => {}}
       />,
     );
-
-    await waitFor(() => {
-      expect(screen.getByText(/sync with moodle/i)).toBeInTheDocument();
-    });
-
-    expect(screen.getByText(/connected to/i)).toBeInTheDocument();
-    expect(screen.getByText('moodle.test.ac.il')).toBeInTheDocument();
-  });
-
-  it('calls onSyncClick when sync button is clicked', async () => {
-    const mockCheckLogin = vi.fn().mockResolvedValue({ loggedIn: true });
-    const onSyncClick = vi.fn();
-    mockUseMoodleExtension.mockReturnValue({
-      isInstalled: true,
-      isChecking: false,
-      checkMoodleLogin: mockCheckLogin,
-    });
-
-    render(
-      <MoodleSyncPrompt
-        moodleConnection={mockConnection}
-        onSyncClick={onSyncClick}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(/sync with moodle/i)).toBeInTheDocument();
-    });
-
-    const user = userEvent.setup();
-    await user.click(screen.getByRole('button', { name: /sync with moodle/i }));
-    expect(onSyncClick).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole('button', { name: /sync with moodle/i }),
+    ).toBeInTheDocument();
   });
 });

--- a/src/components/dashboard/moodle-sync-prompt.tsx
+++ b/src/components/dashboard/moodle-sync-prompt.tsx
@@ -8,7 +8,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { useMoodleExtension } from '@/hooks/use-moodle-extension';
+import {
+  useMoodleExtension,
+  EXPECTED_EXTENSION_VERSION,
+} from '@/hooks/use-moodle-extension';
+import { MoodleCardSkeleton } from './moodle-card-skeleton';
 import { MoodleConnectionSetup } from './moodle-connection-setup';
 
 interface MoodleSyncPromptProps {
@@ -20,34 +24,62 @@ export function MoodleSyncPrompt({
   moodleConnection,
   onSyncClick,
 }: MoodleSyncPromptProps) {
-  const { isInstalled, isChecking } = useMoodleExtension();
+  const { state } = useMoodleExtension();
 
-  if (isChecking) {
-    return null;
+  if (state.status === 'checking') {
+    return <MoodleCardSkeleton />;
   }
 
-  if (!isInstalled) {
+  if (state.status === 'not-installed') {
     return (
-      <Card className="p-6">
+      <Card>
         <CardHeader>
           <CardTitle className="text-base">Moodle Integration</CardTitle>
           <CardDescription>
-            Install the Typenote browser extension to sync your Moodle courses
-            and materials automatically.
+            Install the Typenote extension to sync your Moodle courses and
+            materials automatically.
           </CardDescription>
         </CardHeader>
         <CardContent>
           <Button variant="outline" size="sm" disabled>
             Install Extension
           </Button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Coming soon to the Chrome Web Store. Refresh this page after
+            installing.
+          </p>
         </CardContent>
       </Card>
     );
   }
 
+  if (state.status === 'version-mismatch') {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Moodle Integration</CardTitle>
+          <CardDescription>
+            Update the Typenote extension to continue syncing. Installed
+            version: <strong>{state.installedVersion}</strong>. Required:{' '}
+            <strong>{EXPECTED_EXTENSION_VERSION}</strong>.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" size="sm" disabled>
+            Update Extension
+          </Button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Refresh this page after updating.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // state.status === 'installed'
   if (!moodleConnection) {
     return (
-      <Card className="p-6">
+      <Card>
         <CardHeader>
           <CardTitle className="text-base">Moodle Integration</CardTitle>
           <CardDescription>
@@ -62,7 +94,7 @@ export function MoodleSyncPrompt({
   }
 
   return (
-    <Card className="p-6">
+    <Card>
       <CardHeader>
         <CardTitle className="text-base">Moodle Integration</CardTitle>
         <CardDescription>
@@ -71,7 +103,7 @@ export function MoodleSyncPrompt({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <Button variant="default" onClick={onSyncClick}>
+        <Button size="sm" onClick={onSyncClick}>
           Sync with Moodle
         </Button>
       </CardContent>

--- a/src/hooks/use-extension-platform.test.ts
+++ b/src/hooks/use-extension-platform.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const originalMatchMedia = globalThis.window?.matchMedia;
+const originalChrome = (globalThis as Record<string, unknown>).chrome;
+
+function setPointerFine(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query === '(pointer: fine)' ? matches : false,
+    media: query,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    onchange: null,
+  }));
+}
+
+function setChromeRuntime(present: boolean) {
+  if (present) {
+    (globalThis as Record<string, unknown>).chrome = {
+      runtime: { sendMessage: vi.fn() },
+    };
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+}
+
+beforeEach(() => {
+  setPointerFine(true);
+  setChromeRuntime(true);
+});
+
+afterEach(() => {
+  if (originalMatchMedia) window.matchMedia = originalMatchMedia;
+  if (originalChrome) {
+    (globalThis as Record<string, unknown>).chrome = originalChrome;
+  } else {
+    delete (globalThis as Record<string, unknown>).chrome;
+  }
+});
+
+const { useExtensionPlatform } = await import('./use-extension-platform');
+
+describe('useExtensionPlatform', () => {
+  it('returns true on Chromium desktop (pointer-fine + chrome.runtime)', () => {
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(true);
+  });
+
+  it('returns false on touch-primary devices (iPad/mobile)', () => {
+    setPointerFine(false);
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(false);
+  });
+
+  it('returns false on non-Chromium desktop (no chrome.runtime)', () => {
+    setChromeRuntime(false);
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(false);
+  });
+
+  it('returns false when chrome exists but sendMessage is missing', () => {
+    (globalThis as Record<string, unknown>).chrome = { runtime: {} };
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(false);
+  });
+});

--- a/src/hooks/use-extension-platform.ts
+++ b/src/hooks/use-extension-platform.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+interface ExtensionPlatform {
+  isSupportedPlatform: boolean;
+}
+
+function getSnapshot(): boolean {
+  if (typeof window === 'undefined') return false;
+  const pointerFine = window.matchMedia?.('(pointer: fine)').matches ?? false;
+  const chromeRuntime = (window as unknown as { chrome?: typeof chrome }).chrome
+    ?.runtime;
+  const hasChromeRuntime = typeof chromeRuntime?.sendMessage === 'function';
+  return pointerFine && hasChromeRuntime;
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === 'undefined' || !window.matchMedia) return () => {};
+  const mql = window.matchMedia('(pointer: fine)');
+  mql.addEventListener('change', callback);
+  return () => mql.removeEventListener('change', callback);
+}
+
+/**
+ * Returns whether the current device can host the Typenote Moodle extension.
+ * True only on Chromium-family desktop browsers with a fine pointer (mouse/trackpad).
+ * SSR-safe: returns false on the server, hydrates to the real value on the client.
+ */
+export function useExtensionPlatform(): ExtensionPlatform {
+  const isSupportedPlatform = useSyncExternalStore(
+    subscribe,
+    getSnapshot,
+    () => false,
+  );
+  return { isSupportedPlatform };
+}

--- a/src/hooks/use-moodle-extension.test.ts
+++ b/src/hooks/use-moodle-extension.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 
 // Set env var BEFORE importing the hook so the module-level constant picks it up
 vi.stubEnv('NEXT_PUBLIC_EXTENSION_ID', 'test-extension-id');
@@ -48,7 +48,7 @@ describe('useMoodleExtension', () => {
   it('detects extension as installed when ping succeeds', async () => {
     mockSendMessage.mockImplementation(
       (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
-        callback({ success: true, data: { version: '0.1.0' } });
+        callback({ success: true, data: { version: '0.2.0' } });
       },
     );
 
@@ -120,5 +120,102 @@ describe('useMoodleExtension', () => {
       'https://moodle.test.ac.il',
     );
     expect(data).toBeNull();
+  });
+
+  it('exposes state.status="installed" with version when ping succeeds at the expected version', async () => {
+    mockSendMessage.mockImplementation(
+      (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+        callback({ success: true, data: { version: '0.2.0' } });
+      },
+    );
+
+    const { result } = renderHook(() => useMoodleExtension());
+    await waitFor(() =>
+      expect(result.current.state.status).not.toBe('checking'),
+    );
+
+    expect(result.current.state).toEqual({
+      status: 'installed',
+      version: '0.2.0',
+    });
+    expect(result.current.isInstalled).toBe(true);
+  });
+
+  it('exposes state.status="version-mismatch" when ping returns a different version', async () => {
+    mockSendMessage.mockImplementation(
+      (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+        callback({ success: true, data: { version: '0.1.0' } });
+      },
+    );
+
+    const { result } = renderHook(() => useMoodleExtension());
+    await waitFor(() =>
+      expect(result.current.state.status).not.toBe('checking'),
+    );
+
+    expect(result.current.state).toEqual({
+      status: 'version-mismatch',
+      installedVersion: '0.1.0',
+    });
+    expect(result.current.isInstalled).toBe(false);
+  });
+
+  it('falls back to "not-installed" when the PING response is malformed', async () => {
+    mockSendMessage.mockImplementation(
+      (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+        callback({ success: true, data: {} });
+      },
+    );
+
+    const { result } = renderHook(() => useMoodleExtension());
+    await waitFor(() =>
+      expect(result.current.state.status).not.toBe('checking'),
+    );
+
+    expect(result.current.state.status).toBe('not-installed');
+  });
+
+  it('times out to "not-installed" after 2 seconds when the extension never responds', async () => {
+    vi.useFakeTimers();
+    mockSendMessage.mockImplementation(() => {
+      // never call the callback — simulates a hung extension
+    });
+
+    const { result } = renderHook(() => useMoodleExtension());
+
+    // Advance fake timers past the 2s timeout, wrapped in act so React
+    // flushes state updates that fire as a result of the timer advancing.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(result.current.state.status).toBe('not-installed');
+    vi.useRealTimers();
+  });
+});
+
+describe('useMoodleExtension when NEXT_PUBLIC_EXTENSION_ID is unset', () => {
+  it('treats the extension as not-installed and warns in dev', async () => {
+    vi.stubEnv('NEXT_PUBLIC_EXTENSION_ID', '');
+    const warnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    vi.resetModules();
+
+    const { useMoodleExtension: freshHook } =
+      await import('./use-moodle-extension');
+    const { result } = renderHook(() => freshHook());
+
+    await waitFor(() =>
+      expect(result.current.state.status).not.toBe('checking'),
+    );
+
+    expect(result.current.state.status).toBe('not-installed');
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('NEXT_PUBLIC_EXTENSION_ID'),
+    );
+
+    warnSpy.mockRestore();
+    vi.stubEnv('NEXT_PUBLIC_EXTENSION_ID', 'test-extension-id');
   });
 });

--- a/src/hooks/use-moodle-extension.ts
+++ b/src/hooks/use-moodle-extension.ts
@@ -3,19 +3,17 @@
 import { useState, useEffect, useCallback } from 'react';
 
 const EXTENSION_ID = process.env.NEXT_PUBLIC_EXTENSION_ID ?? '';
+export const EXPECTED_EXTENSION_VERSION = '0.2.0';
+const PING_TIMEOUT_MS = 2_000;
 
-interface ExtensionState {
-  isInstalled: boolean;
-  isChecking: boolean;
-}
+export type ExtensionState =
+  | { status: 'checking' }
+  | { status: 'installed'; version: string }
+  | { status: 'not-installed' }
+  | { status: 'version-mismatch'; installedVersion: string };
 
-/**
- * Send a message to the Typenote Moodle extension.
- * Returns null if extension is not installed.
- */
 async function sendExtensionMessage<T>(message: unknown): Promise<T | null> {
   if (!EXTENSION_ID) return null;
-
   return new Promise((resolve) => {
     try {
       chrome.runtime.sendMessage(EXTENSION_ID, message, (response: unknown) => {
@@ -31,33 +29,73 @@ async function sendExtensionMessage<T>(message: unknown): Promise<T | null> {
   });
 }
 
-export function useMoodleExtension() {
-  const [state, setState] = useState<ExtensionState>({
-    isInstalled: false,
-    isChecking: true,
+function withTimeout<T>(
+  promise: Promise<T | null>,
+  ms: number,
+): Promise<T | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms);
+    promise
+      .then((value) => {
+        clearTimeout(timer);
+        resolve(value);
+      })
+      .catch(() => {
+        clearTimeout(timer);
+        resolve(null);
+      });
   });
+}
 
-  // Ping extension on mount to check if installed
+export function useMoodleExtension() {
+  const [state, setState] = useState<ExtensionState>({ status: 'checking' });
+
   useEffect(() => {
+    let cancelled = false;
+
     async function checkExtension() {
-      const response = await sendExtensionMessage<{ success: boolean }>({
-        type: 'PING',
-      });
-      setState({
-        isInstalled: response?.success === true,
-        isChecking: false,
-      });
+      if (!EXTENSION_ID) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(
+            '[Typenote] NEXT_PUBLIC_EXTENSION_ID is not set. The Moodle extension will appear as not-installed. See .env.local.example.',
+          );
+        }
+        if (!cancelled) setState({ status: 'not-installed' });
+        return;
+      }
+
+      const response = await withTimeout(
+        sendExtensionMessage<{ success: boolean; data?: { version?: string } }>(
+          { type: 'PING' },
+        ),
+        PING_TIMEOUT_MS,
+      );
+
+      if (cancelled) return;
+
+      const version = response?.data?.version;
+      if (!response?.success || !version) {
+        setState({ status: 'not-installed' });
+        return;
+      }
+      if (version !== EXPECTED_EXTENSION_VERSION) {
+        setState({ status: 'version-mismatch', installedVersion: version });
+        return;
+      }
+      setState({ status: 'installed', version });
     }
-    checkExtension();
+
+    void checkExtension();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   const ping = useCallback(async () => {
     const response = await sendExtensionMessage<{
       success: boolean;
       data: { version: string };
-    }>({
-      type: 'PING',
-    });
+    }>({ type: 'PING' });
     return response?.success ? response.data : null;
   }, []);
 
@@ -178,7 +216,9 @@ export function useMoodleExtension() {
   );
 
   return {
-    ...state,
+    state,
+    isInstalled: state.status === 'installed',
+    isChecking: state.status === 'checking',
     ping,
     checkPermission,
     requestPermission,


### PR DESCRIPTION
## Summary

- Gates the Moodle UI behind `<ExtensionGate>` so it only renders on Chromium-family desktop browsers (silent hide on touch/non-Chromium).
- Upgrades `useMoodleExtension` to a discriminated-union state machine with a 2 s detection timeout and a version handshake against `EXPECTED_EXTENSION_VERSION` (`0.2.0`).
- Tightens `extension/manifest.json` — `<all_urls>` moves from `host_permissions` to `optional_host_permissions`. The connection setup now requests per-domain permission at runtime via `chrome.permissions.request()`.
- Adds `MoodleCardSkeleton` + new install/update card UI for the new detection states.
- Adds `<details>`-wrapped debug payload, friendlier network-error messaging, a "Retry failed" button, and a "Grant Permission" fallback inside `<MoodleSyncDialog>`.
- New Playwright spec asserts the Moodle card is hidden on touch viewports and visible on desktop.
- New `extension/QUICKSTART.md` documents local setup, a 10-step smoke flow, and a 3-flow pre-release manual checklist for real-credentials testing.

## Out of scope (deferred)

- Actual Chrome Web Store upload + listing.
- Wiring the "Install Extension" button to a real CWS URL.
- Auto-detection after install (today: refresh).

## Test plan

- [x] `pnpm test` — 818/818 unit tests pass
- [x] `pnpm test:e2e e2e/moodle-touch-gating.spec.ts` — 2/2 new tests pass
- [x] `pnpm build` — clean exit, all 26 routes compile
- [ ] `pnpm test:integration` — locally blocked by missing `document_versions` migration (Docker sandbox), unrelated to this branch; expected to pass in CI
- [ ] `pnpm test:e2e` (full suite) — locally blocked by port 3000 collision with an unrelated project; expected to pass in CI
- [ ] Manual smoke flow per `extension/QUICKSTART.md` steps 1–10 (requires real Moodle credentials)

Spec: `docs/superpowers/specs/2026-05-13-extension-readiness-design.md`
Plan: `docs/superpowers/plans/2026-05-13-extension-readiness.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)