### PR TITLE
test(e2e): migrate editor-toolbar.spec.ts off /test/editor mock page

### DIFF
--- a/e2e/editor-toolbar.spec.ts
+++ b/e2e/editor-toolbar.spec.ts
@@ -1,10 +1,38 @@
 import { test, expect, type Page } from '@playwright/test';
+import { login } from './helpers/auth';
+import {
+  upsertFixtureDocument,
+  deleteFixtureDocument,
+  type FixtureDocument,
+} from './helpers/db';
 
-const EDITOR_URL = '/test/editor';
+// Each test gets a fresh fixture doc with a known starting paragraph
+// ("Hello world"). This replaces the old /test/editor mock page, which
+// CLAUDE.md forbids — feature E2E coverage must go through real flows
+// (login → seeded doc → editor) so we catch real auth / load / persistence
+// bugs that mock pages bypass.
+let currentDocId = '';
+
+function buildFixture(id: string): FixtureDocument {
+  return {
+    id,
+    title: 'Toolbar Test Doc',
+    canvas_type: 'blank',
+    content: {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [{ type: 'text', text: 'Hello world' }],
+        },
+      ],
+    },
+  };
+}
 
 // Helper: get the Tiptap ProseMirror editor element
 function getEditor(page: Page) {
-  return page.locator('.ProseMirror');
+  return page.locator('.ProseMirror').first();
 }
 
 // Helper: click a toolbar button by its aria-label
@@ -19,10 +47,17 @@ async function focusAndSelectAll(page: Page) {
 }
 
 test.describe('Editor Toolbar', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto(EDITOR_URL);
-    // Wait for the Tiptap editor to mount
+  test.beforeEach(async ({ page }, testInfo) => {
+    // Deterministic per-test fixture ID — easy to clean up, never collides.
+    currentDocId = `aa000000-0000-0000-0000-${String(testInfo.testId).padStart(12, '0').slice(-12)}`;
+    await upsertFixtureDocument(buildFixture(currentDocId));
+    await login(page);
+    await page.goto(`/dashboard/documents/${currentDocId}`);
     await expect(getEditor(page)).toBeVisible();
+  });
+
+  test.afterEach(async () => {
+    if (currentDocId) await deleteFixtureDocument(currentDocId);
   });
 
   test.describe('toolbar layout', () => {
@@ -501,7 +536,7 @@ test.describe('Editor Toolbar', () => {
   test.describe('title editing', () => {
     test('document title is editable', async ({ page }) => {
       const titleInput = page.getByPlaceholder('Untitled');
-      await expect(titleInput).toHaveValue('Test Document');
+      await expect(titleInput).toHaveValue('Toolbar Test Doc');
 
       await titleInput.clear();
       await titleInput.fill('New Title');


### PR DESCRIPTION
## Summary

The 40-test \`editor-toolbar.spec.ts\` was the largest E2E spec in the suite and the worst rubric violation from the test audit — it used \`/test/editor\`, a mock page that bypasses real Supabase auth and document load. CLAUDE.md explicitly forbids this pattern for feature E2E coverage, and the audit flagged it as REWRITE-priority.

This PR migrates the entire spec to the real flow:

- Log in as the seeded test user (\`e2e/helpers/auth.ts\`)
- Upsert a fresh fixture document per test via the admin client (\`e2e/helpers/db.ts\` — added in #140)
- Navigate to the real \`/dashboard/documents/{id}\` route
- \`afterEach\` deletes the fixture

Per-test fixture isolation means autosave side effects can't bleed across tests.

## Test plan

- [x] 40/40 tests pass against the real route (full suite locally)
- [x] Test for editable title updated to expect the fixture title (\`Toolbar Test Doc\`)
- [x] Format + lint clean
- [ ] CI green on \`ubuntu-22.04\` runner

## Out of scope (follow-up)

- \`e2e/export-pdf-editor.spec.ts\` still references \`/test/editor\` — separate PR to migrate it, then the mock page itself can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)