### PR TITLE
test: bundle Tier C/D audit additions (4 specs, 16 tests)

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -188,6 +188,28 @@ context-menu entry point works end-to-end.
 
 ---
 
+## Security — XSS (`e2e/security-xss.spec.ts`) — IMPLEMENTED
+
+- [x] XSS payload in document title renders as text on the dashboard and does not execute
+- [x] XSS payload in document title renders as text in the editor header and does not execute
+
+---
+
+## Security — Prompt Injection (`e2e/security-prompt-injection.spec.ts`) — IMPLEMENTED
+
+- [x] AI response containing `<script>` / `<img onerror>` / `<svg onload>` renders as text and does NOT execute
+- [x] Markdown link with `javascript:` URL in AI response is sanitized — no click execution
+
+---
+
+## Security — File Upload Validation (`e2e/security-file-upload.spec.ts`) — IMPLEMENTED
+
+- [x] Non-PDF file rejected by MIME type — inline error visible, no success toast
+- [x] File >50MB rejected — inline error visible, no success toast
+- [x] Double-extension file (`report.pdf.exe`) rejected by MIME type, not just extension
+
+---
+
 ## Summary
 
 | Feature               | Status      | Spec File                           | Tests     |

--- a/e2e/security-file-upload.spec.ts
+++ b/e2e/security-file-upload.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Security: file-upload validation.
+ *
+ * The course-material upload pipeline validates client-side via
+ * `useFileUpload` (`src/hooks/use-file-upload.ts`) — MIME-type allowlist
+ * (PDF only by default) and a 50 MB cap. Bypassing either of these would
+ * let a user push arbitrary binaries into Supabase Storage under their
+ * own user-id prefix, where they could be served back to the browser
+ * with `application/pdf` content-type at view-time, or simply exhaust
+ * the free-tier storage quota.
+ *
+ * These tests exercise the validation at the browser level, not the
+ * hook unit. The hook unit-test (`use-file-upload.test.ts`) covers the
+ * pure validation function in isolation — but if the consuming component
+ * forgets to render the error or call `validateFile`, the unit test
+ * passes and the bug ships. This E2E test guards the wiring.
+ */
+import { test, expect } from '@playwright/test';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { login } from './helpers/auth';
+import { goToSeededCourse } from './helpers/navigate';
+
+test.describe('Security — file upload validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToSeededCourse(page);
+    await expect(page.getByRole('button', { name: 'Import File' })).toBeVisible(
+      { timeout: 15_000 },
+    );
+  });
+
+  test('rejects a non-PDF file by MIME type — error visible, no toast success', async ({
+    page,
+  }) => {
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'malicious.exe',
+      mimeType: 'application/octet-stream',
+      // Real PE-header prefix to make the file look "executable-ish".
+      // The validation runs on file.type (MIME), not on the magic bytes,
+      // so contents are irrelevant — but real-looking bytes make the
+      // test scenario closer to an actual attack attempt.
+      buffer: Buffer.from('MZ\x90\x00\x03\x00\x00\x00fake-binary'),
+    });
+
+    // The hook surfaces validation errors as toast.error(...) AND/OR an
+    // inline <p class="text-destructive">. The exact text matches the
+    // hook's `Accepted file types: ...` template. Either surface must
+    // contain that string.
+    // Error renders both inline (<p class="text-destructive">) AND as a
+    // Sonner toast. Either surface is acceptable — assert on the first
+    // match so strict-mode doesn't complain about the duplicate.
+    await expect(page.getByText(/Accepted file types:/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // No success toast should ever appear for a rejected file.
+    await expect(page.getByText('File imported')).not.toBeVisible({
+      timeout: 1_000,
+    });
+  });
+
+  test('rejects a file larger than 50 MB — error visible, no toast success', async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+
+    // Playwright's `setInputFiles({ buffer })` caps inline payloads at
+    // 50 MB. To exercise the >50 MB branch we write the bytes to disk
+    // first and pass the path. Clean up after.
+    const tmpPath = join(tmpdir(), `typenote-oversized-${Date.now()}.pdf`);
+    const oversized = Buffer.alloc(50 * 1024 * 1024 + 1, 0x20);
+    await fs.writeFile(tmpPath, oversized);
+
+    try {
+      const fileInput = page.locator('input[type="file"]').first();
+      await fileInput.setInputFiles(tmpPath);
+
+      await expect(page.getByText(/under 50MB/i).first()).toBeVisible({
+        timeout: 5_000,
+      });
+
+      await expect(page.getByText('File imported')).not.toBeVisible({
+        timeout: 1_000,
+      });
+    } finally {
+      await fs.unlink(tmpPath).catch(() => {
+        /* best-effort cleanup */
+      });
+    }
+  });
+
+  test('rejects a double-extension file whose MIME is not application/pdf', async ({
+    page,
+  }) => {
+    // Classic disguise attempt: `report.pdf.exe`. Browser sets file.type
+    // from the OS MIME mapping; on a controlled fixture we pass the MIME
+    // explicitly. The hook validates `file.type`, NOT the name, so the
+    // .pdf in the middle does not save the file.
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'report.pdf.exe',
+      mimeType: 'application/x-msdownload',
+      buffer: Buffer.from('MZ\x90fake'),
+    });
+
+    // Error renders both inline (<p class="text-destructive">) AND as a
+    // Sonner toast. Either surface is acceptable — assert on the first
+    // match so strict-mode doesn't complain about the duplicate.
+    await expect(page.getByText(/Accepted file types:/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});

--- a/e2e/security-prompt-injection.spec.ts
+++ b/e2e/security-prompt-injection.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Security: prompt-injection resistance in AI chat responses.
+ *
+ * Threat model: An LLM can be coaxed (intentionally or accidentally) into
+ * emitting raw HTML in its response — `<script>`, `<img onerror>`, etc.
+ * If the chat panel ever switches its markdown renderer to allow raw HTML
+ * (e.g. by adding `rehype-raw`), an attacker who controls course content
+ * or the user's own prior chat history could persist a payload that
+ * executes inside another session.
+ *
+ * `react-markdown` defaults to NOT rendering raw HTML, but that's a
+ * single dependency-config flip from breaking. These tests pin the
+ * behavior end-to-end.
+ *
+ * Strategy:
+ *   - Mock /api/ai/ask to stream back a deterministic SSE response
+ *     containing common HTML/JS payloads.
+ *   - Send any question through the real chat UI.
+ *   - Assert: payload text is visible as text; no dialog fires;
+ *     no sentinel global was set.
+ */
+import { test, expect, type Dialog } from '@playwright/test';
+import { login } from './helpers/auth';
+import { goToSeededCourse } from './helpers/navigate';
+
+const PAYLOADS = {
+  scriptTag: '<script>window.__pi_fired_1=true;alert(1)</script>',
+  imgOnerror: '<img src=x onerror="window.__pi_fired_2=true">',
+  svgOnload: '<svg onload="window.__pi_fired_3=true"></svg>',
+};
+
+/** Build a single SSE stream that the chat panel will parse and render. */
+function buildSseBody(text: string): string {
+  // The client splits on \n\n and parses lines starting with "data: ".
+  const event = (obj: unknown) => `data: ${JSON.stringify(obj)}\n\n`;
+  return [
+    event({ type: 'sources', sources: [], model: 'flash' }),
+    event({ type: 'text', text }),
+  ].join('');
+}
+
+test.describe('Security — prompt-injection resistance in AI chat', () => {
+  test.beforeEach(async ({ page }) => {
+    // Generous quota so the chat input isn't disabled.
+    await page.route('**/api/ai/quota**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          chat: { used: 0, limit: 1000, remaining: 1000 },
+          latex: { used: 0, limit: 1000, remaining: 1000 },
+          tier: 'beta',
+        }),
+      });
+    });
+
+    // Suppress conversation history so the chat opens empty — keeps the
+    // test deterministic regardless of any stored conversations from
+    // previous E2E runs.
+    await page.route('**/api/ai/conversations**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ conversations: [] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await login(page);
+    await page.goto('/dashboard');
+    await goToSeededCourse(page);
+  });
+
+  test('AI response containing <script>/<img onerror>/<svg onload> renders as text and does NOT execute', async ({
+    page,
+  }) => {
+    // Capture any dialog as a hard failure signal.
+    const dialogs: Dialog[] = [];
+    page.on('dialog', async (d) => {
+      dialogs.push(d);
+      await d.dismiss();
+    });
+
+    const responseText = [
+      'Here is some content:',
+      PAYLOADS.scriptTag,
+      PAYLOADS.imgOnerror,
+      PAYLOADS.svgOnload,
+      'End.',
+    ].join('\n\n');
+
+    // Mock the chat endpoint to stream back the injection payload.
+    await page.route('**/api/ai/ask', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: buildSseBody(responseText),
+      });
+    });
+
+    // Open the chat bubble.
+    const openChat = page.getByRole('button', { name: 'Open AI chat' });
+    await expect(openChat).toBeVisible({ timeout: 10_000 });
+    await openChat.click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    // Send any question — the response is mocked, the content doesn't matter.
+    const input = page.locator('input[placeholder*="course materials"]');
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill('hello');
+    await page.keyboard.press('Enter');
+
+    // Wait for the assistant response bubble to appear.
+    // Assistant-rendered markdown lives in a `.prose` wrapper produced by
+    // <MarkdownResponse>. The streaming and the finalized message both
+    // render it. The mocked response is the most-recent assistant bubble
+    // — use `.last()` so any stored conversation history doesn't shadow it.
+    const responseBubble = page.locator('div.prose').last();
+    await expect(responseBubble).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the streamed text to settle (the "End." marker confirms the
+    // full payload was processed).
+    await expect(responseBubble).toContainText('End.', { timeout: 5_000 });
+
+    // The payload text must be visible as TEXT in the rendered bubble.
+    // react-markdown escapes raw HTML, so the literal `<script>` characters
+    // appear as text content.
+    const bubbleText = await responseBubble.textContent();
+    expect(bubbleText).toContain('<script>');
+    expect(bubbleText).toContain('onerror');
+
+    // None of the payloads' sentinel side-effects must have happened.
+    const fired = await page.evaluate(() => ({
+      f1: (window as unknown as { __pi_fired_1?: boolean }).__pi_fired_1,
+      f2: (window as unknown as { __pi_fired_2?: boolean }).__pi_fired_2,
+      f3: (window as unknown as { __pi_fired_3?: boolean }).__pi_fired_3,
+    }));
+    expect(fired.f1).toBeFalsy();
+    expect(fired.f2).toBeFalsy();
+    expect(fired.f3).toBeFalsy();
+    expect(dialogs).toHaveLength(0);
+
+    // Defense-in-depth: assert no live <script> in the bubble subtree
+    // (react-markdown should never emit one from response markdown).
+    const scriptCount = await responseBubble.evaluate(
+      (el) => el.querySelectorAll('script').length,
+    );
+    expect(scriptCount).toBe(0);
+  });
+
+  test('markdown-link with javascript: URL in AI response does not become a clickable execution sink', async ({
+    page,
+  }) => {
+    const dialogs: Dialog[] = [];
+    page.on('dialog', async (d) => {
+      dialogs.push(d);
+      await d.dismiss();
+    });
+
+    // A standard markdown link with a javascript: URL. react-markdown sanitizes
+    // URL protocols on `<a>` by default and replaces `javascript:` with a
+    // safe placeholder. This test pins that behavior.
+    const responseText = '[click me](javascript:window.__pi_fired_4=true)';
+
+    await page.route('**/api/ai/ask', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: buildSseBody(responseText),
+      });
+    });
+
+    const openChat = page.getByRole('button', { name: 'Open AI chat' });
+    await expect(openChat).toBeVisible({ timeout: 10_000 });
+    await openChat.click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    const input = page.locator('input[placeholder*="course materials"]');
+    await input.fill('hello');
+    await page.keyboard.press('Enter');
+
+    // Assistant-rendered markdown lives in a `.prose` wrapper produced by
+    // <MarkdownResponse>. The streaming and the finalized message both
+    // render it. The mocked response is the most-recent assistant bubble
+    // — use `.last()` so any stored conversation history doesn't shadow it.
+    const responseBubble = page.locator('div.prose').last();
+    await expect(responseBubble).toBeVisible({ timeout: 10_000 });
+    await expect(responseBubble).toContainText('click me', { timeout: 5_000 });
+
+    // Find the rendered link and check its href.
+    const link = responseBubble.locator('a', { hasText: 'click me' }).first();
+    const href = await link.getAttribute('href');
+    // react-markdown's default URL sanitizer replaces javascript: with
+    // `javascript:void(0)` or strips the protocol — either way, clicking
+    // must NOT execute. The cleanest assertion is: no live javascript:
+    // protocol survives.
+    expect(href ?? '').not.toMatch(/^javascript:/i);
+
+    // Attempt the click; nothing should fire.
+    await link.click().catch(() => {
+      /* link may be inert — that's a successful sanitization outcome */
+    });
+
+    const fired = await page.evaluate(
+      () => (window as unknown as { __pi_fired_4?: boolean }).__pi_fired_4,
+    );
+    expect(fired).toBeFalsy();
+    expect(dialogs).toHaveLength(0);
+  });
+});

--- a/src/lib/actions/course-weeks-materials.integration.test.ts
+++ b/src/lib/actions/course-weeks-materials.integration.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Integration tests for `course-weeks.ts` and `course-materials.ts` schema
+ * behavior — the parts the server actions rely on but that no other test
+ * exercises directly.
+ *
+ * Risk surfaces:
+ *
+ *   - UNIQUE(course_id, week_number) — prevents two "Week 1" rows in the same
+ *     course. createCourseWeek computes `max + 1` to avoid this, but the
+ *     constraint is the actual guarantee — pinning it ensures any future
+ *     auto-numbering bug fails loudly instead of silently.
+ *
+ *   - course_weeks.course_id CASCADE — deleting a course removes its weeks.
+ *   - course_materials.week_id CASCADE — deleting a week removes its materials.
+ *
+ *   - documents.week_id ON DELETE SET NULL — deleting a week must NOT delete
+ *     the documents in it; they keep their course_id. Contrast with
+ *     documents.course_id CASCADE — week-deletion is a re-organization,
+ *     course-deletion is destructive.
+ *
+ *   - chk_week_requires_course — week_id cannot be set without course_id.
+ *
+ *   - course_materials.category CHECK ('material' | 'homework').
+ *
+ *   - RLS USING on UPDATE/DELETE for both tables.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  TEST_USER_ID,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+const COURSE_ID = '7b000000-0000-0000-0000-000000000001';
+const WEEK_1_ID = '7b000000-0000-0000-0000-000000000002';
+const WEEK_2_ID = '7b000000-0000-0000-0000-000000000003';
+const MATERIAL_ID = '7b000000-0000-0000-0000-000000000010';
+const DOC_IN_WEEK_ID = '7b000000-0000-0000-0000-000000000020';
+const USER_B_COURSE_ID = '7b000000-0000-0000-0000-0000000000b0';
+const USER_B_WEEK_ID = '7b000000-0000-0000-0000-0000000000b1';
+const USER_B_MATERIAL_ID = '7b000000-0000-0000-0000-0000000000b2';
+
+const allTestIds = [
+  COURSE_ID,
+  WEEK_1_ID,
+  WEEK_2_ID,
+  MATERIAL_ID,
+  DOC_IN_WEEK_ID,
+  USER_B_COURSE_ID,
+  USER_B_WEEK_ID,
+  USER_B_MATERIAL_ID,
+];
+
+async function cleanupAll(): Promise<void> {
+  await admin.from('course_materials').delete().in('id', allTestIds);
+  await admin.from('course_weeks').delete().in('id', allTestIds);
+  await admin.from('documents').delete().in('id', allTestIds);
+  await admin.from('courses').delete().in('id', allTestIds);
+}
+
+async function seedCourse(courseId = COURSE_ID, userId = TEST_USER_ID) {
+  await admin.from('courses').insert({
+    id: courseId,
+    user_id: userId,
+    name: 'Test Course',
+    color: '#000000',
+    position: 0,
+  });
+}
+
+describe('course_weeks — schema behavior', () => {
+  beforeAll(cleanupAll);
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it('createCourseWeek: round-trips course_id/week_number/topic', async () => {
+    await seedCourse();
+
+    const { error } = await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+      topic: 'Introduction',
+    });
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('*')
+      .eq('id', WEEK_1_ID)
+      .single();
+    expect(data).toMatchObject({
+      course_id: COURSE_ID,
+      week_number: 1,
+      topic: 'Introduction',
+    });
+  });
+
+  it('UNIQUE(course_id, week_number) rejects a duplicate Week 1', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('course_weeks').insert({
+      id: WEEK_2_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    expect(error).not.toBeNull();
+    // Supabase surfaces the constraint name in error.message
+    expect(error!.message).toMatch(/duplicate|unique/i);
+  });
+
+  it('deleting a course CASCADES to its weeks (FK course_weeks.course_id ON DELETE CASCADE)', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    await admin.from('courses').delete().eq('id', COURSE_ID);
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('id')
+      .eq('id', WEEK_1_ID);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('deleting a week sets documents.week_id NULL but keeps course_id (re-organization, not destructive)', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+    await admin.from('documents').insert({
+      id: DOC_IN_WEEK_ID,
+      user_id: TEST_USER_ID,
+      course_id: COURSE_ID,
+      week_id: WEEK_1_ID,
+      title: 'Doc in week',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    await admin.from('course_weeks').delete().eq('id', WEEK_1_ID);
+
+    const { data } = await admin
+      .from('documents')
+      .select('id, week_id, course_id')
+      .eq('id', DOC_IN_WEEK_ID)
+      .single();
+    // Doc survives — its week_id is null, course_id still set.
+    expect(data).not.toBeNull();
+    expect(data!.week_id).toBeNull();
+    expect(data!.course_id).toBe(COURSE_ID);
+  });
+
+  it('chk_week_requires_course rejects a doc with week_id but no course_id', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('documents').insert({
+      id: DOC_IN_WEEK_ID,
+      user_id: TEST_USER_ID,
+      course_id: null,
+      week_id: WEEK_1_ID,
+      title: 'Should fail',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/chk_week_requires_course/i);
+  });
+});
+
+describe('course_materials — schema behavior', () => {
+  beforeAll(cleanupAll);
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it('createCourseMaterial: round-trips required fields', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_1_ID,
+      user_id: TEST_USER_ID,
+      category: 'material',
+      storage_path: `${TEST_USER_ID}/lec01.pdf`,
+      file_name: 'lec01.pdf',
+      label: 'Lecture 1',
+      file_size: 4096,
+      mime_type: 'application/pdf',
+    });
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('course_materials')
+      .select('*')
+      .eq('id', MATERIAL_ID)
+      .single();
+    expect(data).toMatchObject({
+      week_id: WEEK_1_ID,
+      category: 'material',
+      file_name: 'lec01.pdf',
+      label: 'Lecture 1',
+    });
+  });
+
+  it("category CHECK constraint rejects values other than 'material' | 'homework'", async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_1_ID,
+      user_id: TEST_USER_ID,
+      category: 'lecture-notes', // not allowed
+      storage_path: `${TEST_USER_ID}/bad.pdf`,
+      file_name: 'bad.pdf',
+      file_size: 1,
+      mime_type: 'application/pdf',
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/check|category/i);
+  });
+
+  it('deleting a week CASCADES to its materials (FK course_materials.week_id ON DELETE CASCADE)', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+    await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_1_ID,
+      user_id: TEST_USER_ID,
+      category: 'material',
+      storage_path: `${TEST_USER_ID}/x.pdf`,
+      file_name: 'x.pdf',
+      file_size: 1,
+      mime_type: 'application/pdf',
+    });
+
+    await admin.from('course_weeks').delete().eq('id', WEEK_1_ID);
+
+    const { data } = await admin
+      .from('course_materials')
+      .select('id')
+      .eq('id', MATERIAL_ID);
+    expect(data ?? []).toHaveLength(0);
+  });
+});
+
+describe('course_weeks + course_materials — RLS write enforcement', () => {
+  let clientA: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+
+    await admin.from('course_materials').delete().eq('id', USER_B_MATERIAL_ID);
+    await admin.from('course_weeks').delete().eq('id', USER_B_WEEK_ID);
+    await admin.from('courses').delete().eq('id', USER_B_COURSE_ID);
+
+    await admin.from('courses').insert({
+      id: USER_B_COURSE_ID,
+      user_id: TEST_USER_B.id,
+      name: "B's course",
+      color: '#0000FF',
+      position: 0,
+    });
+    await admin.from('course_weeks').insert({
+      id: USER_B_WEEK_ID,
+      course_id: USER_B_COURSE_ID,
+      user_id: TEST_USER_B.id,
+      week_number: 1,
+      topic: "B's week",
+    });
+    await admin.from('course_materials').insert({
+      id: USER_B_MATERIAL_ID,
+      week_id: USER_B_WEEK_ID,
+      user_id: TEST_USER_B.id,
+      category: 'homework',
+      storage_path: `${TEST_USER_B.id}/private.pdf`,
+      file_name: 'private.pdf',
+      file_size: 1,
+      mime_type: 'application/pdf',
+    });
+  });
+
+  afterAll(async () => {
+    await admin.from('course_materials').delete().eq('id', USER_B_MATERIAL_ID);
+    await admin.from('course_weeks').delete().eq('id', USER_B_WEEK_ID);
+    await admin.from('courses').delete().eq('id', USER_B_COURSE_ID);
+  });
+
+  it("User A's UPDATE on User B's course_week affects 0 rows", async () => {
+    await clientA
+      .from('course_weeks')
+      .update({ topic: 'hacked-by-a' })
+      .eq('id', USER_B_WEEK_ID);
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('topic')
+      .eq('id', USER_B_WEEK_ID)
+      .single();
+    expect(data!.topic).toBe("B's week");
+  });
+
+  it("User A's DELETE on User B's course_week affects 0 rows", async () => {
+    await clientA.from('course_weeks').delete().eq('id', USER_B_WEEK_ID);
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('id')
+      .eq('id', USER_B_WEEK_ID);
+    expect(data ?? []).toHaveLength(1);
+  });
+
+  it("User A's DELETE on User B's course_material affects 0 rows", async () => {
+    await clientA
+      .from('course_materials')
+      .delete()
+      .eq('id', USER_B_MATERIAL_ID);
+
+    const { data } = await admin
+      .from('course_materials')
+      .select('id')
+      .eq('id', USER_B_MATERIAL_ID);
+    expect(data ?? []).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary

One bundled PR combining four test additions from the test-suite audit, per request.

### Files

| File | Tests | Tier |
|------|-------|------|
| `src/lib/actions/course-weeks-materials.integration.test.ts` | 11 | C |
| `e2e/security-prompt-injection.spec.ts` | 2 | D |
| `e2e/security-file-upload.spec.ts` | 3 | D |
| `e2e/TEST_REGISTRY.md` | — | — |

**Total: 16 new tests.**

### What's covered

**course_weeks + course_materials schema/RLS (Tier C):**
- `UNIQUE(course_id, week_number)` duplicate rejection
- `course_weeks.course_id ON DELETE CASCADE`, `course_materials.week_id ON DELETE CASCADE`
- `documents.week_id ON DELETE SET NULL` — week deletion is **re-organization**, not destructive; contrast with `documents.course_id ON DELETE CASCADE` which IS destructive. Pinning the difference prevents an accidental flip that would silently destroy notes when a user trims weeks.
- `chk_week_requires_course` and `course_materials.category` CHECK constraints
- RLS `USING` clause on `UPDATE`/`DELETE` for both tables

**Prompt-injection in AI chat (Tier D):**
- AI response containing `<script>`/`<img onerror>`/`<svg onload>` renders as text and does NOT execute (no dialogs, no sentinel globals)
- Markdown link with `javascript:` URL gets URL-sanitized — clicking it is inert
- Both use `page.route()` to stream mocked SSE; no real Gemini key needed, runs unconditionally in CI
- Defends against a one-line `rehype-raw` regression that would otherwise turn every model jailbreak/stored context into stored-XSS

**File-upload validation (Tier D):**
- Non-PDF rejected by MIME type; success toast must not appear
- >50 MB file rejected (uses `fs` tmp path because Playwright's inline-buffer cap is 50 MB)
- Double-extension `report.pdf.exe` (octet-stream MIME) rejected — pins that validation reads `file.type`, not the name. The corresponding hook unit test (`use-file-upload.test.ts`) covers `validateFile` in isolation; this guards the wiring in `material-upload.tsx`.

### Test plan

- [x] `pnpm test:integration` — 138/138 pass (~5.5s)
- [x] `pnpm test:e2e --grep "Security"` — 7/7 pass (~12s)
- [x] `prettier --write` applied to all new files
- [x] `pnpm lint` — 0 errors (only pre-existing warnings elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)