### PR TITLE
ci: auto-deploy main pushes to Vercel via CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,3 +110,41 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  # Auto-deploy main pushes to Vercel production.
+  # The Vercel GitHub App is not installed on the galigoldman account, so we
+  # cannot use Vercel's native Git integration. Instead we invoke the Vercel
+  # CLI directly with a token + project IDs stored as repo secrets. Runs only
+  # on the post-merge push to main and only if `ci` is green.
+  deploy:
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@51
+
+      - name: Pull Vercel production env
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Build production bundle
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy prebuilt artifacts to production
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- Adds a `deploy` job to `.github/workflows/ci.yml` that runs after `ci` succeeds on a push to `main` and pushes the build to Vercel production using the Vercel CLI.
- Replaces the broken Git integration: the Vercel GitHub App is not installed on the `galigoldman` account, so no main-branch push since 2026-05-15 has triggered a deploy. The latest extension/permission fix (`7ea9ec2`) had to be deployed manually via CLI.
- Uses three repo secrets already added: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.

## Why CLI, not GitHub App
The Vercel API's link endpoint rejects `galigoldman/Typenote` with `"Install GitHub App"`. Installing the app requires the repo owner (`galigoldman`) to approve it on https://github.com/apps/vercel — that flow can't be automated. The CLI route works today without any human action on the GitHub side.

## Security note
`VERCEL_TOKEN` is the user-scoped CLI token (full account access). Recommended follow-up: rotate to a project-scoped token from https://vercel.com/account/tokens.

## Test plan
- [ ] PR CI runs the existing `ci` job (the new `deploy` job is gated to `push` events on `main`, so it skips on PRs — verify it shows as "Skipped").
- [ ] After merge to `main`, the `deploy` job runs and `https://typenote-two.vercel.app` shows a fresh deployment timestamp.
- [ ] `vercel ls typenote-two` lists a new Production deployment matching the merge SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)