### PR TITLE
fix(extension): add host_permissions for upload endpoint

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,12 @@
   "description": "Import course materials from Moodle into Typenote",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmAsETPFXkIxxNHGIsBGrtCXNqx3OSLT/BDLyd22QD6Es4IwKlMN3Png15xHpOB+RRaExNC0DtyW73/dnvSEJRJD8vTWV6JWijUeKRP2BGwk06kLTwz0u+RETLJRRvvnfgUh+WiaeX+hFZlfpFXo5zSJP6EhmZq4Asxhc0MIDyAD5JlLtgivQhy3CoFz8eyiAFcziwSKobnUVaEAm96ayjVStCyrayoz676estF5yNRSii/E5XCNdFGVbuiD70wjF3NH2KdxQm1JiGXUrZyefCtVO0cHov5akc+TWT1YIvBrcYaHuXFN/Uf4oJgzhkj9l5uEDPWdx3ajiv1WXbZirmQIDAQAB",
   "permissions": ["storage", "scripting", "cookies", "tabs", "activeTab"],
+  "host_permissions": [
+    "http://localhost:3000/*",
+    "http://localhost:3001/*",
+    "https://*.typenote.app/*",
+    "https://typenote-two.vercel.app/*"
+  ],
   "optional_host_permissions": ["<all_urls>"],
   "background": {
     "service_worker": "dist/background/service-worker.js"


### PR DESCRIPTION
## Summary

- Service worker's DOWNLOAD_AND_UPLOAD handler `fetch()`s `${webAppOrigin}/api/moodle/upload`.
- Without a matching `host_permission`, the browser treated this as a CORS-controlled extension fetch — the API route returns no CORS headers, so every upload failed with `TypeError: Failed to fetch` before any HTTP response.
- Adds Typenote origins to `host_permissions` (granted at install time, no prompt). Moodle hosts intentionally stay in `optional_host_permissions` (per-user, runtime grant).
- Discovered while testing the full sync flow end-to-end after #163 unblocked the scraper.

## Test plan

- [x] `pnpm test` — passes
- [x] Manual: 3 files that previously failed with `Failed to fetch` now upload successfully after reloading the extension with the new manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)