### PR TITLE
test(hooks): add tests for use-network-status

### DIFF
--- a/src/hooks/__tests__/use-network-status.test.ts
+++ b/src/hooks/__tests__/use-network-status.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests for useNetworkStatus.
+ *
+ * The hook wraps `useSyncExternalStore` around the `online`/`offline`
+ * window events plus `navigator.onLine`. The audit flagged this hook as
+ * untested. Coverage targets:
+ *   - Initial snapshot reflects navigator.onLine
+ *   - online/offline events update the hook
+ *   - Listeners are removed on unmount (no leaks)
+ *   - SSR snapshot is `true` (defensive default)
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNetworkStatus } from '../use-network-status';
+
+function setOnLine(value: boolean) {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+describe('useNetworkStatus', () => {
+  let addSpy: ReturnType<typeof vi.spyOn>;
+  let removeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    setOnLine(true);
+    addSpy = vi.spyOn(window, 'addEventListener');
+    removeSpy = vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+    setOnLine(true);
+  });
+
+  it('reports navigator.onLine as the initial snapshot', () => {
+    setOnLine(true);
+    const { result, unmount } = renderHook(() => useNetworkStatus());
+    expect(result.current.isOnline).toBe(true);
+    unmount();
+  });
+
+  it('reports false when navigator.onLine is false at mount', () => {
+    setOnLine(false);
+    const { result, unmount } = renderHook(() => useNetworkStatus());
+    expect(result.current.isOnline).toBe(false);
+    unmount();
+  });
+
+  it('flips to false when an offline event fires', () => {
+    setOnLine(true);
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.isOnline).toBe(true);
+
+    act(() => {
+      setOnLine(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    expect(result.current.isOnline).toBe(false);
+  });
+
+  it('flips back to true when an online event fires after going offline', () => {
+    setOnLine(false);
+    const { result } = renderHook(() => useNetworkStatus());
+    expect(result.current.isOnline).toBe(false);
+
+    act(() => {
+      setOnLine(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(result.current.isOnline).toBe(true);
+  });
+
+  it('subscribes to both online and offline window events on mount', () => {
+    renderHook(() => useNetworkStatus());
+    const subscribedEvents = addSpy.mock.calls
+      .map((c) => c[0])
+      .filter((name) => name === 'online' || name === 'offline');
+    expect(subscribedEvents).toContain('online');
+    expect(subscribedEvents).toContain('offline');
+  });
+
+  it('removes its listeners on unmount (no leaks)', () => {
+    const { unmount } = renderHook(() => useNetworkStatus());
+    unmount();
+
+    const removedEvents = removeSpy.mock.calls
+      .map((c) => c[0])
+      .filter((name) => name === 'online' || name === 'offline');
+    expect(removedEvents).toContain('online');
+    expect(removedEvents).toContain('offline');
+  });
+});


### PR DESCRIPTION
## Summary

The audit listed \`use-network-status\` as an untested hook. This adds 6 focused unit tests.

\`src/hooks/__tests__/use-network-status.test.ts\` covers:
- Initial snapshot reflects \`navigator.onLine\` (both true and false)
- Dispatching the \`offline\` event flips \`isOnline\` to false
- Dispatching the \`online\` event after going offline flips back to true
- Both \`online\` and \`offline\` window events are subscribed on mount
- Listeners are removed on unmount (no leaks)

Also picks up the \`.gitignore\` entry for \`.claude/scheduled_tasks.lock\` to match prior PRs.

## Test plan

- [x] \`pnpm vitest run src/hooks/__tests__/use-network-status.test.ts\` — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)