### PR TITLE
fix(moodle): classify cross-host redirects as login expiry, not permission revocation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,6 @@ node_modules
 .next
 pnpm-lock.yaml
 public/pdf.worker.min.mjs
+.chrome-debug
+.chrome-debug-moodle
+.claude/worktrees

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,8 @@ const eslintConfig = defineConfig([
     '.claude/**',
     '.specify/**',
     'public/pdf.worker.min.mjs',
+    '.chrome-debug/**',
+    '.chrome-debug-moodle/**',
   ]),
 ]);
 

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -193,6 +193,41 @@ function waitForTabLoad(tabId: number): Promise<void> {
  * one of its exported functions, returning the result.
  */
 /**
+ * Detects whether a tab URL is a login redirect rather than the expected
+ * Moodle page. Returns true if either:
+ *   1. The hostname differs from the expected URL (Moodle bounced to an SSO
+ *      provider on a different domain like `login.runi.ac.il` or `idp.*`).
+ *      This is the canonical signal — if we cannot read the tab, mapping it
+ *      to PERMISSION_DENIED would lie when the real cause is an expired
+ *      session that triggered the redirect.
+ *   2. The path looks like an in-domain login flow (`/login/`, `/auth/`,
+ *      `sso`, `saml`) but is not the page we asked for.
+ */
+function isLoginRedirect(tabUrl: string, expectedUrl: string): boolean {
+  if (!tabUrl) return false;
+  let tabHost = '';
+  let expectedHost = '';
+  try {
+    tabHost = new URL(tabUrl).hostname;
+    expectedHost = new URL(expectedUrl).hostname;
+  } catch {
+    return false;
+  }
+  if (tabHost && expectedHost && tabHost !== expectedHost) return true;
+  const expectedPath = (() => {
+    try {
+      return new URL(expectedUrl).pathname;
+    } catch {
+      return '';
+    }
+  })();
+  return (
+    /\/login\/|\/auth\/|sso|saml|oauth|idp\./i.test(tabUrl) &&
+    !tabUrl.endsWith(expectedPath)
+  );
+}
+
+/**
  * Custom error class so handlers can attach a structured error code that
  * the web app branches on (PERMISSION_DENIED vs NOT_LOGGED_IN vs raw).
  */
@@ -292,13 +327,34 @@ async function handleCheckLogin(moodleUrl: string): Promise<ExtensionResponse> {
       return { success: true, data: { loggedIn: false } as LoginStatusData };
     }
 
-    // Cookie exists, but may be expired — verify by injecting into a tab
+    // Cookie exists, but may be expired — verify by injecting into a tab.
     const tabId = await getOrCreateMoodleTab(moodleUrl);
-    const data = await executeScraperFunction<LoginStatusData>(
-      tabId,
-      'scrapeLoginStatus',
-    );
-    return { success: true, data };
+    const tab = await chrome.tabs.get(tabId);
+    if (isLoginRedirect(tab.url ?? '', moodleUrl)) {
+      // Moodle bounced the tab off-domain for SSO → server-side session is
+      // dead. Treat as logged-out so callers (and the dashboard's
+      // disambiguation) get a clean signal rather than a generic failure.
+      return { success: true, data: { loggedIn: false } as LoginStatusData };
+    }
+    try {
+      const data = await executeScraperFunction<LoginStatusData>(
+        tabId,
+        'scrapeLoginStatus',
+      );
+      return { success: true, data };
+    } catch (err) {
+      // If the script can't run because of a permission error AND the tab
+      // is off-domain, that's still a login-expired signal — fail closed
+      // to loggedIn:false instead of a generic error.
+      if (
+        err instanceof ScraperError &&
+        err.code === 'PERMISSION_DENIED' &&
+        isLoginRedirect(tab.url ?? '', moodleUrl)
+      ) {
+        return { success: true, data: { loggedIn: false } as LoginStatusData };
+      }
+      throw err;
+    }
   } catch (err) {
     return { success: false, error: `Login check failed: ${String(err)}` };
   }
@@ -329,13 +385,10 @@ async function handleScrapeCourses(
     // weren't yet granted for the Moodle domain.
     const tabAfter = await chrome.tabs.get(tabId);
     const tabUrl = tabAfter.url ?? '';
-    if (
-      /\/login\/|\/auth\/|sso|saml/i.test(tabUrl) &&
-      !tabUrl.endsWith('/my/courses.php')
-    ) {
+    if (isLoginRedirect(tabUrl, coursesPageUrl)) {
       return {
         success: false,
-        error: `Moodle redirected to a login page (${tabUrl.substring(0, 120)}).`,
+        error: `Moodle redirected to ${tabUrl.substring(0, 120)} — your session likely expired.`,
         code: 'NOT_LOGGED_IN',
       };
     }
@@ -368,6 +421,16 @@ async function handleScrapeCourseContent(
     if (tab.url !== courseUrl) {
       await chrome.tabs.update(tabId, { url: courseUrl });
       await waitForTabLoad(tabId);
+    }
+
+    const tabAfter = await chrome.tabs.get(tabId);
+    const tabUrl = tabAfter.url ?? '';
+    if (isLoginRedirect(tabUrl, courseUrl)) {
+      return {
+        success: false,
+        error: `Moodle redirected to ${tabUrl.substring(0, 120)} — your session likely expired.`,
+        code: 'NOT_LOGGED_IN',
+      };
     }
 
     // First pass: scrape what's visible (section 0 + tile metadata)

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -102,8 +102,7 @@ export async function scrapeCourses(): Promise<
   const courses: ScrapedCourse[] = [];
 
   cards.forEach((card) => {
-    const moodleCourseId =
-      card.dataset.courseId ?? card.dataset.courseid ?? '';
+    const moodleCourseId = card.dataset.courseId ?? card.dataset.courseid ?? '';
     if (!moodleCourseId) return;
 
     // Extract course name from .multiline area
@@ -240,13 +239,7 @@ function mimeFromExtension(ext: string): string | undefined {
 // zips, images, video/audio, unknown extensions, etc.) is dropped at scrape
 // time so it never reaches the picker or the downloader. Matches the set
 // processable by the AI-context pipeline in src/lib/actions/ai-context.ts.
-const ALLOWED_FILE_EXTENSIONS = new Set([
-  'pdf',
-  'docx',
-  'doc',
-  'pptx',
-  'ppt',
-]);
+const ALLOWED_FILE_EXTENSIONS = new Set(['pdf', 'docx', 'doc', 'pptx', 'ppt']);
 
 /**
  * Parses a single activity element into a ScrapedItem.
@@ -357,9 +350,7 @@ function fileItemFromPluginfileLink(
     if (!url) return null;
     let filename = '';
     try {
-      filename = decodeURIComponent(
-        url.split('/').pop()?.split('?')[0] ?? '',
-      );
+      filename = decodeURIComponent(url.split('/').pop()?.split('?')[0] ?? '');
     } catch {
       filename = url.split('/').pop()?.split('?')[0] ?? '';
     }

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -564,8 +564,59 @@ function scrapeStandardFormat(): ScrapedSection[] {
 }
 
 /**
+ * Sweeps a scope element for every pluginfile.php link whose filename
+ * extension is in ALLOWED_FILE_EXTENSIONS, dedups by href, returns
+ * ScrapedItems. Used as a backstop so we never miss a file just because
+ * its surrounding DOM didn't match an activity-wrapper selector.
+ */
+function linkSweep(scope: HTMLElement): ScrapedItem[] {
+  const items: ScrapedItem[] = [];
+  const seen = new Set<string>();
+  let links: NodeListOf<HTMLAnchorElement> | HTMLAnchorElement[] = [];
+  try {
+    links = scope.querySelectorAll<HTMLAnchorElement>(
+      'a[href*="/pluginfile.php/"]',
+    );
+  } catch {
+    links = [];
+  }
+  for (const link of Array.from(links)) {
+    if (seen.has(link.href)) continue;
+    const item = fileItemFromPluginfileLink(link);
+    if (!item) continue;
+    seen.add(link.href);
+    items.push(item);
+  }
+  return items;
+}
+
+function getMainContentArea(): HTMLElement {
+  return (
+    document.querySelector<HTMLElement>('#region-main .course-content') ??
+    document.querySelector<HTMLElement>('#region-main') ??
+    document.querySelector<HTMLElement>('main') ??
+    document.body
+  );
+}
+
+function mergeUnique(into: ScrapedItem[], extras: ScrapedItem[]): void {
+  const seen = new Set(into.map((i) => i.moodleUrl));
+  for (const e of extras) {
+    if (seen.has(e.moodleUrl)) continue;
+    seen.add(e.moodleUrl);
+    into.push(e);
+  }
+}
+
+/**
  * Scrapes the full course content (sections + items) from a course page.
  * Handles both "tiles" and standard (topics/weeks) formats.
+ *
+ * Backstop: if structured detection found no sections, OR every section
+ * is empty, we add a synthetic "Course Materials" section populated from
+ * a full link sweep of the main content area. This protects against
+ * Moodle themes that completely restructure the section DOM beyond
+ * recognition — we'd rather show a flat list than nothing.
  */
 export function scrapeCourseContent(): ScrapedCourseContentData {
   const format = getCourseFormat();
@@ -575,6 +626,19 @@ export function scrapeCourseContent(): ScrapedCourseContentData {
     sections = scrapeTilesFormat();
   } else {
     sections = scrapeStandardFormat();
+  }
+
+  const totalItems = sections.reduce((n, s) => n + s.items.length, 0);
+  if (totalItems === 0) {
+    const sweep = linkSweep(getMainContentArea());
+    if (sweep.length > 0) {
+      sections.push({
+        moodleSectionId: 'sweep',
+        title: 'Course Materials',
+        position: sections.length,
+        items: sweep,
+      });
+    }
   }
 
   return { sections };
@@ -590,9 +654,10 @@ export function scrapeCourseContent(): ScrapedCourseContentData {
  * we skip those — only scrape the target section's activities.
  */
 export function scrapeSectionPage(): ScrapedItem[] {
-  // Find the visible loaded section (not section-0). Theme variants:
-  // some emit .state-visible on li.section.course-section, some on
-  // li.section.moveablesection, some on a non-li wrapper with [data-region="section"].
+  const items: ScrapedItem[] = [];
+
+  // Pass 1: structured detection. Theme variants emit .state-visible on
+  // different wrappers, so try several.
   const visibleSelectors = [
     'li.section.course-section.state-visible',
     'li.section.moveablesection.state-visible',
@@ -602,42 +667,43 @@ export function scrapeSectionPage(): ScrapedItem[] {
   for (const sel of visibleSelectors) {
     const el = document.querySelector<HTMLElement>(sel);
     if (el) {
-      const items = scrapeActivitiesFromSection(el);
-      if (items.length > 0) return items;
+      mergeUnique(items, scrapeActivitiesFromSection(el));
+      if (items.length > 0) break;
     }
   }
 
-  // Fallback: enumerate sections with activities and skip section-0.
-  let allSections: NodeListOf<HTMLElement> | HTMLElement[] = [];
-  try {
-    allSections = document.querySelectorAll<HTMLElement>(
-      'li.section.course-section, li.section.moveablesection, [data-region="section"], .section.course-section',
-    );
-  } catch {
-    allSections = [];
-  }
-  for (const section of Array.from(allSections)) {
-    const sectionNum =
-      section.dataset.section ?? section.id.replace('section-', '');
-    if (sectionNum === '0') continue;
-    const activities = section.querySelectorAll(
-      '.activity.activity-wrapper[data-for="cmitem"], .activity[data-for="cmitem"]',
-    );
-    if (activities.length > 0) {
-      const items = scrapeActivitiesFromSection(section);
-      if (items.length > 0) return items;
+  // Pass 2: if pass 1 found nothing, walk any section wrapper that has
+  // activity children, skipping section-0.
+  if (items.length === 0) {
+    let allSections: NodeListOf<HTMLElement> | HTMLElement[] = [];
+    try {
+      allSections = document.querySelectorAll<HTMLElement>(
+        'li.section.course-section, li.section.moveablesection, [data-region="section"], .section.course-section',
+      );
+    } catch {
+      allSections = [];
+    }
+    for (const section of Array.from(allSections)) {
+      const sectionNum =
+        section.dataset.section ?? section.id.replace('section-', '');
+      if (sectionNum === '0') continue;
+      const activities = section.querySelectorAll(
+        '.activity.activity-wrapper[data-for="cmitem"], .activity[data-for="cmitem"]',
+      );
+      if (activities.length > 0) {
+        mergeUnique(items, scrapeActivitiesFromSection(section));
+        if (items.length > 0) break;
+      }
     }
   }
 
-  // Final fallback: scrape the whole main content area. The section's
-  // activities live somewhere inside #region-main even if the theme has
-  // restructured the section wrapper beyond recognition.
-  const contentArea =
-    document.querySelector<HTMLElement>('#region-main .course-content') ??
-    document.querySelector<HTMLElement>('#region-main') ??
-    document.querySelector<HTMLElement>('main') ??
-    document.body;
-  return scrapeActivitiesFromSection(contentArea);
+  // Pass 3: ALWAYS run a link sweep across the main content area as a
+  // backstop. Merges in any pluginfile.php links of allowed extensions
+  // that the structured passes missed. Deduped by href so we don't
+  // double-count items already captured by passes 1/2.
+  mergeUnique(items, linkSweep(getMainContentArea()));
+
+  return items;
 }
 
 // ============================================

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -344,69 +344,130 @@ function parseActivity(activity: HTMLElement): ScrapedItem | null {
 }
 
 /**
- * Scrapes the allowed file links (pdf/docx/pptx) inline inside a Moodle
- * folder activity. Folders rendered with "display inline" expose their
- * children as pluginfile.php links in `.foldertree` or `.contentafterlink`.
- * Each child becomes its own ScrapedItem so it appears flat in the picker
- * alongside non-foldered files.
+ * Extracts an allowed-extension file item from a pluginfile.php anchor.
+ * Returns null if the link is missing a recognizable allowed extension.
+ * Wrapped in its own helper because malformed URLs would otherwise throw
+ * out of decodeURIComponent and abort the parent loop.
+ */
+function fileItemFromPluginfileLink(
+  link: HTMLAnchorElement,
+): ScrapedItem | null {
+  try {
+    const url = link.href;
+    if (!url) return null;
+    let filename = '';
+    try {
+      filename = decodeURIComponent(
+        url.split('/').pop()?.split('?')[0] ?? '',
+      );
+    } catch {
+      filename = url.split('/').pop()?.split('?')[0] ?? '';
+    }
+    if (!filename) return null;
+    const extMatch = filename.match(/\.([^.]+)$/);
+    const ext = extMatch?.[1]?.toLowerCase();
+    if (!ext || !ALLOWED_FILE_EXTENSIONS.has(ext)) return null;
+    const name =
+      (link.textContent ?? '').replace(/\s+/g, ' ').trim() || filename;
+    const item: ScrapedItem = { type: 'file', name, moodleUrl: url };
+    const mime = mimeFromExtension(ext);
+    if (mime) item.mimeType = mime;
+    return item;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Scrapes allowed-extension file links inline inside a Moodle folder
+ * activity. Folders rendered with "display inline" expose children as
+ * pluginfile.php links in .foldertree / .contentafterlink. Each child
+ * becomes its own ScrapedItem so it appears flat in the picker.
  *
- * Skips the "Download folder" zip button: those are filtered implicitly
- * because .zip isn't in ALLOWED_FILE_EXTENSIONS.
+ * "Download folder" zip button is naturally skipped — .zip isn't in
+ * ALLOWED_FILE_EXTENSIONS.
  */
 function scrapeFolderActivity(folderEl: HTMLElement): ScrapedItem[] {
   const items: ScrapedItem[] = [];
   const seen = new Set<string>();
-  const links = folderEl.querySelectorAll<HTMLAnchorElement>(
-    'a[href*="/pluginfile.php/"]',
-  );
-  for (const link of Array.from(links)) {
-    const url = link.href;
-    if (seen.has(url)) continue;
-    const filename = decodeURIComponent(
-      url.split('/').pop()?.split('?')[0] ?? '',
+  try {
+    const links = folderEl.querySelectorAll<HTMLAnchorElement>(
+      'a[href*="/pluginfile.php/"]',
     );
-    if (!filename) continue;
-    const extMatch = filename.match(/\.([^.]+)$/);
-    const ext = extMatch?.[1]?.toLowerCase();
-    if (!ext || !ALLOWED_FILE_EXTENSIONS.has(ext)) continue;
-    seen.add(url);
-    const name = (link.textContent ?? '').replace(/\s+/g, ' ').trim() ||
-      filename;
-    const item: ScrapedItem = { type: 'file', name, moodleUrl: url };
-    const mime = mimeFromExtension(ext);
-    if (mime) item.mimeType = mime;
-    items.push(item);
+    for (const link of Array.from(links)) {
+      if (seen.has(link.href)) continue;
+      const item = fileItemFromPluginfileLink(link);
+      if (!item) continue;
+      seen.add(link.href);
+      items.push(item);
+    }
+  } catch {
+    // Defensive: any DOM surprise on a single folder shouldn't blank
+    // out the whole section.
   }
   return items;
 }
 
 /**
- * Scrapes activities from a section element.
+ * Scrapes activities from a section element. Per-activity errors are
+ * swallowed so one malformed activity DOM can't blank the section.
+ * If the structured pass finds zero items, a link-sweep fallback
+ * harvests pluginfile.php links of allowed extensions directly from
+ * the section's DOM — this catches custom themes, raw HTML blocks
+ * with file links, and folder activities that render outside the
+ * expected modtype_folder shell.
  */
 function scrapeActivitiesFromSection(sectionEl: HTMLElement): ScrapedItem[] {
-  // Select only the wrapper activities (not the nested .activity-item duplicates)
-  const activities = sectionEl.querySelectorAll<HTMLElement>(
-    '.activity.activity-wrapper[data-for="cmitem"]',
-  );
   const items: ScrapedItem[] = [];
 
+  let activities: NodeListOf<HTMLElement> | HTMLElement[] = [];
+  try {
+    activities = sectionEl.querySelectorAll<HTMLElement>(
+      '.activity.activity-wrapper[data-for="cmitem"]',
+    );
+  } catch {
+    activities = [];
+  }
+
   activities.forEach((act) => {
-    const modType = act.dataset.modtype ?? '';
-    const baseModType = modType.split('_')[0];
-    const isFolder =
-      baseModType === 'folder' || act.className.includes('modtype_folder');
+    try {
+      const modType = act.dataset.modtype ?? '';
+      const baseModType = modType.split('_')[0];
+      const isFolder =
+        baseModType === 'folder' || act.className.includes('modtype_folder');
 
-    if (isFolder) {
-      // Folders never appear as files themselves — but their contained
-      // pdf/docx/pptx links should each be lifted into the section as
-      // individual items. Drop the folder shell.
-      items.push(...scrapeFolderActivity(act));
-      return;
+      if (isFolder) {
+        items.push(...scrapeFolderActivity(act));
+        return;
+      }
+
+      const item = parseActivity(act);
+      if (item) items.push(item);
+    } catch {
+      // Swallow per-activity failures — keep scraping the rest.
     }
-
-    const item = parseActivity(act);
-    if (item) items.push(item);
   });
+
+  // Link-sweep fallback. Only kicks in if the structured pass found
+  // nothing — we don't want to dedupe-merge with a working pass.
+  if (items.length === 0) {
+    const seen = new Set<string>();
+    let links: NodeListOf<HTMLAnchorElement> | HTMLAnchorElement[] = [];
+    try {
+      links = sectionEl.querySelectorAll<HTMLAnchorElement>(
+        'a[href*="/pluginfile.php/"]',
+      );
+    } catch {
+      links = [];
+    }
+    for (const link of Array.from(links)) {
+      if (seen.has(link.href)) continue;
+      const item = fileItemFromPluginfileLink(link);
+      if (!item) continue;
+      seen.add(link.href);
+      items.push(item);
+    }
+  }
 
   return items;
 }
@@ -529,36 +590,53 @@ export function scrapeCourseContent(): ScrapedCourseContentData {
  * we skip those — only scrape the target section's activities.
  */
 export function scrapeSectionPage(): ScrapedItem[] {
-  // Find the visible loaded section (not section-0)
-  // The target section has class "state-visible" or is the only non-zero section with activities
-  const loadedSection = document.querySelector<HTMLElement>(
-    'li.section.course-section.state-visible, li.section.moveablesection.state-visible',
-  );
-  if (loadedSection) {
-    return scrapeActivitiesFromSection(loadedSection);
+  // Find the visible loaded section (not section-0). Theme variants:
+  // some emit .state-visible on li.section.course-section, some on
+  // li.section.moveablesection, some on a non-li wrapper with [data-region="section"].
+  const visibleSelectors = [
+    'li.section.course-section.state-visible',
+    'li.section.moveablesection.state-visible',
+    '[data-region="section"].state-visible',
+    '.section.course-section.state-visible',
+  ];
+  for (const sel of visibleSelectors) {
+    const el = document.querySelector<HTMLElement>(sel);
+    if (el) {
+      const items = scrapeActivitiesFromSection(el);
+      if (items.length > 0) return items;
+    }
   }
 
-  // Fallback: find sections with activities, skip section-0
-  const allSections = document.querySelectorAll<HTMLElement>(
-    'li.section.course-section, li.section.moveablesection',
-  );
-  for (const section of allSections) {
+  // Fallback: enumerate sections with activities and skip section-0.
+  let allSections: NodeListOf<HTMLElement> | HTMLElement[] = [];
+  try {
+    allSections = document.querySelectorAll<HTMLElement>(
+      'li.section.course-section, li.section.moveablesection, [data-region="section"], .section.course-section',
+    );
+  } catch {
+    allSections = [];
+  }
+  for (const section of Array.from(allSections)) {
     const sectionNum =
       section.dataset.section ?? section.id.replace('section-', '');
     if (sectionNum === '0') continue;
     const activities = section.querySelectorAll(
-      '.activity.activity-wrapper[data-for="cmitem"]',
+      '.activity.activity-wrapper[data-for="cmitem"], .activity[data-for="cmitem"]',
     );
     if (activities.length > 0) {
-      return scrapeActivitiesFromSection(section);
+      const items = scrapeActivitiesFromSection(section);
+      if (items.length > 0) return items;
     }
   }
 
-  // Final fallback: use the whole content area
-  const contentArea = document.querySelector<HTMLElement>(
-    '#region-main .course-content',
-  );
-  if (!contentArea) return [];
+  // Final fallback: scrape the whole main content area. The section's
+  // activities live somewhere inside #region-main even if the theme has
+  // restructured the section wrapper beyond recognition.
+  const contentArea =
+    document.querySelector<HTMLElement>('#region-main .course-content') ??
+    document.querySelector<HTMLElement>('#region-main') ??
+    document.querySelector<HTMLElement>('main') ??
+    document.body;
   return scrapeActivitiesFromSection(contentArea);
 }
 

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -344,6 +344,43 @@ function parseActivity(activity: HTMLElement): ScrapedItem | null {
 }
 
 /**
+ * Scrapes the allowed file links (pdf/docx/pptx) inline inside a Moodle
+ * folder activity. Folders rendered with "display inline" expose their
+ * children as pluginfile.php links in `.foldertree` or `.contentafterlink`.
+ * Each child becomes its own ScrapedItem so it appears flat in the picker
+ * alongside non-foldered files.
+ *
+ * Skips the "Download folder" zip button: those are filtered implicitly
+ * because .zip isn't in ALLOWED_FILE_EXTENSIONS.
+ */
+function scrapeFolderActivity(folderEl: HTMLElement): ScrapedItem[] {
+  const items: ScrapedItem[] = [];
+  const seen = new Set<string>();
+  const links = folderEl.querySelectorAll<HTMLAnchorElement>(
+    'a[href*="/pluginfile.php/"]',
+  );
+  for (const link of Array.from(links)) {
+    const url = link.href;
+    if (seen.has(url)) continue;
+    const filename = decodeURIComponent(
+      url.split('/').pop()?.split('?')[0] ?? '',
+    );
+    if (!filename) continue;
+    const extMatch = filename.match(/\.([^.]+)$/);
+    const ext = extMatch?.[1]?.toLowerCase();
+    if (!ext || !ALLOWED_FILE_EXTENSIONS.has(ext)) continue;
+    seen.add(url);
+    const name = (link.textContent ?? '').replace(/\s+/g, ' ').trim() ||
+      filename;
+    const item: ScrapedItem = { type: 'file', name, moodleUrl: url };
+    const mime = mimeFromExtension(ext);
+    if (mime) item.mimeType = mime;
+    items.push(item);
+  }
+  return items;
+}
+
+/**
  * Scrapes activities from a section element.
  */
 function scrapeActivitiesFromSection(sectionEl: HTMLElement): ScrapedItem[] {
@@ -354,6 +391,19 @@ function scrapeActivitiesFromSection(sectionEl: HTMLElement): ScrapedItem[] {
   const items: ScrapedItem[] = [];
 
   activities.forEach((act) => {
+    const modType = act.dataset.modtype ?? '';
+    const baseModType = modType.split('_')[0];
+    const isFolder =
+      baseModType === 'folder' || act.className.includes('modtype_folder');
+
+    if (isFolder) {
+      // Folders never appear as files themselves — but their contained
+      // pdf/docx/pptx links should each be lifted into the section as
+      // individual items. Drop the folder shell.
+      items.push(...scrapeFolderActivity(act));
+      return;
+    }
+
     const item = parseActivity(act);
     if (item) items.push(item);
   });

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -72,19 +72,38 @@ export async function scrapeCourses(): Promise<
   // status:'complete' (network idle for the document itself, not for the
   // follow-up AJAX). If the user navigates quickly we'd query the DOM
   // before the cards mount and falsely report "no courses". Poll instead.
-  const CARD_SELECTOR = '.card.dashboard-card[data-course-id]';
+  //
+  // We also try several selectors: institutions and Moodle themes vary —
+  // some render `.card.dashboard-card[data-course-id]`, some only set
+  // `[data-courseid]`, some wrap differently. Any one matching is enough.
+  const CARD_SELECTORS = [
+    '.card.dashboard-card[data-course-id]',
+    '.dashboard-card[data-course-id]',
+    '[data-region="paged-content-page"] [data-course-id]',
+    '[data-region="paged-content-page"] [data-courseid]',
+    '[data-courseid]',
+  ];
+  const findCards = (): HTMLElement[] => {
+    for (const sel of CARD_SELECTORS) {
+      const els = Array.from(document.querySelectorAll<HTMLElement>(sel));
+      if (els.length > 0) return els;
+    }
+    return [];
+  };
   const POLL_INTERVAL_MS = 250;
   const POLL_TIMEOUT_MS = 8000;
   const start = Date.now();
-  let cards = document.querySelectorAll<HTMLElement>(CARD_SELECTOR);
+  let cards = findCards();
   while (cards.length === 0 && Date.now() - start < POLL_TIMEOUT_MS) {
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
-    cards = document.querySelectorAll<HTMLElement>(CARD_SELECTOR);
+    cards = findCards();
   }
+
   const courses: ScrapedCourse[] = [];
 
   cards.forEach((card) => {
-    const moodleCourseId = card.dataset.courseId;
+    const moodleCourseId =
+      card.dataset.courseId ?? card.dataset.courseid ?? '';
     if (!moodleCourseId) return;
 
     // Extract course name from .multiline area
@@ -118,6 +137,39 @@ export async function scrapeCourses(): Promise<
       courses.push({ moodleCourseId, name, url });
     }
   });
+
+  // Theme-agnostic fallback: if the card selectors still found nothing
+  // (or the cards lacked the expected name/link structure), harvest course
+  // links from the page's main content. This catches list/summary views
+  // and themes that completely restructure the dashboard. We dedupe by
+  // course id and skip the nav/sidebar so we don't pick up "recent courses"
+  // widgets duplicating the real list.
+  if (courses.length === 0) {
+    const container =
+      document.querySelector('#region-main, #page-content, main') ??
+      document.body;
+    const seen = new Set<string>();
+    const links = container.querySelectorAll<HTMLAnchorElement>(
+      'a[href*="/course/view.php?id="]',
+    );
+    for (const link of Array.from(links)) {
+      const m = link.href.match(/[?&]id=(\d+)/);
+      if (!m) continue;
+      const moodleCourseId = m[1];
+      if (seen.has(moodleCourseId)) continue;
+      const aria = link.getAttribute('aria-label') ?? '';
+      const clone = link.cloneNode(true) as HTMLElement;
+      clone
+        .querySelectorAll('.sr-only, .accesshide')
+        .forEach((el) => el.remove());
+      const name = (aria || clone.textContent || '')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if (!name || name.length < 2) continue;
+      seen.add(moodleCourseId);
+      courses.push({ moodleCourseId, name, url: link.href });
+    }
+  }
 
   return {
     courses,

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -62,12 +62,25 @@ export function scrapeLoginStatus(): LoginStatusData {
  *       span[aria-hidden="true"]  ->  visible course name
  *       span.sr-only              ->  accessible course name (fallback)
  */
-export function scrapeCourses(): ScrapedCoursesData & {
-  _debug?: { title: string; url: string; cardCount: number };
-} {
-  const cards = document.querySelectorAll<HTMLElement>(
-    '.card.dashboard-card[data-course-id]',
-  );
+export async function scrapeCourses(): Promise<
+  ScrapedCoursesData & {
+    _debug?: { title: string; url: string; cardCount: number };
+  }
+> {
+  // Moodle's /my/courses.php hydrates the dashboard cards via XHR after
+  // DOMContentLoaded — the SW's waitForTabLoad only waits for tab
+  // status:'complete' (network idle for the document itself, not for the
+  // follow-up AJAX). If the user navigates quickly we'd query the DOM
+  // before the cards mount and falsely report "no courses". Poll instead.
+  const CARD_SELECTOR = '.card.dashboard-card[data-course-id]';
+  const POLL_INTERVAL_MS = 250;
+  const POLL_TIMEOUT_MS = 8000;
+  const start = Date.now();
+  let cards = document.querySelectorAll<HTMLElement>(CARD_SELECTOR);
+  while (cards.length === 0 && Date.now() - start < POLL_TIMEOUT_MS) {
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    cards = document.querySelectorAll<HTMLElement>(CARD_SELECTOR);
+  }
   const courses: ScrapedCourse[] = [];
 
   cards.forEach((card) => {

--- a/extension/src/content/moodle-scraper.ts
+++ b/extension/src/content/moodle-scraper.ts
@@ -184,6 +184,18 @@ function mimeFromExtension(ext: string): string | undefined {
   return map[ext.toLowerCase()];
 }
 
+// Only these file types are imported. Everything else (URLs, assignments,
+// zips, images, video/audio, unknown extensions, etc.) is dropped at scrape
+// time so it never reaches the picker or the downloader. Matches the set
+// processable by the AI-context pipeline in src/lib/actions/ai-context.ts.
+const ALLOWED_FILE_EXTENSIONS = new Set([
+  'pdf',
+  'docx',
+  'doc',
+  'pptx',
+  'ppt',
+]);
+
 /**
  * Parses a single activity element into a ScrapedItem.
  *
@@ -211,11 +223,9 @@ function parseActivity(activity: HTMLElement): ScrapedItem | null {
     activity.querySelector<HTMLImageElement>('img.activityicon')?.alt ?? '';
   const classes = activity.className;
 
-  // Determine if this is a file or a link
-  const isFile =
-    modType.startsWith('resource') ||
-    classes.includes('modtype_resource') ||
-    iconAlt === 'File icon';
+  // Determine if this is an external URL resource (filtered out below).
+  // Files are identified by file-extension detection rather than a heuristic
+  // flag — see ALLOWED_FILE_EXTENSIONS guard further down.
   const isUrl =
     modType === 'url' ||
     classes.includes('modtype_url') ||
@@ -243,31 +253,36 @@ function parseActivity(activity: HTMLElement): ScrapedItem | null {
     return null;
   }
 
-  // Assignments are not downloadable files — treat them as links
-  if (baseModType === 'assign' || moodleUrl.includes('/mod/assign/')) {
-    return {
-      type: 'link',
-      name,
-      moodleUrl,
-      externalUrl: moodleUrl,
-    };
+  // Assignments and URL resources are not downloadable files we can embed
+  // — drop them. (Previously surfaced as type:'link' but the dashboard /
+  // AI-context pipeline can't do anything with them.)
+  if (
+    isUrl ||
+    baseModType === 'assign' ||
+    baseModType === 'url' ||
+    moodleUrl.includes('/mod/assign/')
+  ) {
+    return null;
   }
 
-  // For files: extract file extension from modtype or icon
+  // For files: extract file extension from modtype or icon.
+  // Filter to ALLOWED_FILE_EXTENSIONS so zips / images / video / unknown
+  // types never reach the picker. Items without a detectable extension are
+  // dropped too — we can't import what we can't classify. (This also
+  // implicitly drops modtype_page, modtype_folder, modtype_book, etc.
+  // since extractFileType returns their bare modtype name, which isn't
+  // in the allow-list.)
   const fileExt = extractFileType(classes);
-  const mimeType = fileExt ? mimeFromExtension(fileExt) : undefined;
+  if (!fileExt || !ALLOWED_FILE_EXTENSIONS.has(fileExt.toLowerCase())) {
+    return null;
+  }
+  const mimeType = mimeFromExtension(fileExt);
 
   const item: ScrapedItem = {
-    type: isUrl ? 'link' : 'file',
+    type: 'file',
     name,
     moodleUrl,
   };
-
-  if (isUrl) {
-    // For URL resources, the actual external URL is behind the Moodle redirect
-    // The extension will resolve it when downloading
-    item.externalUrl = moodleUrl;
-  }
 
   if (mimeType) {
     item.mimeType = mimeType;

--- a/src/app/api/moodle/upload-finalize/route.ts
+++ b/src/app/api/moodle/upload-finalize/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { indexContent } from '@/lib/actions/ai-context';
+import { recordUserFileImport } from '@/lib/actions/moodle-sync';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 
@@ -115,6 +116,11 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (!updateError && fileRecord) {
+      if (moodleCourseDbId) {
+        recordUserFileImport(userId, fileRecord.id, moodleCourseDbId).catch(
+          (err) => console.error('user_file_imports upsert failed:', err),
+        );
+      }
       if (appCourseId) {
         indexContent({
           type: 'moodle_file',
@@ -152,6 +158,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (moodleCourseDbId) {
+      recordUserFileImport(userId, newRecord.id, moodleCourseDbId).catch(
+        (err) => console.error('user_file_imports upsert failed:', err),
+      );
+    }
     if (appCourseId) {
       indexContent({
         type: 'moodle_file',

--- a/src/app/api/moodle/upload/route.ts
+++ b/src/app/api/moodle/upload/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { indexContent } from '@/lib/actions/ai-context';
+import { recordUserFileImport } from '@/lib/actions/moodle-sync';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 
@@ -130,6 +131,11 @@ export async function POST(request: NextRequest) {
       .single();
 
     if (!fileError && fileRecord) {
+      if (moodleCourseDbId) {
+        recordUserFileImport(userId, fileRecord.id, moodleCourseDbId).catch(
+          (err) => console.error('user_file_imports upsert failed:', err),
+        );
+      }
       // Index for AI search (fire-and-forget)
       if (appCourseId) {
         indexContent({
@@ -169,6 +175,11 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    if (moodleCourseDbId) {
+      recordUserFileImport(userId, newRecord.id, moodleCourseDbId).catch(
+        (err) => console.error('user_file_imports upsert failed:', err),
+      );
+    }
     // Index for AI search (fire-and-forget)
     if (appCourseId) {
       indexContent({

--- a/src/components/dashboard/moodle-sync-dialog.test.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.test.tsx
@@ -150,7 +150,9 @@ describe('MoodleSyncDialog', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText(/no courses found/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/couldn't find any courses/i),
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -119,6 +119,7 @@ export function MoodleSyncDialog({
     downloadAndUpload,
     requestPermission,
     checkPermission,
+    checkMoodleLogin,
   } = useMoodleExtension();
   const supabaseRef = useRef(createClient());
 
@@ -423,13 +424,23 @@ export function MoodleSyncDialog({
         return;
       }
       if (code === 'PERMISSION_DENIED') {
-        // Stale permission — was granted at the gate, then revoked mid-flow.
-        // Re-stash so the popup is primed, surface the permission-error UI
-        // with a Retry button. We don't auto-loop loadCourses from inside its
-        // own useCallback (self-reference cycle).
+        // PERMISSION_DENIED is ambiguous from the dashboard side: it can be
+        // a genuine permission revocation OR a session expiry whose redirect
+        // landed on a cross-host SSO page the extension cannot read. Probe
+        // login state first so we route to the right UI instead of always
+        // blaming permissions. checkMoodleLogin's fast path checks for the
+        // MoodleSession cookie and returns loggedIn:false without needing
+        // tab access, so it works even when permissions are the issue.
+        const loginStatus = await checkMoodleLogin(moodleUrl);
+        if (loginStatus?.loggedIn === false) {
+          setPhase('awaiting-login');
+          return;
+        }
         await requestPermission(moodleUrl);
         setPermissionError(true);
-        setError('Permission was revoked. Click Retry to re-grant access.');
+        setError(
+          'Could not access Moodle. Your session may have expired, or the extension may have lost permission for this host.',
+        );
         setPhase('error');
         return;
       }
@@ -1130,10 +1141,18 @@ export function MoodleSyncDialog({
               )}
               {permissionError && (
                 <p className="text-xs text-muted-foreground">
-                  Click <strong>Retry</strong> below — Typenote will ask the
-                  extension for access, then guide you to click{' '}
-                  <strong>Allow</strong>
-                  on the toolbar icon.
+                  Two things to check: (1) you&rsquo;re signed in to{' '}
+                  <a
+                    href={`https://${moodleConnection.domain}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {moodleConnection.domain}
+                  </a>{' '}
+                  (open it in a new tab and confirm), and (2) the extension has
+                  permission for that host. Then click <strong>Retry</strong>{' '}
+                  below.
                 </p>
               )}
               {debugInfo && (

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -136,6 +136,7 @@ export function MoodleSyncDialog({
   const [authError, setAuthError] = useState(false);
   const [networkError, setNetworkError] = useState(false);
   const [permissionError, setPermissionError] = useState(false);
+  const [noCoursesError, setNoCoursesError] = useState(false);
   const [debugInfo, setDebugInfo] = useState<string | null>(null);
   const [progress, setProgress] = useState('');
 
@@ -327,6 +328,7 @@ export function MoodleSyncDialog({
     setAuthError(false);
     setNetworkError(false);
     setPermissionError(false);
+    setNoCoursesError(false);
     setDebugInfo(null);
     setCourses([]);
     setSelectedCourseIds(new Set());
@@ -392,7 +394,10 @@ export function MoodleSyncDialog({
           setPhase('awaiting-login');
           return;
         }
-        setError('No courses found on Moodle.');
+        setError(
+          `Couldn't find any courses on ${moodleConnection.domain}.`,
+        );
+        setNoCoursesError(true);
         if (debug) {
           setDebugInfo(
             `Page: "${debug.title}" at ${debug.url} (${debug.cardCount} cards)`,
@@ -1153,6 +1158,22 @@ export function MoodleSyncDialog({
                   (open it in a new tab and confirm), and (2) the extension has
                   permission for that host. Then click <strong>Retry</strong>{' '}
                   below.
+                </p>
+              )}
+              {noCoursesError && (
+                <p className="text-xs text-muted-foreground">
+                  Open{' '}
+                  <a
+                    href={`https://${moodleConnection.domain}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    {moodleConnection.domain}
+                  </a>{' '}
+                  in a tab, make sure you&rsquo;re signed in and your courses
+                  show on the <strong>My Courses</strong> page, then click{' '}
+                  <strong>Retry</strong>.
                 </p>
               )}
               {debugInfo && (

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -114,12 +114,12 @@ const STATUS_BADGE_MAP: Record<
 function friendlyFileLabel(mimeType: string | undefined): string {
   if (!mimeType) return 'file';
   if (mimeType === 'application/pdf') return 'PDF';
-  if (mimeType.includes('wordprocessingml') || mimeType === 'application/msword')
-    return 'DOCX';
   if (
-    mimeType.includes('presentationml') ||
-    mimeType.includes('ms-powerpoint')
+    mimeType.includes('wordprocessingml') ||
+    mimeType === 'application/msword'
   )
+    return 'DOCX';
+  if (mimeType.includes('presentationml') || mimeType.includes('ms-powerpoint'))
     return 'PPTX';
   return 'file';
 }
@@ -410,9 +410,7 @@ export function MoodleSyncDialog({
           setPhase('awaiting-login');
           return;
         }
-        setError(
-          `Couldn't find any courses on ${moodleConnection.domain}.`,
-        );
+        setError(`Couldn't find any courses on ${moodleConnection.domain}.`);
         setNoCoursesError(true);
         if (debug) {
           setDebugInfo(

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -98,15 +98,31 @@ function isPermissionError(message: string): boolean {
   return PERMISSION_ERROR_PATTERNS.some((p) => lower.includes(p));
 }
 
+// Course statuses are per-user (see compareCourses): only `new_to_system`
+// and `synced_by_user` are actually returned. The other type members exist
+// for backward compatibility and never reach the badge map at runtime.
 const STATUS_BADGE_MAP: Record<
   CourseComparisonStatus,
   { label: string; variant: 'default' | 'secondary' | 'outline' }
 > = {
   new_to_system: { label: 'New', variant: 'default' },
-  synced_by_others: { label: 'Available', variant: 'secondary' },
+  synced_by_others: { label: 'New', variant: 'default' },
   synced_by_user: { label: 'Synced', variant: 'outline' },
-  has_new_items: { label: 'New Items', variant: 'default' },
+  has_new_items: { label: 'New', variant: 'default' },
 };
+
+function friendlyFileLabel(mimeType: string | undefined): string {
+  if (!mimeType) return 'file';
+  if (mimeType === 'application/pdf') return 'PDF';
+  if (mimeType.includes('wordprocessingml') || mimeType === 'application/msword')
+    return 'DOCX';
+  if (
+    mimeType.includes('presentationml') ||
+    mimeType.includes('ms-powerpoint')
+  )
+    return 'PPTX';
+  return 'file';
+}
 
 export function MoodleSyncDialog({
   open,
@@ -463,6 +479,7 @@ export function MoodleSyncDialog({
     checkPermission,
     requestPermission,
     waitForPermission,
+    checkMoodleLogin,
   ]);
 
   useEffect(() => {
@@ -1079,8 +1096,7 @@ export function MoodleSyncDialog({
                                         className="text-[10px] px-1.5 py-0"
                                       >
                                         {item.type === 'file'
-                                          ? (item.mimeType?.split('/')[1] ??
-                                            'file')
+                                          ? friendlyFileLabel(item.mimeType)
                                           : 'link'}
                                       </Badge>
                                     </label>

--- a/src/lib/actions/moodle-sync.ts
+++ b/src/lib/actions/moodle-sync.ts
@@ -51,30 +51,88 @@ export async function removeMoodleConnection() {
 }
 
 /**
- * Get the set of Moodle file URLs already in the registry for a course.
- * Used to mark already-synced items in the content picker.
+ * Get the set of Moodle file URLs the CURRENT user has already imported
+ * for a course. Used to mark already-synced items in the content picker.
+ *
+ * The shared registry holds every file anyone has ever synced, but each
+ * user only "owns" files they themselves chose to import (tracked in
+ * user_file_imports). The picker must reflect the current user's state —
+ * never another user's — otherwise items appear locked when they're not.
  */
 export async function getExistingFileUrls(
   registryId: string,
 ): Promise<string[]> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
   const admin = createAdminClient();
 
   const { data: sections } = await admin
     .from('moodle_sections')
     .select('id')
     .eq('course_id', registryId);
-
   if (!sections || sections.length === 0) return [];
+
+  const sectionIds = sections.map((s: { id: string }) => s.id);
 
   const { data: files } = await admin
     .from('moodle_files')
-    .select('moodle_url')
-    .in(
-      'section_id',
-      sections.map((s: { id: string }) => s.id),
-    );
+    .select('id, moodle_url')
+    .in('section_id', sectionIds);
+  if (!files || files.length === 0) return [];
 
-  return (files ?? []).map((f: { moodle_url: string }) => f.moodle_url);
+  const urlByFileId = new Map<string, string>(
+    files.map((f: { id: string; moodle_url: string }) => [f.id, f.moodle_url]),
+  );
+
+  const { data: imports } = await admin
+    .from('user_file_imports')
+    .select('moodle_file_id')
+    .eq('user_id', user.id)
+    .eq('status', 'imported')
+    .in('moodle_file_id', Array.from(urlByFileId.keys()));
+
+  return (imports ?? [])
+    .map((i: { moodle_file_id: string }) => urlByFileId.get(i.moodle_file_id))
+    .filter((u): u is string => !!u);
+}
+
+/**
+ * Record that the current user has imported a specific Moodle file.
+ * Called from the upload routes after a successful storage write so the
+ * picker can show "synced" only for files THIS user actually imported.
+ *
+ * If no user_course_syncs row exists (e.g., the file was uploaded outside
+ * the normal sync flow), this is a no-op — user_file_imports.sync_id is
+ * NOT NULL, so we can't synthesize a parent here.
+ */
+export async function recordUserFileImport(
+  userId: string,
+  moodleFileId: string,
+  moodleCourseDbId: string,
+): Promise<void> {
+  const admin = createAdminClient();
+
+  const { data: sync } = await admin
+    .from('user_course_syncs')
+    .select('id')
+    .eq('user_id', userId)
+    .eq('moodle_course_id', moodleCourseDbId)
+    .single();
+  if (!sync?.id) return;
+
+  await admin.from('user_file_imports').upsert(
+    {
+      user_id: userId,
+      moodle_file_id: moodleFileId,
+      sync_id: sync.id,
+      status: 'imported' as const,
+    },
+    { onConflict: 'user_id,moodle_file_id' },
+  );
 }
 
 /**

--- a/src/lib/moodle/sync-service.test.ts
+++ b/src/lib/moodle/sync-service.test.ts
@@ -188,11 +188,12 @@ describe('compareCourses', () => {
     ]);
   });
 
-  it('returns synced_by_others when course exists but user has no sync record', async () => {
+  it('returns new_to_system when course exists in registry but user has no sync record', async () => {
+    // Per-user isolation: another user may have synced this course before,
+    // but the current user should never see that — it's brand new to them.
     const mock = createMockAdmin([
       { data: { id: 'inst-1' } }, // instance exists (.single())
       { data: { id: 'course-uuid-1' } }, // course exists in registry (.single())
-      { data: null, count: 5 }, // moodle_files count query (.in()) — has content
       { data: null }, // no user_course_syncs record (.single())
     ]);
     mockCreateAdminClient.mockReturnValue(mock);
@@ -208,23 +209,52 @@ describe('compareCourses', () => {
         moodleCourseId: 'CS101',
         name: 'Intro to CS',
         moodleUrl: 'https://moodle.example.com/course/view.php?id=101',
-        status: 'synced_by_others',
+        status: 'new_to_system',
         registryId: 'course-uuid-1',
       },
     ]);
   });
 
-  it('returns synced_by_user when course exists and user has a sync record', async () => {
+  it('returns new_to_system when user has sync row but no actual file imports', async () => {
     const mock = createMockAdmin([
-      { data: { id: 'inst-1' } }, // instance exists (.single())
-      { data: { id: 'course-uuid-1' } }, // course exists in registry (.single())
-      { data: null, count: 3 }, // moodle_files count query (.in()) — has content
+      { data: { id: 'inst-1' } }, // instance .single()
+      { data: { id: 'course-uuid-1' } }, // registry course .single()
       {
-        data: {
-          id: 'sync-1',
-          last_synced_at: '2026-03-10T12:00:00Z',
-        },
-      }, // user has sync record (.single())
+        data: { id: 'sync-1', last_synced_at: '2026-03-10T12:00:00Z' },
+      }, // user_course_syncs .single()
+      { data: [{ id: 's1' }] }, // sections .in()
+      { data: [{ id: 'f1' }, { id: 'f2' }] }, // files .in()
+      { data: null, count: 0 }, // user_file_imports count .in() — zero
+    ]);
+    mockCreateAdminClient.mockReturnValue(mock);
+
+    const result = await compareCourses(
+      'moodle.example.com',
+      scrapedCourses,
+      'user-1',
+    );
+
+    expect(result).toEqual([
+      {
+        moodleCourseId: 'CS101',
+        name: 'Intro to CS',
+        moodleUrl: 'https://moodle.example.com/course/view.php?id=101',
+        status: 'new_to_system',
+        registryId: 'course-uuid-1',
+      },
+    ]);
+  });
+
+  it('returns synced_by_user with the user-specific import count', async () => {
+    const mock = createMockAdmin([
+      { data: { id: 'inst-1' } }, // instance .single()
+      { data: { id: 'course-uuid-1' } }, // registry course .single()
+      {
+        data: { id: 'sync-1', last_synced_at: '2026-03-10T12:00:00Z' },
+      }, // user_course_syncs .single()
+      { data: [{ id: 's1' }] }, // sections .in()
+      { data: [{ id: 'f1' }, { id: 'f2' }, { id: 'f3' }] }, // files .in()
+      { data: null, count: 3 }, // user_file_imports count .in() — three
     ]);
     mockCreateAdminClient.mockReturnValue(mock);
 
@@ -247,7 +277,7 @@ describe('compareCourses', () => {
     ]);
   });
 
-  it('handles multiple courses with different statuses', async () => {
+  it('handles multiple courses with mixed per-user states', async () => {
     const multiCourses = [
       {
         moodleCourseId: 'CS101',
@@ -267,19 +297,17 @@ describe('compareCourses', () => {
     ];
 
     const mock = createMockAdmin([
-      { data: { id: 'inst-1' } }, // instance exists (.single())
-      { data: null }, // CS101: not in registry (.single())
-      { data: { id: 'course-uuid-2' } }, // CS201: in registry (.single())
-      { data: null, count: 4 }, // CS201: moodle_files count (.in()) — has content
-      { data: null }, // CS201: no user sync (.single())
-      { data: { id: 'course-uuid-3' } }, // CS301: in registry (.single())
-      { data: null, count: 2 }, // CS301: moodle_files count (.in()) — has content
+      { data: { id: 'inst-1' } }, // instance .single()
+      { data: null }, // CS101: not in registry — done
+      { data: { id: 'course-uuid-2' } }, // CS201: in registry .single()
+      { data: null }, // CS201: no user_course_syncs .single() — done (new_to_system)
+      { data: { id: 'course-uuid-3' } }, // CS301: in registry .single()
       {
-        data: {
-          id: 'sync-3',
-          last_synced_at: '2026-03-09T08:00:00Z',
-        },
-      }, // CS301: user has sync (.single())
+        data: { id: 'sync-3', last_synced_at: '2026-03-09T08:00:00Z' },
+      }, // CS301: user_course_syncs .single()
+      { data: [{ id: 's3' }] }, // CS301: sections .in()
+      { data: [{ id: 'f3a' }, { id: 'f3b' }] }, // CS301: files .in()
+      { data: null, count: 2 }, // CS301: user imports count .in()
     ]);
     mockCreateAdminClient.mockReturnValue(mock);
 
@@ -291,11 +319,12 @@ describe('compareCourses', () => {
 
     expect(result).toHaveLength(3);
     expect(result[0].status).toBe('new_to_system');
-    expect(result[1].status).toBe('synced_by_others');
+    expect(result[1].status).toBe('new_to_system');
     expect(result[1].registryId).toBe('course-uuid-2');
     expect(result[2].status).toBe('synced_by_user');
     expect(result[2].registryId).toBe('course-uuid-3');
     expect(result[2].lastSyncedAt).toBe('2026-03-09T08:00:00Z');
+    expect(result[2].syncedFileCount).toBe(2);
   });
 });
 

--- a/src/lib/moodle/sync-service.ts
+++ b/src/lib/moodle/sync-service.ts
@@ -30,14 +30,11 @@ export interface CourseComparison {
 }
 
 /**
- * Compare scraped Moodle courses against the shared registry
- * to determine each course's status for the current user.
- *
- * Logic per course:
- * 1. Look up instance by domain
- * 2. Check if course exists in `moodle_courses`
- * 3. If exists, check if this user has a `user_course_syncs` record
- * 4. Return appropriate status
+ * Compare scraped Moodle courses against the shared registry for the
+ * current user. The returned status only reflects what THIS user has
+ * actually imported — never what another user has done. The shared
+ * registry is used purely to scope per-user queries, never to surface
+ * "available because someone else synced it" hints.
  */
 export async function compareCourses(
   instanceDomain: string,
@@ -46,14 +43,12 @@ export async function compareCourses(
 ): Promise<CourseComparison[]> {
   const admin = createAdminClient();
 
-  // Step 1: Look up instance by domain
   const { data: instance } = await admin
     .from('moodle_instances')
     .select('id')
     .eq('domain', instanceDomain)
     .single();
 
-  // If instance doesn't exist, all courses are new
   if (!instance) {
     return scrapedCourses.map((course) => ({
       moodleCourseId: course.moodleCourseId,
@@ -66,7 +61,6 @@ export async function compareCourses(
   const results: CourseComparison[] = [];
 
   for (const scraped of scrapedCourses) {
-    // Step 2: Check if course exists in the shared registry
     const { data: registryCourse } = await admin
       .from('moodle_courses')
       .select('id')
@@ -84,29 +78,6 @@ export async function compareCourses(
       continue;
     }
 
-    // Step 3: Check if the course actually has content (sections with files)
-    const { count: fileCount } = await admin
-      .from('moodle_sections')
-      .select('id, moodle_files(id)', { count: 'exact', head: false })
-      .eq('course_id', registryCourse.id);
-
-    // Count actual files across all sections
-    const { count: totalFiles } = await admin
-      .from('moodle_files')
-      .select('id', { count: 'exact', head: true })
-      .in(
-        'section_id',
-        (
-          await admin
-            .from('moodle_sections')
-            .select('id')
-            .eq('course_id', registryCourse.id)
-        ).data?.map((s: { id: string }) => s.id) ?? [],
-      );
-
-    const hasContent = (totalFiles ?? 0) > 0;
-
-    // Step 4: Check if this user has a sync record
     const { data: userSync } = await admin
       .from('user_course_syncs')
       .select('id, last_synced_at')
@@ -115,15 +86,10 @@ export async function compareCourses(
       .single();
 
     if (!userSync) {
-      results.push({
-        moodleCourseId: scraped.moodleCourseId,
-        name: scraped.name,
-        moodleUrl: scraped.url,
-        status: hasContent ? 'synced_by_others' : 'new_to_system',
-        registryId: registryCourse.id,
-      });
-    } else if (!hasContent) {
-      // User has a sync record but no actual content — treat as new
+      // Course exists in the shared registry because someone else once
+      // synced it, but this user has never touched it. From the user's
+      // perspective it's brand new — we deliberately do not leak the
+      // existence of other users' syncs into the UI.
       results.push({
         moodleCourseId: scraped.moodleCourseId,
         name: scraped.name,
@@ -131,17 +97,57 @@ export async function compareCourses(
         status: 'new_to_system',
         registryId: registryCourse.id,
       });
-    } else {
+      continue;
+    }
+
+    // Count THIS user's imported files for files in this course.
+    const { data: sectionRows } = await admin
+      .from('moodle_sections')
+      .select('id')
+      .in('course_id', [registryCourse.id]);
+    const sectionIds = (sectionRows ?? []).map((s: { id: string }) => s.id);
+
+    let userFileCount = 0;
+    if (sectionIds.length > 0) {
+      const { data: fileRows } = await admin
+        .from('moodle_files')
+        .select('id')
+        .in('section_id', sectionIds);
+      const fileIds = (fileRows ?? []).map((f: { id: string }) => f.id);
+      if (fileIds.length > 0) {
+        const { count } = await admin
+          .from('user_file_imports')
+          .select('id', { count: 'exact', head: true })
+          .eq('user_id', userId)
+          .eq('status', 'imported')
+          .in('moodle_file_id', fileIds);
+        userFileCount = count ?? 0;
+      }
+    }
+
+    if (userFileCount === 0) {
+      // Sync row exists but zero per-user imports — either a stale row or
+      // a previous failed download. From the user's perspective they have
+      // nothing here yet, so show it as new.
       results.push({
         moodleCourseId: scraped.moodleCourseId,
         name: scraped.name,
         moodleUrl: scraped.url,
-        status: 'synced_by_user',
+        status: 'new_to_system',
         registryId: registryCourse.id,
-        lastSyncedAt: userSync.last_synced_at,
-        syncedFileCount: totalFiles ?? 0,
       });
+      continue;
     }
+
+    results.push({
+      moodleCourseId: scraped.moodleCourseId,
+      name: scraped.name,
+      moodleUrl: scraped.url,
+      status: 'synced_by_user',
+      registryId: registryCourse.id,
+      lastSyncedAt: userSync.last_synced_at,
+      syncedFileCount: userFileCount,
+    });
   }
 
   return results;


### PR DESCRIPTION
## Problem
When a Moodle session expires and Moodle redirects to an SSO identity provider on a different hostname (e.g. \`login.runi.ac.il\`, \`idp.*\`, \`adfs.*\`), the extension's \`chrome.scripting.executeScript\` fails with "Cannot access contents of the page". The service worker was indiscriminately mapping that error to \`PERMISSION_DENIED\`, and the dashboard showed:

> Permission was revoked. Click Retry to re-grant access.
> Click Retry below — Typenote will ask the extension for access, then guide you to click Allow on the toolbar icon.

…which is wrong: the user's permission wasn't revoked, their **login** expired. The "fix" being offered (grant permission again) doesn't address the real problem.

## Fix — defense in depth, so the right UI shows even if any one layer misses

1. **Extension SW** — new \`isLoginRedirect(tabUrl, expectedUrl)\` helper trips on either:
   - hostname change (canonical SSO signal — \`login.runi.ac.il\` ≠ \`moodle.runi.ac.il\`)
   - path containing \`/login/\`, \`/auth/\`, \`sso\`, \`saml\`, \`oauth\`, or \`idp.\`

   Applied in \`handleScrapeCourses\`, \`handleScrapeCourseContent\`, and \`handleCheckLogin\`. The latter also catches \`PERMISSION_DENIED\` from its own \`executeScript\` when off-domain and reports \`loggedIn: false\` so callers get a clean signal.

2. **Dashboard** — when a scrape returns \`PERMISSION_DENIED\`, probe \`checkMoodleLogin\` first. If the user isn't logged in, route to the existing \`awaiting-login\` UI ("You're not logged in to Moodle" + Open Moodle link) instead of the permission UI. This works even if the SW classification still misses an edge case, because \`checkMoodleLogin\`'s fast path checks the \`MoodleSession\` cookie without needing tab access.

3. **Dashboard** — \`PERMISSION_DENIED\` error text and the \`permissionError\` helper paragraph rewritten to mention both possibilities (session vs permission) and link to Moodle so the user can confirm sign-in.

## Test plan
- [ ] Reload the extension after merge (or build locally).
- [ ] Delete the \`MoodleSession\` cookie for moodle.runi.ac.il (or wait for natural expiry).
- [ ] Open Typenote dashboard → Sync with Moodle.
- [ ] **Expected:** "You're not logged in to Moodle" card with "Open moodle.runi.ac.il" link. Not the permission-revoked message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)