### PR TITLE
feat(extension): allow typenote-two.vercel.app in externally_connectable

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -14,7 +14,8 @@
       "http://localhost:3000/*",
       "http://localhost:3001/*",
       "http://151.145.83.151:3001/*",
-      "https://*.typenote.app/*"
+      "https://*.typenote.app/*",
+      "https://typenote-two.vercel.app/*"
     ]
   },
   "web_accessible_resources": [


### PR DESCRIPTION
## Summary

- Add `https://typenote-two.vercel.app/*` to the extension's `externally_connectable.matches`
- Without it, `chrome.runtime.sendMessage` from the prod page is dropped silently, so the dashboard card never transitions out of `not-installed` even with the extension loaded
- Discovered while testing the full installed flow against prod after #154 landed

## Test plan

- [x] `pnpm test` — 849/849 passing
- [x] `npm run build` in `extension/` — service-worker + content script bundles ok
- [x] Manifest JSON parses, new host present in the matches array
- [ ] After merge: set `NEXT_PUBLIC_EXTENSION_ID=beajdnpmcbgjfkhojoangknkeimimmfm` on Vercel prod, redeploy, install unpacked extension from main, verify card transitions to "Enter your Moodle URL" and the connect → sync flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)