### PR TITLE
test: round 3 — storage RLS + MarkdownResponse XSS unit tests (9 tests)

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -218,6 +218,12 @@ context-menu entry point works end-to-end.
 
 ---
 
+## Security — Storage RLS (integration test, not E2E)
+
+Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verifies path-prefix RLS on the `personal-files` Storage bucket: list/download/upload/delete attempts on a path NOT owned by the calling user are rejected.
+
+---
+
 ## Summary
 
 | Feature               | Status      | Spec File                           | Tests     |

--- a/src/__tests__/integration/storage-rls.integration.test.ts
+++ b/src/__tests__/integration/storage-rls.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Storage-bucket RLS isolation tests.
+ *
+ * The `personal-files` and `course-materials` buckets are PRIVATE
+ * (`public: false`) and guard cross-user access via path-prefix RLS:
+ *
+ *   USING (
+ *     bucket_id = 'personal-files'
+ *     AND auth.uid()::text = (storage.foldername(name))[1]
+ *   )
+ *
+ * In plain English: a file at `{user_id}/anything.pdf` is only
+ * readable/writable by the user whose UUID is the first path segment.
+ *
+ * Existing tests verify the *table* RLS (`rls-isolation.integration.test.ts`)
+ * but not the storage layer. If the path-prefix policy is dropped or
+ * mis-written, a forged path could let user A list and download every
+ * other user's private files. These tests pin the storage policy.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+const BUCKET = 'personal-files';
+const FILE_NAME = `rls-test-${Date.now()}.pdf`;
+const PATH_A = `${TEST_USER_A.id}/${FILE_NAME}`;
+const PATH_B = `${TEST_USER_B.id}/${FILE_NAME}`;
+
+const PDF_BYTES = new Uint8Array(
+  Buffer.from('%PDF-1.4\n%fake pdf for rls test\n%%EOF'),
+);
+
+async function cleanup() {
+  // Use admin to remove any leftover fixtures. Best-effort.
+  await admin.storage
+    .from(BUCKET)
+    .remove([PATH_A, PATH_B])
+    .catch(() => {
+      /* ignore */
+    });
+}
+
+describe('storage RLS — personal-files bucket', () => {
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    clientB = await createUserClient(TEST_USER_B);
+    await cleanup();
+
+    // Seed: each user uploads ONE file under their own user-id prefix.
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const upA = await clientA.storage.from(BUCKET).upload(PATH_A, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upA.error) throw new Error(`seed A: ${upA.error.message}`);
+
+    const upB = await clientB.storage.from(BUCKET).upload(PATH_B, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upB.error) throw new Error(`seed B: ${upB.error.message}`);
+  });
+
+  afterAll(cleanup);
+
+  it("User A's list of their own folder returns only their file (RLS scope by path prefix)", async () => {
+    const { data, error } = await clientA.storage
+      .from(BUCKET)
+      .list(TEST_USER_A.id);
+    expect(error).toBeNull();
+    const names = (data ?? []).map((o) => o.name);
+    expect(names).toContain(FILE_NAME);
+  });
+
+  it("User A's list of User B's folder returns empty (RLS blocks cross-user listing)", async () => {
+    const { data } = await clientA.storage.from(BUCKET).list(TEST_USER_B.id);
+    // Storage RLS makes the listing return empty rather than an error.
+    // Either way, the file must not appear.
+    const names = (data ?? []).map((o) => o.name);
+    expect(names).not.toContain(FILE_NAME);
+  });
+
+  it("User A's download of User B's file fails (RLS blocks cross-user read)", async () => {
+    const { data, error } = await clientA.storage.from(BUCKET).download(PATH_B);
+    // Storage returns either `error` or `null`/empty data. We accept
+    // either failure mode but never a successful cross-user read.
+    if (!error && data) {
+      const text = await data.text();
+      // If we got bytes, they must not contain the PDF header — a
+      // common false-pass mode is getting back a public placeholder.
+      expect(text).not.toContain('%PDF');
+    }
+  });
+
+  it("User A's upload to User B's path fails (RLS WITH CHECK blocks spoofed prefix)", async () => {
+    const spoofPath = `${TEST_USER_B.id}/spoof-by-a.pdf`;
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const { error } = await clientA.storage
+      .from(BUCKET)
+      .upload(spoofPath, blob, {
+        contentType: 'application/pdf',
+        upsert: false,
+      });
+    expect(error).not.toBeNull();
+    // Best-effort cleanup if the policy missed and the upload landed.
+    await admin.storage
+      .from(BUCKET)
+      .remove([spoofPath])
+      .catch(() => {});
+  });
+
+  it("User A's delete of User B's file fails (RLS blocks cross-user delete)", async () => {
+    await clientA.storage.from(BUCKET).remove([PATH_B]);
+
+    // Verify B's file still exists by admin-listing the folder.
+    const { data } = await admin.storage.from(BUCKET).list(TEST_USER_B.id);
+    const names = (data ?? []).map((o) => o.name);
+    expect(names).toContain(FILE_NAME);
+  });
+});

--- a/src/components/ai/__tests__/markdown-response.test.tsx
+++ b/src/components/ai/__tests__/markdown-response.test.tsx
@@ -94,3 +94,56 @@ describe('MarkdownResponse', () => {
     expect(container.innerHTML).toBe('');
   });
 });
+
+/**
+ * XSS-safety: unit-level guard for the same property the E2E
+ * `e2e/security-prompt-injection.spec.ts` covers.
+ *
+ * react-markdown by default does NOT render raw HTML. The moment
+ * someone adds `rehype-raw` (or any plugin that emits raw HTML), the
+ * `<script>` count below jumps from 0 and this test fails — much
+ * cheaper than catching the regression 30s into an E2E run.
+ */
+describe('MarkdownResponse — XSS safety', () => {
+  it('does not emit a live <script> for inline <script> in markdown', () => {
+    const { container } = render(
+      <MarkdownResponse content="hello <script>window.__md_xss=true</script> world" />,
+    );
+    expect(container.querySelectorAll('script')).toHaveLength(0);
+    // The literal characters appear as text (escaped) so a reader sees
+    // what the model said.
+    expect(container.textContent).toContain('<script>');
+  });
+
+  it('does not emit an <img> with an onerror sink', () => {
+    const { container } = render(
+      <MarkdownResponse content='<img src=x onerror="window.__md_xss=true">' />,
+    );
+    for (const img of Array.from(container.querySelectorAll('img'))) {
+      expect(img.getAttribute('onerror')).toBeNull();
+    }
+    expect(container.textContent).toContain('onerror');
+  });
+
+  it('sanitizes javascript: URLs in markdown links', () => {
+    const { container } = render(
+      <MarkdownResponse content="[click](javascript:window.__md_xss=true)" />,
+    );
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    // react-markdown's URL allowlist replaces unsafe protocols. Either
+    // the protocol is stripped (href becomes empty/about:blank) or
+    // replaced — what matters is that no live javascript: remains.
+    expect(link!.getAttribute('href') ?? '').not.toMatch(/^javascript:/i);
+    expect(link!.textContent).toBe('click');
+  });
+
+  it('preserves safe https:// URLs (regression guard against over-sanitization)', () => {
+    const { container } = render(
+      <MarkdownResponse content="[docs](https://example.com)" />,
+    );
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toBe('https://example.com');
+  });
+});


### PR DESCRIPTION
## Summary

Round 3 bundle. Companion to #158 and #159.

| File | Tests | Tier |
|------|-------|------|
| `src/__tests__/integration/storage-rls.integration.test.ts` | 5 | D |
| `src/components/ai/__tests__/markdown-response.test.tsx` (extended) | +4 (11 total) | D |
| `e2e/TEST_REGISTRY.md` | — | — |

**Total: 9 new test cases.**

### Storage RLS (Tier D)

The `personal-files` bucket is private (`public: false`) and uses path-prefix RLS — the file at `{user_id}/anything.pdf` is only readable/writable by that user. The existing `rls-isolation` test covers TABLE RLS but not storage. If the storage policy is dropped or mis-written, a forged path lets user A enumerate every other user's private files.

These tests use two real anon-key clients signed in as `TEST_USER_A` and `TEST_USER_B` to verify:
- List, download, upload to spoofed path, delete — all cross-user attempts fail

### MarkdownResponse XSS unit tests (Tier D, complements E2E in #158)

The E2E in `security-prompt-injection.spec.ts` already covers the AI chat flow end-to-end. These 4 new unit cases pin the SAME property at the component level — much cheaper, and the failure mode is unambiguous: if someone adds `rehype-raw`, this fails immediately at the unit layer instead of 30s into an E2E run.

## Test plan

- [x] `pnpm test:integration` — 148/148 pass (~5s)
- [x] `pnpm test src/components/ai/__tests__/markdown-response.test.tsx` — 11/11 pass (~2s)
- [x] `prettier --write` applied
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)