### PR TITLE
test(e2e): fix version-history spec with admin-seeded versions and content assertions

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"f4501667-eef9-428b-bf64-76d4ffbb1428","pid":939108,"procStart":"774680321","acquiredAt":1778684058711}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"f4501667-eef9-428b-bf64-76d4ffbb1428","pid":939108,"procStart":"774680321","acquiredAt":1778684058711}

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@
 .DS_Store
 *.pem
 
+# claude code runtime state
+.claude/scheduled_tasks.lock
+.claude/scheduled_tasks/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/e2e/helpers/db.ts
+++ b/e2e/helpers/db.ts
@@ -62,3 +62,47 @@ export async function upsertFixtureDocument(
 export async function deleteFixtureDocument(id: string): Promise<void> {
   await admin().from('documents').delete().eq('id', id);
 }
+
+export interface FixtureVersion {
+  documentId: string;
+  title: string;
+  content: unknown;
+  // Must match a value the sidebar's TRIGGER_LABELS table understands.
+  // `idle`, `periodic`, `close` all render as "Auto-saved".
+  // `before_restore` renders as "Before restore".
+  trigger?: 'idle' | 'periodic' | 'close' | 'before_restore';
+  createdAtIso?: string;
+}
+
+/**
+ * Insert an explicit document_versions row via the admin client. Use this to
+ * seed known historical versions for restore tests instead of relying on the
+ * editor's auto-save snapshot timing.
+ */
+export async function insertFixtureVersion(v: FixtureVersion): Promise<string> {
+  const { data, error } = await admin()
+    .from('document_versions')
+    .insert({
+      document_id: v.documentId,
+      user_id: TEST_USER_ID,
+      title: v.title,
+      content: v.content,
+      trigger: v.trigger ?? 'idle',
+      ...(v.createdAtIso ? { created_at: v.createdAtIso } : {}),
+    })
+    .select('id')
+    .single();
+  if (error || !data) {
+    throw new Error(
+      `Failed to insert fixture version for ${v.documentId}: ${error?.message ?? 'unknown'}`,
+    );
+  }
+  return data.id as string;
+}
+
+export async function deleteFixtureVersions(documentId: string): Promise<void> {
+  await admin()
+    .from('document_versions')
+    .delete()
+    .eq('document_id', documentId);
+}

--- a/e2e/version-history.spec.ts
+++ b/e2e/version-history.spec.ts
@@ -1,100 +1,125 @@
 import { test, expect } from '@playwright/test';
 import { login } from './helpers/auth';
+import {
+  upsertFixtureDocument,
+  deleteFixtureDocument,
+  insertFixtureVersion,
+  deleteFixtureVersions,
+  type FixtureDocument,
+} from './helpers/db';
 
-// The seeded "Limits and Continuity" document has 3 version snapshots
-const SEEDED_DOC_TITLE = 'Limits and Continuity';
+// Fixture document with three explicit versions. The current document content
+// is V3 ("the current version"); the sidebar should expose V2 and V1 from the
+// document_versions table. Restoring V1 must change the editor content to V1
+// AND create a "Before restore" snapshot of V3.
+
+const DOC_ID = '9b000000-0000-0000-0000-000000000001';
+
+function docWithText(text: string) {
+  return {
+    type: 'doc',
+    content: [
+      {
+        type: 'paragraph',
+        content: [{ type: 'text', text }],
+      },
+    ],
+  };
+}
+
+const V1_TEXT = 'VERSION ONE — earliest snapshot';
+const V2_TEXT = 'VERSION TWO — middle snapshot';
+const V3_TEXT = 'VERSION THREE — current document';
+
+const FIXTURE: FixtureDocument = {
+  id: DOC_ID,
+  title: 'Version History Fixture',
+  canvas_type: 'blank',
+  content: docWithText(V3_TEXT),
+};
 
 test.describe('Version History', () => {
   test.beforeEach(async ({ page }) => {
-    await login(page);
-  });
-
-  test('open version history sidebar from document', async ({ page }) => {
-    // Navigate to the seeded document that has versions
-    // Open Calculus I folder first
-    const folder = page.getByText('Calculus I').first();
-    await expect(folder).toBeVisible({ timeout: 10_000 });
-    await folder.click();
-
-    // Click on the document
-    const doc = page.getByText(SEEDED_DOC_TITLE).first();
-    await expect(doc).toBeVisible({ timeout: 10_000 });
-    await doc.click();
-
-    // Wait for editor to load
-    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
-      timeout: 10_000,
+    // Reset doc + versions to a known state.
+    await upsertFixtureDocument(FIXTURE);
+    await deleteFixtureVersions(DOC_ID);
+    // Insert versions in chronological order; the sidebar shows newest first.
+    await insertFixtureVersion({
+      documentId: DOC_ID,
+      title: FIXTURE.title,
+      content: docWithText(V1_TEXT),
+      trigger: 'idle',
+      createdAtIso: '2026-05-10T10:00:00Z',
+    });
+    await insertFixtureVersion({
+      documentId: DOC_ID,
+      title: FIXTURE.title,
+      content: docWithText(V2_TEXT),
+      trigger: 'idle',
+      createdAtIso: '2026-05-11T10:00:00Z',
     });
 
-    // Click the version history button (Clock icon)
-    const historyButton = page.getByTitle('Version history');
-    await expect(historyButton).toBeVisible({ timeout: 10_000 });
-    await historyButton.click();
+    await login(page);
+    await page.goto(`/dashboard/documents/${DOC_ID}`);
+    await expect(page.locator('.ProseMirror').first()).toBeVisible({
+      timeout: 10_000,
+    });
+    // Confirm the editor opened on V3 — the test's premise.
+    await expect(page.getByText(V3_TEXT)).toBeVisible({ timeout: 10_000 });
+  });
 
-    // Version sidebar should appear with "Version History" heading
+  test.afterEach(async () => {
+    await deleteFixtureVersions(DOC_ID);
+    await deleteFixtureDocument(DOC_ID);
+  });
+
+  test('open version history sidebar from editor toolbar', async ({ page }) => {
+    await page.getByTitle('Version history').click();
     await expect(page.getByText('Version History')).toBeVisible({
       timeout: 5_000,
     });
   });
 
-  test('version sidebar shows seeded version entries', async ({ page }) => {
-    // Navigate to the document with seeded versions
-    const folder = page.getByText('Calculus I').first();
-    await expect(folder).toBeVisible({ timeout: 10_000 });
-    await folder.click();
-
-    const doc = page.getByText(SEEDED_DOC_TITLE).first();
-    await expect(doc).toBeVisible({ timeout: 10_000 });
-    await doc.click();
-
-    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
-      timeout: 10_000,
-    });
-
-    // Open version history
+  test('sidebar lists the seeded versions newest-first', async ({ page }) => {
     await page.getByTitle('Version history').click();
     await expect(page.getByText('Version History')).toBeVisible({
       timeout: 5_000,
     });
 
-    // Should show "Auto-saved" labels (the 3 seeded versions all have Auto-saved triggers)
+    // We seeded two versions; the sidebar should expose at least two entries
+    // labeled "Auto-saved". Looser assertion — exact list ordering is a UI
+    // implementation detail.
     const autoSavedLabels = page.getByText('Auto-saved');
     await expect(autoSavedLabels.first()).toBeVisible({ timeout: 5_000 });
+    expect(await autoSavedLabels.count()).toBeGreaterThanOrEqual(2);
   });
 
-  test('restore a version shows "Before restore" entry', async ({ page }) => {
-    // Navigate to the document
-    const folder = page.getByText('Calculus I').first();
-    await expect(folder).toBeVisible({ timeout: 10_000 });
-    await folder.click();
-
-    const doc = page.getByText(SEEDED_DOC_TITLE).first();
-    await expect(doc).toBeVisible({ timeout: 10_000 });
-    await doc.click();
-
-    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
-      timeout: 10_000,
-    });
-
-    // Open version history
+  test('restoring an older version changes the editor content and creates a Before-restore snapshot', async ({
+    page,
+  }) => {
     await page.getByTitle('Version history').click();
     await expect(page.getByText('Version History')).toBeVisible({
       timeout: 5_000,
     });
 
-    // Click the first version entry to select it
-    const autoSaved = page.getByText('Auto-saved').first();
-    await expect(autoSaved).toBeVisible({ timeout: 5_000 });
-    await autoSaved.click();
+    // The two seeded versions appear newest-first. We click the LAST one in
+    // the list — that's V1, the oldest — and restore it.
+    const versionEntries = page.getByText('Auto-saved');
+    await expect(versionEntries.first()).toBeVisible({ timeout: 5_000 });
+    const count = await versionEntries.count();
+    expect(count).toBeGreaterThanOrEqual(2);
+    await versionEntries.nth(count - 1).click();
 
-    // "Restore this version" button should appear
     const restoreButton = page.getByText('Restore this version');
     await expect(restoreButton).toBeVisible({ timeout: 5_000 });
-
-    // Click restore
     await restoreButton.click();
 
-    // After restore, should see a "Before restore" entry in the sidebar
+    // After restore, the editor should display V1's content — and NOT V3.
+    await expect(page.getByText(V1_TEXT)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(V3_TEXT)).not.toBeVisible();
+
+    // A "Before restore" entry must appear in the sidebar — it's the safety
+    // snapshot of V3 that the restore RPC creates atomically.
     await expect(page.getByText('Before restore')).toBeVisible({
       timeout: 10_000,
     });


### PR DESCRIPTION
## Summary

The audit flagged \`e2e/version-history.spec.ts\` as **FIX**: it relied on the seeded \"Limits and Continuity\" document having 3 version snapshots (so the test would silently pass if seed had zero versions), and the restore test only checked for the \"Before restore\" label — never that the editor content actually reverted.

Rewrite:

- Add \`insertFixtureVersion\` / \`deleteFixtureVersions\` to \`e2e/helpers/db.ts\`. These insert directly into \`document_versions\` via the admin client, with explicit \`created_at\` timestamps for stable ordering.
- Replace the seed-dependent doc with a fixture (\`9b000000-...\`) and explicitly insert V1 + V2 in beforeEach; the document content is V3.
- After clicking the oldest entry and clicking \"Restore this version\":
  - assert V1 text appears in the editor
  - assert V3 text is gone
  - assert a \"Before restore\" entry exists (proves the atomic safety snapshot)
- Version \`trigger\` must be one of \`idle | periodic | close\` to render as \"Auto-saved\" per \`version-sidebar.tsx#TRIGGER_LABELS\`.

Also untrack an accidentally committed \`.claude/scheduled_tasks.lock\` runtime file.

## Test plan

- [x] \`pnpm exec playwright test e2e/version-history.spec.ts\` — 3/3 pass locally
- [x] \`pnpm lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)