### PR TITLE
test: real RLS isolation integration test

### DIFF
--- a/src/__tests__/integration/rls-isolation.integration.test.ts
+++ b/src/__tests__/integration/rls-isolation.integration.test.ts
@@ -1,0 +1,325 @@
+/**
+ * RLS isolation tests — verify Supabase Row-Level Security actually prevents
+ * one user from reading or modifying another user's data.
+ *
+ * Every other integration test in this repo runs as `service_role`, which
+ * bypasses RLS by design. That makes those tests great for verifying schema /
+ * cascade / trigger behaviour, but useless for verifying RLS policies — if a
+ * policy were removed entirely, every existing test would still pass.
+ *
+ * This file uses two real anon-key clients, each signed in as a different
+ * seeded user. Cross-user read attempts must return empty result sets;
+ * cross-user write attempts must either fail or affect zero rows (verified
+ * with the admin client). If any of these assertions fail, RLS has regressed.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+// Stable fixture IDs in a high range so they don't collide with seeded data.
+const FIXTURES = {
+  a: {
+    folderId: '7e000000-0000-0000-0000-00000000000a',
+    docId: '7e000000-0000-0000-0000-00000000001a',
+    courseId: '7e000000-0000-0000-0000-00000000002a',
+    weekId: '7e000000-0000-0000-0000-00000000003a',
+    materialId: '7e000000-0000-0000-0000-00000000004a',
+    conversationId: '7e000000-0000-0000-0000-00000000005a',
+    messageId: '7e000000-0000-0000-0000-00000000006a',
+    personalFileId: '7e000000-0000-0000-0000-00000000007a',
+    versionId: '7e000000-0000-0000-0000-00000000008a',
+  },
+  b: {
+    folderId: '7e000000-0000-0000-0000-00000000000b',
+    docId: '7e000000-0000-0000-0000-00000000001b',
+    courseId: '7e000000-0000-0000-0000-00000000002b',
+    weekId: '7e000000-0000-0000-0000-00000000003b',
+    materialId: '7e000000-0000-0000-0000-00000000004b',
+    conversationId: '7e000000-0000-0000-0000-00000000005b',
+    messageId: '7e000000-0000-0000-0000-00000000006b',
+    personalFileId: '7e000000-0000-0000-0000-00000000007b',
+    versionId: '7e000000-0000-0000-0000-00000000008b',
+  },
+} as const;
+
+describe('RLS isolation — cross-user access', () => {
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    clientB = await createUserClient(TEST_USER_B);
+
+    // Clean any leftover fixtures from a prior run.
+    await cleanupFixtures();
+
+    // Seed parallel fixtures, owned by each user respectively.
+    await seedFor(TEST_USER_A.id, FIXTURES.a);
+    await seedFor(TEST_USER_B.id, FIXTURES.b);
+  });
+
+  afterAll(async () => {
+    await cleanupFixtures();
+  });
+
+  // ─── documents ─────────────────────────────────────────────────────────
+
+  it('User A cannot read User B documents', async () => {
+    const { data, error } = await clientA
+      .from('documents')
+      .select()
+      .eq('id', FIXTURES.b.docId);
+    expect(error).toBeNull();
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('User A cannot update User B documents', async () => {
+    await clientA
+      .from('documents')
+      .update({ title: 'hacked-by-a' })
+      .eq('id', FIXTURES.b.docId);
+
+    const { data } = await admin
+      .from('documents')
+      .select('title')
+      .eq('id', FIXTURES.b.docId)
+      .single();
+    expect(data?.title).toBe(`B doc ${FIXTURES.b.docId}`);
+  });
+
+  it('User A cannot delete User B documents', async () => {
+    await clientA.from('documents').delete().eq('id', FIXTURES.b.docId);
+    const { data } = await admin
+      .from('documents')
+      .select('id')
+      .eq('id', FIXTURES.b.docId);
+    expect(data ?? []).toHaveLength(1);
+  });
+
+  it('User A cannot insert a document claiming User B ownership', async () => {
+    const { error } = await clientA.from('documents').insert({
+      id: '7e000000-0000-0000-0000-0000000000ff',
+      user_id: TEST_USER_B.id,
+      title: 'spoofed-by-a',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+    // RLS WITH CHECK should reject this. Either an error is raised or the
+    // row never lands — verify the latter explicitly.
+    const { data } = await admin
+      .from('documents')
+      .select('id')
+      .eq('id', '7e000000-0000-0000-0000-0000000000ff');
+    expect(data ?? []).toHaveLength(0);
+    expect(error).not.toBeNull();
+  });
+
+  // ─── folders ───────────────────────────────────────────────────────────
+
+  it('User A cannot read User B folders', async () => {
+    const { data } = await clientA
+      .from('folders')
+      .select()
+      .eq('id', FIXTURES.b.folderId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  // ─── courses + nested resources ────────────────────────────────────────
+
+  it('User A cannot read User B courses', async () => {
+    const { data } = await clientA
+      .from('courses')
+      .select()
+      .eq('id', FIXTURES.b.courseId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('User A cannot read User B course_weeks', async () => {
+    const { data } = await clientA
+      .from('course_weeks')
+      .select()
+      .eq('id', FIXTURES.b.weekId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('User A cannot read User B course_materials', async () => {
+    const { data } = await clientA
+      .from('course_materials')
+      .select()
+      .eq('id', FIXTURES.b.materialId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  // ─── personal_files ────────────────────────────────────────────────────
+
+  it('User A cannot read User B personal_files', async () => {
+    const { data } = await clientA
+      .from('personal_files')
+      .select()
+      .eq('id', FIXTURES.b.personalFileId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  // ─── ai_conversations + ai_messages ────────────────────────────────────
+
+  it('User A cannot read User B ai_conversations', async () => {
+    const { data } = await clientA
+      .from('ai_conversations')
+      .select()
+      .eq('id', FIXTURES.b.conversationId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('User A cannot read User B ai_messages', async () => {
+    const { data } = await clientA
+      .from('ai_messages')
+      .select()
+      .eq('id', FIXTURES.b.messageId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  // ─── document_versions ─────────────────────────────────────────────────
+
+  it('User A cannot read User B document_versions', async () => {
+    const { data } = await clientA
+      .from('document_versions')
+      .select()
+      .eq('id', FIXTURES.b.versionId);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  // ─── sanity: each client CAN see their own data ────────────────────────
+
+  it('each user CAN read their own document', async () => {
+    const { data: dataA } = await clientA
+      .from('documents')
+      .select()
+      .eq('id', FIXTURES.a.docId);
+    expect(dataA).toHaveLength(1);
+
+    const { data: dataB } = await clientB
+      .from('documents')
+      .select()
+      .eq('id', FIXTURES.b.docId);
+    expect(dataB).toHaveLength(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Fixture management — uses admin client to set up rows for both users.
+// ─────────────────────────────────────────────────────────────────────────
+
+type Fixtures = (typeof FIXTURES)['a'];
+
+async function seedFor(userId: string, ids: Fixtures): Promise<void> {
+  await admin.from('folders').insert({
+    id: ids.folderId,
+    user_id: userId,
+    name: `Folder ${ids.folderId}`,
+    color: '#000000',
+    position: 0,
+  });
+
+  await admin.from('documents').insert({
+    id: ids.docId,
+    user_id: userId,
+    folder_id: ids.folderId,
+    title: `B doc ${ids.docId}`.replace(
+      'B doc',
+      userId === TEST_USER_A.id ? 'A doc' : 'B doc',
+    ),
+    subject: 'other',
+    canvas_type: 'blank',
+    position: 0,
+  });
+
+  await admin.from('courses').insert({
+    id: ids.courseId,
+    user_id: userId,
+    name: `Course ${ids.courseId}`,
+    code: 'RLS-TEST',
+    semester: 'Spring 2026',
+    color: '#000000',
+    position: 0,
+  });
+
+  await admin.from('course_weeks').insert({
+    id: ids.weekId,
+    course_id: ids.courseId,
+    user_id: userId,
+    week_number: 1,
+    topic: 'RLS Test Week',
+  });
+
+  await admin.from('course_materials').insert({
+    id: ids.materialId,
+    week_id: ids.weekId,
+    user_id: userId,
+    category: 'material',
+    storage_path: `${userId}/rls-test.pdf`,
+    file_name: 'rls-test.pdf',
+    label: 'RLS Test',
+    file_size: 1024,
+    mime_type: 'application/pdf',
+  });
+
+  await admin.from('personal_files').insert({
+    id: ids.personalFileId,
+    user_id: userId,
+    storage_path: `${userId}/personal.pdf`,
+    file_name: 'personal.pdf',
+    file_size: 1024,
+    mime_type: 'application/pdf',
+  });
+
+  await admin.from('ai_conversations').insert({
+    id: ids.conversationId,
+    user_id: userId,
+    course_id: ids.courseId,
+    title: 'RLS test conversation',
+  });
+
+  await admin.from('ai_messages').insert({
+    id: ids.messageId,
+    conversation_id: ids.conversationId,
+    role: 'user',
+    content: 'rls-test',
+  });
+
+  await admin.from('document_versions').insert({
+    id: ids.versionId,
+    document_id: ids.docId,
+    user_id: userId,
+    content: { type: 'doc', content: [] },
+    pages: null,
+    label: null,
+    trigger: 'idle',
+  });
+}
+
+async function cleanupFixtures(): Promise<void> {
+  const ids = [
+    ...Object.values(FIXTURES.a),
+    ...Object.values(FIXTURES.b),
+    '7e000000-0000-0000-0000-0000000000ff',
+  ];
+  // Order matters for FK relationships — delete leaves before roots.
+  await admin.from('document_versions').delete().in('id', ids);
+  await admin.from('ai_messages').delete().in('id', ids);
+  await admin.from('ai_conversations').delete().in('id', ids);
+  await admin.from('personal_files').delete().in('id', ids);
+  await admin.from('course_materials').delete().in('id', ids);
+  await admin.from('course_weeks').delete().in('id', ids);
+  await admin.from('documents').delete().in('id', ids);
+  await admin.from('courses').delete().in('id', ids);
+  await admin.from('folders').delete().in('id', ids);
+}

--- a/src/lib/actions/conversations.integration.test.ts
+++ b/src/lib/actions/conversations.integration.test.ts
@@ -485,66 +485,8 @@ describe('Course deletion cascades to conversations', () => {
   });
 });
 
-describe('RLS blocks cross-user access', () => {
-  // RLS is enforced by Supabase when using the anon key with a user JWT.
-  // The admin (service_role) client bypasses RLS by design.
-  // To test RLS properly we switch the Postgres role via raw SQL,
-  // matching the pattern described in supabase-client.ts.
-
-  let conversationId: string;
-
-  beforeAll(async () => {
-    // Create a conversation owned by the test user
-    const { data } = await supabase
-      .from('ai_conversations')
-      .insert({
-        user_id: TEST_USER_ID,
-        course_id: COURSE_ID,
-        title: 'RLS test conversation',
-      })
-      .select()
-      .single();
-
-    conversationId = data!.id;
-    createdConversationIds.push(conversationId);
-  });
-
-  it('service_role client can see the conversation (bypasses RLS)', async () => {
-    const { data, error } = await supabase
-      .from('ai_conversations')
-      .select()
-      .eq('id', conversationId)
-      .single();
-
-    expect(error).toBeNull();
-    expect(data).toBeDefined();
-    expect(data!.id).toBe(conversationId);
-  });
-
-  it('RLS policies exist on ai_conversations', async () => {
-    // Verify the table has RLS enabled by querying pg_tables
-    const { error } = await supabase.rpc('check_rls_enabled').select();
-
-    if (error) {
-      // If the RPC doesn't exist, check that we can at least query the table
-      // (service_role bypasses RLS, so this proves the table exists and is queryable)
-      const { error: queryError } = await supabase
-        .from('ai_conversations')
-        .select('id')
-        .limit(1);
-      expect(queryError).toBeNull();
-    }
-  });
-
-  it('RLS policies exist on ai_messages', async () => {
-    const { error } = await supabase.rpc('check_rls_enabled').select();
-
-    if (error) {
-      const { error: queryError } = await supabase
-        .from('ai_messages')
-        .select('id')
-        .limit(1);
-      expect(queryError).toBeNull();
-    }
-  });
-});
+// Real cross-user RLS isolation is tested in
+// src/__tests__/integration/rls-isolation.integration.test.ts using two
+// anon-key clients with different user JWTs. Placeholder tests previously
+// here only verified the table was queryable by the admin client (which
+// bypasses RLS), so they could not detect a missing or broken policy.

--- a/src/lib/queries/crud.integration.test.ts
+++ b/src/lib/queries/crud.integration.test.ts
@@ -166,33 +166,7 @@ describe('Documents CRUD', () => {
   });
 });
 
-describe('RLS policies exist', () => {
-  it('all main tables have RLS enabled', async () => {
-    const { data, error } = await supabase.rpc('check_rls_enabled');
-
-    // If the RPC doesn't exist, fall back to checking via PostgREST
-    // behavior: admin client bypasses RLS so we just verify policies
-    // exist by checking the pg_policies catalog
-    if (error) {
-      // Query pg_policies directly to verify RLS policies exist
-      const tables = [
-        'profiles',
-        'folders',
-        'documents',
-        'courses',
-        'course_weeks',
-        'course_materials',
-      ];
-
-      for (const table of tables) {
-        // If we can query the table with admin client, the table exists
-        const { error: queryError } = await supabase
-          .from(table)
-          .select('id')
-          .limit(1);
-
-        expect(queryError).toBeNull();
-      }
-    }
-  });
-});
+// Cross-user RLS isolation is tested in
+// src/__tests__/integration/rls-isolation.integration.test.ts. The previous
+// placeholder test here used the admin client, which bypasses RLS, and so
+// could not detect a regression in any policy.

--- a/src/test/supabase-client.ts
+++ b/src/test/supabase-client.ts
@@ -36,3 +36,48 @@ export const DATABASE_URL = DB_URL;
 
 /** The user_id of the seeded test user (from seed.sql) */
 export const TEST_USER_ID = 'ac3be77d-4566-406c-9ac0-7c410634ad41';
+
+/** Seeded test user A — used as the "default" user across integration tests. */
+export const TEST_USER_A = {
+  id: 'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  email: 'test@typenote.dev',
+  password: 'Test1234',
+} as const;
+
+/** Seeded test user B — used for cross-user (RLS isolation) testing. */
+export const TEST_USER_B = {
+  id: 'bd4ce88e-5677-507d-ad1d-8d4275a45b52',
+  email: 'test-b@typenote.dev',
+  password: 'Test1234',
+} as const;
+
+/** Supabase anon key (local dev). CI overrides via env. */
+export const SUPABASE_ANON_KEY =
+  process.env.SUPABASE_ANON_KEY ??
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0';
+
+/**
+ * Build an anon-key client and sign it in as the given seeded user.
+ * All requests this client makes will carry the user's JWT, so RLS applies
+ * exactly as it would for that user in the real app. Use this — not the
+ * admin client — to test RLS policies.
+ */
+export async function createUserClient(user: {
+  email: string;
+  password: string;
+}): Promise<SupabaseClient> {
+  const client = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { error } = await client.auth.signInWithPassword({
+    email: user.email,
+    password: user.password,
+  });
+  if (error) {
+    throw new Error(
+      `Failed to sign in ${user.email}: ${error.message}. Did you re-run supabase/seed.sql after adding test-b?`,
+    );
+  }
+  return client;
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -65,6 +65,71 @@ INSERT INTO auth.identities (
 -- Set the test user's subscription tier (default is 'free', explicit for clarity).
 UPDATE public.profiles SET subscription_tier = 'free' WHERE id = 'ac3be77d-4566-406c-9ac0-7c410634ad41';
 
+-- ============================================
+-- SECOND TEST USER (for RLS isolation tests)
+-- Email: test-b@typenote.dev | Password: Test1234
+-- ============================================
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  recovery_token,
+  email_change,
+  email_change_token_new,
+  email_change_token_current,
+  email_change_confirm_status
+) VALUES (
+  'bd4ce88e-5677-507d-ad1d-8d4275a45b52',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'test-b@typenote.dev',
+  crypt('Test1234', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{"email":"test-b@typenote.dev","email_verified":true,"full_name":"Test User B"}',
+  now(),
+  now(),
+  '',
+  '',
+  '',
+  '',
+  '',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.identities (
+  id,
+  user_id,
+  identity_data,
+  provider,
+  provider_id,
+  last_sign_in_at,
+  created_at,
+  updated_at
+) VALUES (
+  'bd4ce88e-5677-507d-ad1d-8d4275a45b52',
+  'bd4ce88e-5677-507d-ad1d-8d4275a45b52',
+  '{"sub":"bd4ce88e-5677-507d-ad1d-8d4275a45b52","email":"test-b@typenote.dev","email_verified":true}',
+  'email',
+  'bd4ce88e-5677-507d-ad1d-8d4275a45b52',
+  now(),
+  now(),
+  now()
+) ON CONFLICT (provider_id, provider) DO NOTHING;
+
+UPDATE public.profiles SET subscription_tier = 'free' WHERE id = 'bd4ce88e-5677-507d-ad1d-8d4275a45b52';
+
 -- Sample AI usage data for testing the quota display
 INSERT INTO public.ai_usage (user_id, usage_month, query_type, query_count, last_model)
 VALUES ('ac3be77d-4566-406c-9ac0-7c410634ad41', to_char(CURRENT_DATE, 'YYYY-MM'), 'chat', 3, 'flash')


### PR DESCRIPTION
## Summary

Closes the highest-severity false green in the test suite. Previously, every "RLS test" used the `service_role` client, which bypasses RLS by design — meaning if any policy regressed (or was removed entirely), no test would notice.

This PR adds a second seeded user and a real cross-user isolation spec using **two anon-key clients with different JWTs**, so RLS is actually enforced.

## What's tested

For every user-owned table — `documents`, `folders`, `courses`, `course_weeks`, `course_materials`, `personal_files`, `ai_conversations`, `ai_messages`, `document_versions`:

- User A cannot SELECT User B's rows (cross-user reads return empty)
- (documents) User A cannot UPDATE User B's row (verified by reading back with admin client)
- (documents) User A cannot DELETE User B's row
- (documents) User A cannot INSERT a row claiming User B's `user_id` — WITH CHECK rejects
- Sanity: each user CAN read their own row

13 new tests. Integration suite: 109/109 pass (4 false-green placeholders removed).

## What's removed

- `src/lib/actions/conversations.integration.test.ts` — placeholder \"RLS blocks cross-user access\" describe block that called a non-existent \`check_rls_enabled\` RPC and silently fell back to a service_role query.
- `src/lib/queries/crud.integration.test.ts` — same pattern.

Both are now redirected via comment to the new spec.

## Test plan

- [x] 13 new RLS tests pass
- [x] 109 integration tests pass (was 113, minus 4 removed placeholders)
- [x] 801 unit tests pass
- [x] Format + lint clean
- [ ] CI green on `ubuntu-22.04` runner

## Follow-ups

- AI usage RLS (covered indirectly via existing ai-usage.integration.test.ts tier boundaries, but cross-user not tested yet)
- Storage bucket RLS (course-materials, personal-files buckets) — separate concern, requires storage API client

🤖 Generated with [Claude Code](https://claude.com/claude-code)