### PR TITLE
test: round 4 — storage RLS for other buckets + AI search validation (16 tests)

### DIFF
--- a/src/__tests__/integration/storage-rls-buckets.integration.test.ts
+++ b/src/__tests__/integration/storage-rls-buckets.integration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Storage RLS — coverage for the OTHER two storage buckets the app uses,
+ * with their distinct access models. Companion to
+ * `storage-rls.integration.test.ts` which covers `personal-files`.
+ *
+ *   - `course-materials`:  same per-user path-prefix RLS as personal-files
+ *   - `moodle-materials`:  shared "any authenticated user can read"; no
+ *                          regular-user writes (service-role only)
+ *
+ * Why this matters: each bucket has its OWN policy set. A migration
+ * could drop one bucket's policy without affecting the other, and the
+ * existing personal-files test would still pass. Per-bucket tests
+ * catch that.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import {
+  SUPABASE_ANON_KEY,
+  TEST_USER_A,
+  TEST_USER_B,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321';
+
+const admin = createAdminClient();
+
+const PDF_BYTES = new Uint8Array(
+  Buffer.from('%PDF-1.4\n%fake pdf for storage rls\n%%EOF'),
+);
+
+// ─── course-materials ──────────────────────────────────────────────
+
+describe('storage RLS — course-materials bucket (per-user path prefix)', () => {
+  const BUCKET = 'course-materials';
+  const FILE_NAME = `rls-cm-${Date.now()}.pdf`;
+  const PATH_A = `${TEST_USER_A.id}/${FILE_NAME}`;
+  const PATH_B = `${TEST_USER_B.id}/${FILE_NAME}`;
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  async function cleanup() {
+    await admin.storage
+      .from(BUCKET)
+      .remove([PATH_A, PATH_B])
+      .catch(() => {});
+  }
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    clientB = await createUserClient(TEST_USER_B);
+    await cleanup();
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const upA = await clientA.storage.from(BUCKET).upload(PATH_A, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upA.error) throw new Error(`seed A: ${upA.error.message}`);
+    const upB = await clientB.storage.from(BUCKET).upload(PATH_B, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upB.error) throw new Error(`seed B: ${upB.error.message}`);
+  });
+
+  afterAll(cleanup);
+
+  it("User A cannot list User B's folder", async () => {
+    const { data } = await clientA.storage.from(BUCKET).list(TEST_USER_B.id);
+    expect((data ?? []).map((o) => o.name)).not.toContain(FILE_NAME);
+  });
+
+  it("User A's upload to User B's path is rejected", async () => {
+    const spoofPath = `${TEST_USER_B.id}/spoof-cm.pdf`;
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const { error } = await clientA.storage
+      .from(BUCKET)
+      .upload(spoofPath, blob, {
+        contentType: 'application/pdf',
+        upsert: false,
+      });
+    expect(error).not.toBeNull();
+    await admin.storage
+      .from(BUCKET)
+      .remove([spoofPath])
+      .catch(() => {});
+  });
+
+  it("User A's delete of User B's file is silently noop'd", async () => {
+    await clientA.storage.from(BUCKET).remove([PATH_B]);
+    const { data } = await admin.storage.from(BUCKET).list(TEST_USER_B.id);
+    expect((data ?? []).map((o) => o.name)).toContain(FILE_NAME);
+  });
+});
+
+// ─── moodle-materials ──────────────────────────────────────────────
+
+describe('storage RLS — moodle-materials bucket (shared read, no user writes)', () => {
+  const BUCKET = 'moodle-materials';
+  // moodle-materials is a SHARED bucket — paths are NOT prefixed by
+  // user id. We seed a known fixture as admin (the only role allowed
+  // to write) and verify each access mode.
+  const FIXTURE_PATH = `rls-fixtures/moodle-fixture-${Date.now()}.pdf`;
+  let clientA: SupabaseClient;
+  let anonClient: SupabaseClient;
+
+  async function cleanup() {
+    await admin.storage
+      .from(BUCKET)
+      .remove([FIXTURE_PATH])
+      .catch(() => {});
+  }
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    anonClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    await cleanup();
+
+    // Seed with admin (service role); no user policy permits INSERT.
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const { error } = await admin.storage
+      .from(BUCKET)
+      .upload(FIXTURE_PATH, blob, {
+        contentType: 'application/pdf',
+        upsert: true,
+      });
+    if (error) throw new Error(`moodle seed: ${error.message}`);
+  });
+
+  afterAll(cleanup);
+
+  it('any authenticated user CAN download the fixture (shared-read policy)', async () => {
+    const { data, error } = await clientA.storage
+      .from(BUCKET)
+      .download(FIXTURE_PATH);
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    const text = await data!.text();
+    // The bytes we uploaded survive a round-trip.
+    expect(text).toContain('%PDF-1.4');
+  });
+
+  it('an anon (signed-out) client CANNOT download the fixture', async () => {
+    const { data, error } = await anonClient.storage
+      .from(BUCKET)
+      .download(FIXTURE_PATH);
+    if (!error && data) {
+      const text = await data.text();
+      // Anything other than a failure must NOT contain the PDF bytes.
+      expect(text).not.toContain('%PDF-1.4');
+    }
+  });
+
+  it('a regular authenticated user CANNOT upload to moodle-materials (service-role only)', async () => {
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const sneakyPath = `rls-fixtures/sneak-by-user-${Date.now()}.pdf`;
+    const { error } = await clientA.storage
+      .from(BUCKET)
+      .upload(sneakyPath, blob, {
+        contentType: 'application/pdf',
+        upsert: false,
+      });
+    expect(error).not.toBeNull();
+    await admin.storage
+      .from(BUCKET)
+      .remove([sneakyPath])
+      .catch(() => {});
+  });
+
+  it('a regular authenticated user CANNOT delete from moodle-materials', async () => {
+    await clientA.storage.from(BUCKET).remove([FIXTURE_PATH]);
+    // Admin can still see the fixture — it was not actually removed.
+    const { data, error } = await admin.storage
+      .from(BUCKET)
+      .download(FIXTURE_PATH);
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+  });
+});

--- a/src/app/api/ai/search/validation.test.ts
+++ b/src/app/api/ai/search/validation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Input-validation tests for GET /api/ai/search.
+ *
+ * The route is the RAG entry point — callers pass `query` and `courseId`
+ * (plus optional `weekId`, `maxResults`). Bad inputs must return 4xx
+ * BEFORE touching `searchContext`, otherwise a malformed call could
+ * trigger a costly embedding lookup or DB scan on every request.
+ *
+ * Mirrors the existing `src/app/api/ai/ask/validation.test.ts` pattern:
+ * mock `searchContext` at module level, then drive the route with
+ * various URLs and assert response status + error shape.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearchContext = vi.fn();
+vi.mock('@/lib/actions/ai-context', () => ({
+  searchContext: (...args: unknown[]) => mockSearchContext(...args),
+}));
+
+import { GET } from './route';
+
+function makeReq(query: Record<string, string>): Request {
+  const url = new URL('http://test/api/ai/search');
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return new Request(url, { method: 'GET' });
+}
+
+describe('GET /api/ai/search — input validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchContext.mockResolvedValue([]);
+  });
+
+  it('rejects missing query with 400', async () => {
+    const res = await GET(makeReq({ courseId: 'c1' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/query/i);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty/whitespace-only query with 400', async () => {
+    const res = await GET(makeReq({ query: '   ', courseId: 'c1' }));
+    expect(res.status).toBe(400);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing courseId with 400', async () => {
+    const res = await GET(makeReq({ query: 'derivative' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/courseId/i);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-integer maxResults with 400', async () => {
+    const res = await GET(
+      makeReq({ query: 'q', courseId: 'c1', maxResults: 'banana' }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/maxResults/i);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative or zero maxResults with 400', async () => {
+    const res = await GET(
+      makeReq({ query: 'q', courseId: 'c1', maxResults: '0' }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid request and trims the query before passing it on', async () => {
+    mockSearchContext.mockResolvedValue([{ id: 'x', sourceName: 'lec01.pdf' }]);
+    const res = await GET(makeReq({ query: '  derivative  ', courseId: 'c1' }));
+    expect(res.status).toBe(200);
+    expect(mockSearchContext).toHaveBeenCalledWith({
+      query: 'derivative',
+      courseId: 'c1',
+      weekId: undefined,
+      maxResults: undefined,
+    });
+  });
+
+  it('forwards weekId and maxResults when provided', async () => {
+    mockSearchContext.mockResolvedValue([]);
+    await GET(
+      makeReq({
+        query: 'q',
+        courseId: 'c1',
+        weekId: 'w1',
+        maxResults: '5',
+      }),
+    );
+    expect(mockSearchContext).toHaveBeenCalledWith({
+      query: 'q',
+      courseId: 'c1',
+      weekId: 'w1',
+      maxResults: 5,
+    });
+  });
+
+  it('maps an "Unauthorized" thrown by searchContext to a 401 response', async () => {
+    mockSearchContext.mockRejectedValue(new Error('Unauthorized'));
+    const res = await GET(makeReq({ query: 'q', courseId: 'c1' }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/unauth/i);
+  });
+
+  it('maps any other thrown error to a 500 without leaking the message', async () => {
+    mockSearchContext.mockRejectedValue(new Error('internal connection wat'));
+    const res = await GET(makeReq({ query: 'q', courseId: 'c1' }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    // The route returns a generic "Failed to search context" — the raw
+    // error message must NOT leak to the client.
+    expect(data.error).not.toContain('connection wat');
+  });
+});


### PR DESCRIPTION
## Summary

Round-4 bundle. Companion to #158, #159, #160.

| File | Tests |
|------|-------|
| `src/__tests__/integration/storage-rls-buckets.integration.test.ts` | 7 |
| `src/app/api/ai/search/validation.test.ts` | 9 |

**Total: 16 new tests.**

### Storage RLS — course-materials + moodle-materials (Tier D)

Each Storage bucket has its OWN policy set. PR #160 covered `personal-files`; this PR covers the other two:

- **course-materials**: same per-user path-prefix model. Cross-user list/upload/delete all rejected.
- **moodle-materials**: SHARED model. Any *authenticated* user can read, but anon cannot, and only service-role can write. Verified via a separate anon-key client created without sign-in.

A migration that drops one bucket's policy wouldn't affect the others, so per-bucket coverage is necessary.

### `/api/ai/search` validation (Tier C)

Mirrors the validation pattern from `/api/ai/ask` (already covered in #148). Bad input rejected BEFORE the RAG embedding lookup — important because every malformed call would otherwise hit pgvector.

- Missing/empty `query` or `courseId` → 400
- Non-integer or zero `maxResults` → 400
- Valid request trims `query` and forwards `weekId`/`maxResults`
- `searchContext` throwing "Unauthorized" → 401
- Other errors → 500 with generic message (no raw error leak to client)

## Test plan

- [x] `pnpm test:integration` — 155/155 pass (~5s)
- [x] `pnpm test src/app/api/ai/search/validation.test.ts` — 9/9 pass (~1s)
- [x] `prettier --write` applied
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)