### PR TITLE
fix(extension): make install card reachable on Chromium without extension

### DIFF
--- a/e2e/moodle-touch-gating.spec.ts
+++ b/e2e/moodle-touch-gating.spec.ts
@@ -29,15 +29,17 @@ test.describe('Moodle UI — touch / non-Chromium gating', () => {
       viewport: { width: 1440, height: 900 },
       baseURL: BASE_URL,
     });
-    // Stub window.chrome.runtime.sendMessage so useExtensionPlatform() sees a
-    // Chromium-family desktop environment. Without an actual Chrome extension
-    // loaded, Playwright's Chromium does not expose window.chrome at all.
+    // Stub window.chrome with the Chrome-family globals (loadTimes/csi/app)
+    // that useExtensionPlatform() uses for Chromium detection. We deliberately
+    // omit `runtime` here — that field is only injected once the extension is
+    // installed and lists the page in externally_connectable, so the gate must
+    // work without it (otherwise the install card itself is unreachable).
     await context.addInitScript(() => {
       Object.defineProperty(window, 'chrome', {
         value: {
-          runtime: {
-            sendMessage: () => {},
-          },
+          loadTimes: () => ({}),
+          csi: () => ({}),
+          app: {},
         },
         writable: true,
       });

--- a/src/components/dashboard/extension-gate.test.tsx
+++ b/src/components/dashboard/extension-gate.test.tsx
@@ -16,8 +16,11 @@ function setSupported(supported: boolean) {
     onchange: null,
   }));
   if (supported) {
+    // Mimic a clean Chromium browser without the extension installed.
     (globalThis as Record<string, unknown>).chrome = {
-      runtime: { sendMessage: vi.fn() },
+      loadTimes: () => ({}),
+      csi: () => ({}),
+      app: {},
     };
   } else {
     delete (globalThis as Record<string, unknown>).chrome;

--- a/src/components/dashboard/moodle-install-dialog.test.tsx
+++ b/src/components/dashboard/moodle-install-dialog.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MoodleInstallDialog } from './moodle-install-dialog';
+import { Button } from '@/components/ui/button';
+
+function renderDialog() {
+  return render(
+    <MoodleInstallDialog trigger={<Button>Install Extension</Button>} />,
+  );
+}
+
+describe('MoodleInstallDialog', () => {
+  it('does not render dialog content until the trigger is clicked', () => {
+    renderDialog();
+    expect(
+      screen.queryByText(/install the typenote extension/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens with the install instructions when the trigger is clicked', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(
+      screen.getByRole('button', { name: /install extension/i }),
+    );
+
+    expect(
+      screen.getByRole('heading', { name: /install the typenote extension/i }),
+    ).toBeInTheDocument();
+    // Anchor to one Chrome-specific term and one repo-specific term so the
+    // test catches accidental copy regressions on either side.
+    expect(screen.getByText(/chrome:\/\/extensions/i)).toBeInTheDocument();
+    expect(screen.getByText(/Load unpacked/i)).toBeInTheDocument();
+  });
+
+  it('links to the extension folder on GitHub', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(
+      screen.getByRole('button', { name: /install extension/i }),
+    );
+
+    const githubLink = screen.getByRole('link', { name: /view on github/i });
+    expect(githubLink).toHaveAttribute(
+      'href',
+      'https://github.com/galigoldman/Typenote/tree/main/extension',
+    );
+    expect(githubLink).toHaveAttribute('target', '_blank');
+    expect(githubLink).toHaveAttribute(
+      'rel',
+      expect.stringContaining('noreferrer'),
+    );
+  });
+
+  it('closes when the user clicks "Got it"', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(
+      screen.getByRole('button', { name: /install extension/i }),
+    );
+    expect(
+      screen.getByRole('heading', { name: /install the typenote extension/i }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /got it/i }));
+    expect(
+      screen.queryByRole('heading', {
+        name: /install the typenote extension/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/moodle-install-dialog.tsx
+++ b/src/components/dashboard/moodle-install-dialog.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { ExternalLink } from 'lucide-react';
+
+const EXTENSION_REPO_URL =
+  'https://github.com/galigoldman/Typenote/tree/main/extension';
+
+interface MoodleInstallDialogProps {
+  trigger: ReactNode;
+}
+
+/**
+ * Inline install instructions for the Typenote Moodle extension while the
+ * extension is still pre-Chrome-Web-Store. Built for the small beta-tester
+ * group: clone the repo, build the unpacked extension, load it in Chrome.
+ *
+ * Once we publish to the Chrome Web Store this whole component can be
+ * replaced with a single anchor tag pointing at the listing.
+ */
+export function MoodleInstallDialog({ trigger }: MoodleInstallDialogProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle>Install the Typenote extension</DialogTitle>
+          <DialogDescription>
+            The extension is in beta and not yet on the Chrome Web Store. Follow
+            these steps to load it as an unpacked extension in any Chromium
+            browser (Chrome, Edge, Brave, Arc).
+          </DialogDescription>
+        </DialogHeader>
+
+        <ol className="ml-5 list-decimal space-y-3 text-sm">
+          <li>
+            <p>
+              Clone the repo and build the extension bundle:{' '}
+              <span className="block">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                  git clone https://github.com/galigoldman/Typenote.git
+                </code>
+              </span>
+              <span className="block">
+                <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs">
+                  cd Typenote/extension && npm install && npm run build
+                </code>
+              </span>
+            </p>
+          </li>
+          <li>
+            Open{' '}
+            <code className="rounded bg-muted px-1 font-mono">
+              chrome://extensions
+            </code>{' '}
+            in a new tab.
+          </li>
+          <li>
+            Toggle <strong>Developer mode</strong> on (top-right corner of the
+            page).
+          </li>
+          <li>
+            Click <strong>Load unpacked</strong> and pick the{' '}
+            <code className="rounded bg-muted px-1 font-mono">extension/</code>{' '}
+            folder from the repo you just cloned.
+          </li>
+          <li>
+            Copy the extension ID Chrome shows on the new card (a 32-character
+            lowercase string).
+          </li>
+          <li>
+            <strong>Refresh this page.</strong> The card will switch to "Enter
+            your Moodle URL".
+          </li>
+        </ol>
+
+        <p className="text-xs text-muted-foreground">
+          Need help? See the full quickstart in{' '}
+          <code className="font-mono">extension/QUICKSTART.md</code>.
+        </p>
+
+        <DialogFooter className="sm:justify-between sm:gap-2">
+          <Button asChild variant="outline" size="sm">
+            <a href={EXTENSION_REPO_URL} target="_blank" rel="noreferrer">
+              View on GitHub
+              <ExternalLink className="ml-2 size-3.5" aria-hidden />
+            </a>
+          </Button>
+          <Button size="sm" onClick={() => setOpen(false)}>
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/moodle-install-dialog.tsx
+++ b/src/components/dashboard/moodle-install-dialog.tsx
@@ -81,8 +81,8 @@ export function MoodleInstallDialog({ trigger }: MoodleInstallDialogProps) {
             lowercase string).
           </li>
           <li>
-            <strong>Refresh this page.</strong> The card will switch to "Enter
-            your Moodle URL".
+            <strong>Refresh this page.</strong> The card will switch to{' '}
+            <em>Enter your Moodle URL</em>.
           </li>
         </ol>
 

--- a/src/components/dashboard/moodle-sync-prompt.test.tsx
+++ b/src/components/dashboard/moodle-sync-prompt.test.tsx
@@ -37,7 +37,7 @@ describe('MoodleSyncPrompt', () => {
     expect(container.querySelector('[aria-busy="true"]')).toBeInTheDocument();
   });
 
-  it('renders the Install card when extension is not installed', () => {
+  it('renders the Install card with an enabled trigger when extension is not installed', () => {
     setState({ status: 'not-installed' });
     render(<MoodleSyncPrompt moodleConnection={null} onSyncClick={() => {}} />);
     expect(
@@ -45,7 +45,7 @@ describe('MoodleSyncPrompt', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: /install extension/i }),
-    ).toBeDisabled();
+    ).toBeEnabled();
   });
 
   it('renders the Update card with both versions when version mismatches', () => {

--- a/src/components/dashboard/moodle-sync-prompt.tsx
+++ b/src/components/dashboard/moodle-sync-prompt.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/hooks/use-moodle-extension';
 import { MoodleCardSkeleton } from './moodle-card-skeleton';
 import { MoodleConnectionSetup } from './moodle-connection-setup';
+import { MoodleInstallDialog } from './moodle-install-dialog';
 
 interface MoodleSyncPromptProps {
   moodleConnection: { domain: string; instanceId: string } | null;
@@ -41,12 +42,16 @@ export function MoodleSyncPrompt({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Button variant="outline" size="sm" disabled>
-            Install Extension
-          </Button>
+          <MoodleInstallDialog
+            trigger={
+              <Button variant="outline" size="sm">
+                Install Extension
+              </Button>
+            }
+          />
           <p className="mt-2 text-xs text-muted-foreground">
-            Coming soon to the Chrome Web Store. Refresh this page after
-            installing.
+            Beta — load the unpacked extension from GitHub. Refresh this page
+            after installing.
           </p>
         </CardContent>
       </Card>

--- a/src/hooks/use-extension-platform.test.ts
+++ b/src/hooks/use-extension-platform.test.ts
@@ -17,10 +17,14 @@ function setPointerFine(matches: boolean) {
   }));
 }
 
-function setChromeRuntime(present: boolean) {
+function setChromiumFamily(present: boolean) {
   if (present) {
+    // Mimic a clean Chromium browser without the extension installed:
+    // `loadTimes`/`csi`/`app` exist but `runtime` does NOT.
     (globalThis as Record<string, unknown>).chrome = {
-      runtime: { sendMessage: vi.fn() },
+      loadTimes: () => ({}),
+      csi: () => ({}),
+      app: {},
     };
   } else {
     delete (globalThis as Record<string, unknown>).chrome;
@@ -29,7 +33,7 @@ function setChromeRuntime(present: boolean) {
 
 beforeEach(() => {
   setPointerFine(true);
-  setChromeRuntime(true);
+  setChromiumFamily(true);
 });
 
 afterEach(() => {
@@ -44,7 +48,18 @@ afterEach(() => {
 const { useExtensionPlatform } = await import('./use-extension-platform');
 
 describe('useExtensionPlatform', () => {
-  it('returns true on Chromium desktop (pointer-fine + chrome.runtime)', () => {
+  it('returns true on a clean Chromium desktop without the extension installed', () => {
+    const { result } = renderHook(() => useExtensionPlatform());
+    expect(result.current.isSupportedPlatform).toBe(true);
+  });
+
+  it('returns true on Chromium desktop with the extension already installed (chrome.runtime present)', () => {
+    (globalThis as Record<string, unknown>).chrome = {
+      loadTimes: () => ({}),
+      csi: () => ({}),
+      app: {},
+      runtime: { sendMessage: vi.fn() },
+    };
     const { result } = renderHook(() => useExtensionPlatform());
     expect(result.current.isSupportedPlatform).toBe(true);
   });
@@ -55,14 +70,15 @@ describe('useExtensionPlatform', () => {
     expect(result.current.isSupportedPlatform).toBe(false);
   });
 
-  it('returns false on non-Chromium desktop (no chrome.runtime)', () => {
-    setChromeRuntime(false);
+  it('returns false on non-Chromium browsers (no window.chrome)', () => {
+    setChromiumFamily(false);
     const { result } = renderHook(() => useExtensionPlatform());
     expect(result.current.isSupportedPlatform).toBe(false);
   });
 
-  it('returns false when chrome exists but sendMessage is missing', () => {
-    (globalThis as Record<string, unknown>).chrome = { runtime: {} };
+  it('returns false when window.chrome exists but lacks Chrome-family globals', () => {
+    // Some non-Chromium browsers expose a stubbed `chrome` namespace.
+    (globalThis as Record<string, unknown>).chrome = {};
     const { result } = renderHook(() => useExtensionPlatform());
     expect(result.current.isSupportedPlatform).toBe(false);
   });

--- a/src/hooks/use-extension-platform.ts
+++ b/src/hooks/use-extension-platform.ts
@@ -9,10 +9,17 @@ interface ExtensionPlatform {
 function getSnapshot(): boolean {
   if (typeof window === 'undefined') return false;
   const pointerFine = window.matchMedia?.('(pointer: fine)').matches ?? false;
-  const chromeRuntime = (window as unknown as { chrome?: typeof chrome }).chrome
-    ?.runtime;
-  const hasChromeRuntime = typeof chromeRuntime?.sendMessage === 'function';
-  return pointerFine && hasChromeRuntime;
+  const chromeObj = (window as unknown as { chrome?: Record<string, unknown> })
+    .chrome;
+  // `chrome.runtime` only appears once the extension is installed AND the page
+  // is in its `externally_connectable.matches`, so we can't gate on it — that
+  // would make the install card itself unreachable. Instead detect the Chromium
+  // family via the stable Chrome-only globals (`loadTimes`/`csi`/`app`) that
+  // exist on every Chromium-based browser without any extension installed.
+  const isChromiumFamily =
+    !!chromeObj &&
+    ('loadTimes' in chromeObj || 'csi' in chromeObj || 'app' in chromeObj);
+  return pointerFine && isChromiumFamily;
 }
 
 function subscribe(callback: () => void): () => void {


### PR DESCRIPTION
## Summary

- Detect Chromium-family via `chrome.loadTimes/csi/app` instead of `chrome.runtime.sendMessage`, so the install card actually renders on a fresh browser without the extension already installed (chicken-and-egg fix).
- Add `MoodleInstallDialog` with the 6-step dev-install flow (clone → build → `chrome://extensions` → Developer Mode → Load Unpacked → refresh) and a link to the `extension/` folder on GitHub.
- Replace the disabled "Install Extension" button with a working trigger.

## Why

Production (`typenote-two.vercel.app`) currently runs `feat/extension-readiness` and shows **no Moodle card at all**. Root cause: `useExtensionPlatform` required `chrome.runtime.sendMessage` to exist, but Chrome only injects `chrome.runtime` after the extension is installed and lists the page in `externally_connectable`. So the gate hid the card from every user who didn't already have the extension — making the install card itself unreachable.

After this PR: a clean Chromium browser shows the "Moodle Integration" card with a working **Install Extension** button that opens an inline dev-install dialog. Targeted at beta testers; Web Store listing comes later.

## Test plan

- [x] `pnpm test` — all 849 unit tests pass (16 affected, all green)
- [x] `pnpm prettier --check` on changed files
- [ ] After merge: confirm `typenote-two.vercel.app/dashboard` shows the Moodle Integration card with a working dialog when clicking "Install Extension"
- [ ] Spot-check: dialog renders, GitHub link opens the extension folder, "Got it" closes the dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)