### PR TITLE
test(e2e): un-skip course-page tests, harden navigation helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,11 @@ jobs:
           TEST_USER_PASSWORD: Test1234
           NEXT_PUBLIC_SUPABASE_URL: ${{ steps.supabase.outputs.SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ steps.supabase.outputs.SUPABASE_ANON_KEY }}
+          # The Next.js dev server (started by Playwright) calls
+          # createAdminClient() in server components (e.g. courses page) and
+          # in API routes. Forward the service-role key so SSR doesn't
+          # throw "Missing SUPABASE_SERVICE_ROLE_KEY" during E2E runs.
+          SUPABASE_SERVICE_ROLE_KEY: ${{ steps.supabase.outputs.SUPABASE_SERVICE_ROLE_KEY }}
 
       - name: Upload Playwright report
         if: failure()

--- a/e2e/courses.spec.ts
+++ b/e2e/courses.spec.ts
@@ -30,9 +30,6 @@ test.describe('Courses', () => {
   });
 
   test('view course with weeks', async ({ page }) => {
-    // Course page rendering is flaky in CI — server component auth
-    // propagation causes intermittent "Import File" button absence
-    test.skip(!!process.env.CI, 'Course page rendering flaky in CI');
     await goToSeededCourse(page);
 
     // The course page should show the course title
@@ -48,7 +45,6 @@ test.describe('Courses', () => {
   });
 
   test('create document inside course', async ({ page }) => {
-    test.skip(!!process.env.CI, 'Course page rendering flaky in CI');
     await goToSeededCourse(page);
 
     const docTitle = `Course Doc ${Date.now()}`;
@@ -71,7 +67,6 @@ test.describe('Courses', () => {
   });
 
   test('add file inside course', async ({ page }) => {
-    test.skip(!!process.env.CI, 'Course page rendering flaky in CI');
     test.setTimeout(45_000);
 
     await goToSeededCourse(page);
@@ -95,7 +90,6 @@ test.describe('Courses', () => {
   });
 
   test('view course material opens in canvas editor', async ({ page }) => {
-    test.skip(!!process.env.CI, 'Course page rendering flaky in CI');
     test.setTimeout(30_000);
 
     await goToSeededCourse(page);

--- a/e2e/file-upload.spec.ts
+++ b/e2e/file-upload.spec.ts
@@ -2,17 +2,14 @@ import { test, expect } from '@playwright/test';
 import { login } from './helpers/auth';
 import { goToSeededCourse } from './helpers/navigate';
 
-const COURSE_URL = '/dashboard/courses/30000000-0000-0000-0000-000000000001';
-
 test.describe('File Upload', () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
   });
 
   test('import file into course', async ({ page }) => {
-    test.skip(!!process.env.CI, 'Course page rendering flaky in CI');
     test.setTimeout(30_000);
-    await page.goto(COURSE_URL);
+    await goToSeededCourse(page);
     await expect(page.getByRole('button', { name: 'Import File' })).toBeVisible(
       { timeout: 15_000 },
     );
@@ -38,7 +35,7 @@ test.describe('File Upload', () => {
     // that's unreliable in CI's local Supabase environment.
     test.skip(!!process.env.CI, 'File conversion unreliable in local CI');
     test.setTimeout(45_000);
-    await page.goto(COURSE_URL);
+    await goToSeededCourse(page);
     await expect(page.getByRole('button', { name: 'Import File' })).toBeVisible(
       { timeout: 15_000 },
     );
@@ -70,9 +67,8 @@ test.describe('File Upload', () => {
   });
 
   test('delete imported file', async ({ page }) => {
-    test.skip(!!process.env.CI, 'Course page rendering flaky in CI');
     test.setTimeout(45_000);
-    await page.goto(COURSE_URL);
+    await goToSeededCourse(page);
     await expect(page.getByRole('button', { name: 'Import File' })).toBeVisible(
       { timeout: 15_000 },
     );

--- a/e2e/helpers/navigate.ts
+++ b/e2e/helpers/navigate.ts
@@ -3,16 +3,32 @@ import { expect } from '@playwright/test';
 
 /**
  * Navigate to the seeded "Introduction to CS" course from the dashboard.
- * Assumes the user is already logged in and on the dashboard.
+ *
+ * Assumes the user is already logged in and on the dashboard. This helper
+ * waits for the course-page heading to render before returning so the
+ * caller can interact with course-page elements without hitting a
+ * server-component auth-propagation race.
+ *
+ * If the course page renders unauthenticated (404 or empty) on the first
+ * navigation — a known CI race — we reload once and retry the assertion.
  */
 export async function goToSeededCourse(page: Page) {
-  // The seeded course "Introduction to CS" is at root level
-  // Use a text match that works even if the name is truncated
   const courseLink = page.getByText('Introduction to CS').first();
   await expect(courseLink).toBeVisible({ timeout: 10_000 });
   await courseLink.click();
 
-  await expect(page).toHaveURL(/\/dashboard\/courses\//, {
-    timeout: 10_000,
+  await expect(page).toHaveURL(/\/dashboard\/courses\//, { timeout: 10_000 });
+
+  // Wait for a course-page-only element to prove the SSR rendered the
+  // authenticated view (not a notFound or unauthed redirect).
+  const courseHeading = page.getByRole('heading', {
+    name: 'Introduction to CS',
   });
+  try {
+    await expect(courseHeading).toBeVisible({ timeout: 8_000 });
+  } catch {
+    // Server-component auth cookie race: reload once and retry.
+    await page.reload();
+    await expect(courseHeading).toBeVisible({ timeout: 10_000 });
+  }
 }


### PR DESCRIPTION
## Summary

Six E2E tests were skipped with the comment \"Course page rendering flaky in CI\" — a server-component auth-cookie propagation race. The course-page server component sometimes renders unauthenticated and the headings/buttons the tests look for never appear.

**Fix in \`e2e/helpers/navigate.ts#goToSeededCourse\`:**
- Wait for the \"Introduction to CS\" heading after the URL match (proves the SSR fetched the authenticated course, not a 404).
- If the heading doesn't appear within 8s, reload once and retry — the reload re-sends auth cookies and avoids the race.

**\`e2e/file-upload.spec.ts\`** previously used \`page.goto(COURSE_URL)\` directly and bypassed the navigation helper. Migrated to \`goToSeededCourse\` so the retry path runs there too.

**Un-skipped (6 tests):**
- \`courses.spec.ts\`: view course with weeks, create document inside course, add file inside course, view course material
- \`file-upload.spec.ts\`: import file into course, delete imported file

The \"open imported file creates a document\" file-upload test stays CI-skipped — its skip reason (\"file conversion unreliable\") is a separate substantive issue, not the auth race.

## Test plan

- [x] \`pnpm exec playwright test e2e/courses.spec.ts e2e/file-upload.spec.ts\` — 6 pass, 1 skipped (intentional), 1 locally-failing (pre-existing, CI-skipped)
- [x] \`pnpm lint\` clean
- [x] CI will be the source of truth for whether the auth race is fixed; if a re-run is needed, the retry block handles it

🤖 Generated with [Claude Code](https://claude.com/claude-code)