### PR TITLE
test(e2e): un-skip LaTeX AI tests using page.route mock

### DIFF
--- a/e2e/helpers/ai-mock.ts
+++ b/e2e/helpers/ai-mock.ts
@@ -1,0 +1,63 @@
+import { type Page, type Route } from '@playwright/test';
+
+/**
+ * Intercept the LaTeX conversion endpoint and return a deterministic fixture
+ * response so E2E tests don't need a real Gemini API key in CI.
+ *
+ * Pass a map of natural-language input → LaTeX output. The mock parses the
+ * request body and returns the matching fixture, or a default fallback.
+ *
+ * Usage:
+ *   await mockLatexConversion(page, {
+ *     'x squared plus y': 'x^2 + y',
+ *     'a in A': 'a \\in A',
+ *   });
+ */
+export async function mockLatexConversion(
+  page: Page,
+  fixtures: Record<string, string>,
+  fallback = '\\text{mocked}',
+) {
+  await page.route('**/api/ai/latex', async (route: Route) => {
+    const req = route.request();
+    if (req.method() !== 'POST') {
+      await route.continue();
+      return;
+    }
+    let text = '';
+    try {
+      const body = req.postDataJSON() as { text?: string } | null;
+      text = (body?.text ?? '').trim();
+    } catch {
+      /* malformed body — fall through to fallback */
+    }
+    const latex = fixtures[text] ?? fallback;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ latex }),
+    });
+  });
+}
+
+/**
+ * Mock the AI quota endpoint to return generous limits, in case a test
+ * navigates to a screen that displays remaining quota.
+ */
+export async function mockAiQuota(
+  page: Page,
+  quota = {
+    used: 0,
+    limit: 1000,
+    tier: 'beta',
+    resetsAt: null as string | null,
+  },
+) {
+  await page.route('**/api/ai/quota**', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(quota),
+    });
+  });
+}

--- a/e2e/latex-math.spec.ts
+++ b/e2e/latex-math.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { login } from './helpers/auth';
+import { mockLatexConversion } from './helpers/ai-mock';
 
 /**
  * Seed the test document with math content via Supabase REST API,
@@ -119,6 +120,14 @@ test.describe('LaTeX Math', () => {
   test.beforeEach(async ({ page }) => {
     await seedMathDocument();
 
+    // Mock the AI LaTeX conversion endpoint with deterministic responses so
+    // CI doesn't need GOOGLE_GENERATIVE_AI_API_KEY. The mock returns the
+    // mapped LaTeX for each natural-language input the tests send.
+    await mockLatexConversion(page, {
+      'x squared plus y': 'x^2 + y',
+      'a in A': 'a \\in A',
+    });
+
     await login(page);
     await page.goto(DOC_URL);
     await expect(page).toHaveURL(/\/dashboard\/documents\//, {
@@ -132,10 +141,6 @@ test.describe('LaTeX Math', () => {
   });
 
   test('insert math with :{ trigger', async ({ page }) => {
-    test.skip(
-      !!process.env.CI,
-      'LaTeX AI conversion needs GOOGLE_GENERATIVE_AI_API_KEY in CI',
-    );
     test.setTimeout(30_000);
 
     // Focus the editor and type the trigger sequence
@@ -268,10 +273,6 @@ test.describe('LaTeX Math', () => {
   });
 
   test('math renders LTR inside RTL text', async ({ page }) => {
-    test.skip(
-      !!process.env.CI,
-      'LaTeX AI conversion needs GOOGLE_GENERATIVE_AI_API_KEY in CI',
-    );
     test.setTimeout(30_000);
 
     // Focus the editor


### PR DESCRIPTION
## Summary

The 2 LaTeX tests gated on \`GOOGLE_GENERATIVE_AI_API_KEY\` (\`insert math with :{ trigger\` and \`math renders LTR inside RTL text\`) were \`test.skip\`'d in CI. Replace with a Playwright \`page.route\` mock so they run unconditionally with deterministic responses.

- New helper \`e2e/helpers/ai-mock.ts\` exports \`mockLatexConversion(page, fixtures)\` and \`mockAiQuota(page)\`.
- \`e2e/latex-math.spec.ts\` installs the mock in \`beforeEach\` with fixtures matching the natural-language inputs the tests send.
- Both \`test.skip(!!process.env.CI, ...)\` blocks deleted.

## Test plan

- [x] \`pnpm exec playwright test e2e/latex-math.spec.ts\` — 6/6 pass locally
- [x] \`pnpm lint\` clean
- [x] Mock is deterministic — no flake risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)