### PR TITLE
feat: Google sign-up as only registration option

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -13,13 +13,13 @@ When adding or modifying a feature, update this registry and write the correspon
 
 ## Auth (`e2e/auth.spec.ts`) — IMPLEMENTED
 
-- [x] Sign up with email and password
-- [x] Sign up with invalid email shows error
+- [x] Signup page shows only Google button (no email/password form)
 - [x] Log in with valid credentials redirects to dashboard
 - [x] Log in with wrong password shows error
 - [x] Log out returns to login page
 - [x] Password reset sends email (forgot password flow)
 - [x] Unauthenticated user is redirected to login
+- [x] Login page still shows both email/password and Google options
 
 ---
 

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -24,31 +24,34 @@ test.describe('Auth', () => {
     await expect(page).not.toHaveURL(/\/dashboard/);
   });
 
-  test('sign up with valid details redirects to dashboard', async ({
+  test('signup page shows only Google button (no email/password form)', async ({
     page,
   }) => {
-    const uniqueEmail = `test-signup-${Date.now()}@typenote.dev`;
-
     await page.goto('/signup');
-    await page.getByLabel('Display Name').fill('E2E Test User');
-    await page.getByLabel('Email').fill(uniqueEmail);
-    await page.getByLabel('Password').fill('TestPassword123');
-    await page.getByRole('button', { name: 'Sign up' }).click();
 
-    await expect(page).toHaveURL(/\/dashboard/, { timeout: 10_000 });
+    // Google signup button should be visible
+    await expect(
+      page.getByRole('button', { name: /sign up with google/i }),
+    ).toBeVisible();
+
+    // Email/password form fields should NOT exist
+    await expect(page.getByLabel('Email')).not.toBeVisible();
+    await expect(page.getByLabel('Password')).not.toBeVisible();
+    await expect(page.getByLabel('Display Name')).not.toBeVisible();
   });
 
-  test('sign up with invalid email shows error', async ({ page }) => {
-    await page.goto('/signup');
-    await page.getByLabel('Display Name').fill('Bad Email User');
-    await page.getByLabel('Email').fill('not-an-email');
-    await page.getByLabel('Password').fill('TestPassword123');
-    await page.getByRole('button', { name: 'Sign up' }).click();
+  test('login page still shows both email/password and Google options', async ({
+    page,
+  }) => {
+    await page.goto('/login');
 
-    // The browser's built-in validation should prevent submission,
-    // or Supabase returns an error. Either way, we should NOT reach dashboard.
-    await page.waitForTimeout(1000);
-    await expect(page).toHaveURL(/\/signup/);
+    // Email/password form should be present
+    await expect(page.getByLabel('Email')).toBeVisible();
+    await expect(page.getByLabel('Password')).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+
+    // Google button should also be present
+    await expect(page.getByRole('button', { name: /google/i })).toBeVisible();
   });
 
   test('logout returns to login page', async ({ page }) => {

--- a/specs/042-google-signup/checklists/requirements.md
+++ b/specs/042-google-signup/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Google Sign-Up as Only Registration Option
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. The spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- The Assumptions section documents that Google OAuth is already configured and the database trigger handles Google metadata — these are confirmed facts from codebase inspection, not guesses.

--- a/specs/042-google-signup/data-model.md
+++ b/specs/042-google-signup/data-model.md
@@ -1,0 +1,37 @@
+# Data Model: Google Sign-Up as Only Registration Option
+
+**Feature**: 042-google-signup
+**Date**: 2026-05-18
+
+## Schema Changes
+
+**None.** This feature requires no database changes.
+
+## Existing Entities (unchanged)
+
+### Profile
+
+The `profiles` table already handles Google OAuth users correctly.
+
+| Field        | Type        | Source (Google OAuth)               |
+| ------------ | ----------- | ----------------------------------- |
+| id           | uuid (PK)   | `auth.users.id` (auto-generated)    |
+| email        | text        | `auth.users.email` (from Google)    |
+| display_name | text        | `raw_user_meta_data->>'name'`       |
+| avatar_url   | text        | `raw_user_meta_data->>'avatar_url'` |
+| created_at   | timestamptz | `now()` (default)                   |
+| updated_at   | timestamptz | `now()` (default, auto-updated)     |
+
+### Trigger: `handle_new_user`
+
+Fires `AFTER INSERT ON auth.users`. Creates a `profiles` row using:
+
+- `full_name` or `name` from `raw_user_meta_data` (Google provides `name`)
+- `avatar_url` from `raw_user_meta_data` (Google provides this)
+- Falls back to email username if no name is available
+
+No modifications needed — this trigger already works for Google OAuth users.
+
+## Migrations
+
+No new migration files required.

--- a/specs/042-google-signup/plan.md
+++ b/specs/042-google-signup/plan.md
@@ -1,0 +1,105 @@
+# Implementation Plan: [FEATURE]
+
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+[Extract from feature spec: primary requirement + technical approach from research]
+
+## Technical Context
+
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+[Gates determined based on constitution file]
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
+```text
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
+
+tests/
+├── contract/
+├── integration/
+└── unit/
+
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
+
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
+
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
+
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
+```
+
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation                  | Why Needed         | Simpler Alternative Rejected Because |
+| -------------------------- | ------------------ | ------------------------------------ |
+| [e.g., 4th project]        | [current need]     | [why 3 projects insufficient]        |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient]  |

--- a/specs/042-google-signup/quickstart.md
+++ b/specs/042-google-signup/quickstart.md
@@ -1,0 +1,54 @@
+# Quickstart: Google Sign-Up as Only Registration Option
+
+**Feature**: 042-google-signup
+
+## Prerequisites
+
+- Node.js 22+
+- pnpm installed
+- Supabase CLI installed
+- Google OAuth configured in Supabase (already done for this project)
+
+## Setup
+
+```bash
+# 1. Switch to the feature branch
+git checkout 042-google-signup
+
+# 2. Install dependencies
+pnpm install
+
+# 3. Start local Supabase
+supabase start
+
+# 4. Start dev server
+pnpm dev
+```
+
+## What to Verify
+
+1. **Signup page** (`/signup`): Should show only a "Sign up with Google" button — no email/password form
+2. **Login page** (`/login`): Should still show both email/password form AND Google sign-in button
+3. **Existing user login**: Use `test@typenote.dev` / `Test1234` to verify email/password login still works
+4. **Auth callback**: `/auth/callback` should still work for OAuth redirects
+
+## Running Tests
+
+```bash
+# Unit tests
+pnpm test
+
+# Integration tests (requires local Supabase)
+pnpm test:integration
+
+# E2E tests (requires local Supabase + dev server)
+pnpm test:e2e
+```
+
+## Key Files
+
+| File                                  | Change | Purpose                         |
+| ------------------------------------- | ------ | ------------------------------- |
+| `src/app/(auth)/signup/page.tsx`      | MODIFY | Google-only signup UI           |
+| `src/app/(auth)/signup/page.test.tsx` | MODIFY | Updated unit tests              |
+| `e2e/google-signup.spec.ts`           | NEW    | E2E test for Google signup flow |

--- a/specs/042-google-signup/research.md
+++ b/specs/042-google-signup/research.md
@@ -1,0 +1,42 @@
+# Research: Google Sign-Up as Only Registration Option
+
+**Feature**: 042-google-signup
+**Date**: 2026-05-18
+
+## Research Tasks
+
+### 1. Current Google OAuth Implementation
+
+**Decision**: Reuse the existing Google OAuth flow — no changes to the OAuth configuration or callback route.
+
+**Rationale**: The codebase already has a working `handleGoogleSignup()` function in `src/app/(auth)/signup/page.tsx` that calls `supabase.auth.signInWithOAuth({ provider: 'google' })`. The callback route at `src/app/auth/callback/route.ts` correctly exchanges the authorization code for a session and redirects to `/dashboard`. The database trigger `handle_new_user` (in `00001_initial_schema.sql`) already extracts `name` and `avatar_url` from `raw_user_meta_data`, which Google OAuth populates.
+
+**Alternatives considered**:
+
+- Building a custom OAuth flow with Google's API directly — rejected because Supabase Auth already handles this securely and correctly.
+
+### 2. Impact on Login Page
+
+**Decision**: Keep the login page unchanged — it retains both email/password and Google sign-in options.
+
+**Rationale**: Existing beta users signed up with email/password and need to continue logging in that way. Removing email/password from login would lock them out. The Google button on the login page serves existing Google users and any new users who signed up via Google.
+
+**Alternatives considered**:
+
+- Making login Google-only too — rejected because it would break access for existing email/password users (violates FR-004).
+- Adding a migration path to link email/password accounts to Google — out of scope for this feature, could be a future enhancement.
+
+### 3. Error Handling for OAuth Failures
+
+**Decision**: Display error messages on the signup page when Google OAuth fails or is cancelled.
+
+**Rationale**: The existing callback route (`/auth/callback/route.ts`) already redirects to `/login?error=auth_failed` on failure. The signup page should handle a similar error query parameter (or the signup page can show errors when the OAuth flow returns the user to the signup page without completing).
+
+**Alternatives considered**:
+
+- Silent failure with no message — rejected because users need feedback.
+- Custom error page — rejected as over-engineering for this scope.
+
+## Summary
+
+No unknowns remain. The existing infrastructure handles Google OAuth, profile creation, and session management. The implementation is purely a UI simplification of the signup page.

--- a/specs/042-google-signup/spec.md
+++ b/specs/042-google-signup/spec.md
@@ -1,0 +1,95 @@
+# Feature Specification: Google Sign-Up as Only Registration Option
+
+**Feature Branch**: `042-google-signup`
+**Created**: 2026-05-18
+**Status**: Draft
+**Input**: User description: "I want to add google sign up and make it the only option instead of regular sign up. make a sign up with google and of course sign the users that sign this way as regular users that can get inside the app and have all their notebooks saved, as we have in the beta-users now. do not cancel any users, keep all of the existing users just make a google signup possible"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - New User Signs Up with Google (Priority: P1)
+
+A new user visits Typenote and wants to create an account. The signup page presents a single "Sign up with Google" button. The user clicks it, authenticates with their Google account, and is redirected into the app with a fully provisioned account — profile created, dashboard accessible, and ready to create notebooks.
+
+**Why this priority**: This is the core feature — without it, no new users can register.
+
+**Independent Test**: Can be fully tested by visiting the signup page, clicking "Sign up with Google", completing Google OAuth, and verifying the user lands on the dashboard with a profile containing their Google name and avatar.
+
+**Acceptance Scenarios**:
+
+1. **Given** a visitor with no account, **When** they visit `/signup` and click "Sign up with Google", **Then** they are redirected to Google's OAuth consent screen
+2. **Given** a visitor completes Google OAuth, **When** the callback is processed, **Then** a new profile is created with their Google name, email, and avatar, and they are redirected to the dashboard
+3. **Given** a visitor visits `/signup`, **When** the page loads, **Then** there is NO email/password form — only the Google sign-up button is visible
+
+---
+
+### User Story 2 - Existing Email/Password User Continues Logging In (Priority: P1)
+
+An existing user who signed up with email/password during the beta can still log in using their email and password. Nothing changes for them — their data, notebooks, and account remain intact.
+
+**Why this priority**: Equal to P1 — breaking existing user access would be critical.
+
+**Independent Test**: Can be tested by logging in with a known email/password test account and verifying dashboard and notebooks load correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing email/password user, **When** they visit `/login` and enter their credentials, **Then** they are authenticated and redirected to the dashboard with all their data intact
+2. **Given** an existing user, **When** they log in, **Then** their notebooks, folders, courses, and AI conversations are all present
+
+---
+
+### User Story 3 - Existing User Logs In with Google (Priority: P2)
+
+An existing user (whether they originally signed up with email/password or Google) can use the "Sign in with Google" button on the login page to authenticate.
+
+**Why this priority**: Provides convenience for existing users who prefer Google login but is not essential for launch.
+
+**Independent Test**: Can be tested by having an existing Google user click "Sign in with Google" on the login page and verifying they reach their dashboard.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing user who originally signed up with Google, **When** they click "Sign in with Google" on the login page, **Then** they are authenticated and see their existing data
+2. **Given** an existing email/password user whose email matches their Google account, **When** they click "Sign in with Google", **Then** the system handles account linking per its configured identity linking behavior
+
+---
+
+### Edge Cases
+
+- What happens if a user tries to access `/signup` while already authenticated? They should be redirected to the dashboard.
+- What happens if Google OAuth fails or the user cancels? They should be returned to the signup page with a clear error message.
+- What happens if a user navigates directly to the old email/password signup URL? They see the new Google-only signup page (same URL, updated content).
+- What happens if Google is temporarily unavailable? The user sees an appropriate error message.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: The signup page MUST present only a "Sign up with Google" button — no email, password, or display name fields
+- **FR-002**: New users who sign up via Google MUST receive a full account with the same access level and capabilities as existing beta users
+- **FR-003**: The system MUST automatically create a user profile using the Google account's name, email, and avatar upon first sign-up
+- **FR-004**: All existing user accounts (email/password and Google) MUST remain fully functional — no data migration, no account deletion, no access changes
+- **FR-005**: The login page MUST retain both email/password login AND Google sign-in options, so existing users can continue using their preferred method
+- **FR-006**: After successful Google sign-up, the user MUST be redirected to the dashboard
+- **FR-007**: If Google OAuth fails or is cancelled, the user MUST see a clear error message on the signup page
+- **FR-008**: The signup page MUST link to the login page for users who already have an account
+
+### Key Entities
+
+- **Profile**: Represents a user in the system. Created automatically on sign-up via a database trigger. Key attributes: id, email, display_name, avatar_url. For Google users, display_name and avatar_url are populated from Google's OAuth metadata.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: New users can create an account via Google sign-up in under 30 seconds (from clicking button to reaching dashboard)
+- **SC-002**: 100% of existing email/password users can still log in with their credentials after the change
+- **SC-003**: New Google users have full access to all application features (create notebooks, AI chat, PDF export, etc.) immediately after sign-up
+- **SC-004**: The signup page contains exactly one call-to-action for registration (the Google button) — no alternative registration paths
+
+## Assumptions
+
+- Google OAuth is already configured in Supabase (confirmed: the current signup and login pages already have working Google OAuth buttons)
+- The existing `handle_new_user` database trigger already handles Google OAuth metadata (`name`, `avatar_url`) correctly — no database migration needed
+- Supabase's default identity linking behavior is acceptable for cases where an email/password user later signs in with Google using the same email
+- The login page retains email/password fields because existing beta users need them; the change is signup-only
+- No new subscription tier or role assignment is needed — all users get the same default tier

--- a/specs/042-google-signup/tasks.md
+++ b/specs/042-google-signup/tasks.md
@@ -1,0 +1,144 @@
+# Tasks: Google Sign-Up as Only Registration Option
+
+**Input**: Design documents from `/specs/042-google-signup/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Tests**: Required per CLAUDE.md — unit tests (Vitest) and E2E tests (Playwright) for every feature.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: User Story 1 - New User Signs Up with Google (Priority: P1) MVP
+
+**Goal**: Replace the email/password signup form with a single "Sign up with Google" button. New Google users get full accounts.
+
+**Independent Test**: Visit `/signup`, verify only Google button is shown, click it, complete OAuth, land on dashboard with profile.
+
+### Tests for User Story 1
+
+- [x] T001 [P] [US1] Write unit test: signup page renders only Google button (no email/password form) in `src/app/(auth)/signup/page.test.tsx`
+- [x] T002 [P] [US1] Write unit test: signup page shows error message when `error` query param is present in `src/app/(auth)/signup/page.test.tsx`
+- [x] T003 [P] [US1] Write unit test: signup page links to login page in `src/app/(auth)/signup/page.test.tsx`
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Replace signup page with Google-only UI: remove email/password/display-name form, keep Google OAuth button, add error handling for failed OAuth in `src/app/(auth)/signup/page.tsx`
+
+**Checkpoint**: Signup page shows only "Sign up with Google" button. Unit tests pass. Existing OAuth callback route works unchanged.
+
+---
+
+## Phase 2: User Story 2 - Existing Email/Password User Continues Logging In (Priority: P1)
+
+**Goal**: Verify existing email/password login is unaffected. No code changes — login page is NOT modified.
+
+**Independent Test**: Log in with `test@typenote.dev` / `Test1234`, verify dashboard loads with all data.
+
+### Verification for User Story 2
+
+- [x] T005 [US2] Verify login page is unchanged: confirm email/password form AND Google button both remain in `src/app/(auth)/login/page.tsx` (read-only check, no modifications)
+
+**Checkpoint**: Login page unchanged. Existing email/password login works.
+
+---
+
+## Phase 3: User Story 3 - Existing User Logs In with Google (Priority: P2)
+
+**Goal**: Verify existing Google sign-in on the login page works. No code changes — already implemented.
+
+**Independent Test**: Click "Sign in with Google" on login page, verify authentication and redirect to dashboard.
+
+### Verification for User Story 3
+
+- [x] T006 [US3] Verify Google sign-in button on login page still calls `signInWithOAuth` with correct callback URL in `src/app/(auth)/login/page.tsx` (read-only check, no modifications)
+
+**Checkpoint**: Google sign-in on login page works for existing users.
+
+---
+
+## Phase 4: E2E Tests & Polish
+
+**Purpose**: E2E browser tests and test registry update
+
+- [x] T007 Update E2E test registry with Google signup scenarios in `e2e/TEST_REGISTRY.md`
+- [x] T008 Write E2E test: signup page shows only Google button (no email/password form) in `e2e/auth.spec.ts`
+- [x] T009 Write E2E test: login page still shows both email/password and Google options in `e2e/auth.spec.ts`
+- [x] T010 Run full test suite: `pnpm test && pnpm test:integration && pnpm test:e2e`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (US1)**: No dependencies — can start immediately (no setup/foundational phase needed)
+- **Phase 2 (US2)**: Independent of Phase 1 — read-only verification
+- **Phase 3 (US3)**: Independent of Phase 1 — read-only verification
+- **Phase 4 (E2E/Polish)**: Depends on Phase 1 completion (signup page must be modified before E2E tests)
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: No dependencies — only modifies `signup/page.tsx` and its test
+- **User Story 2 (P1)**: No dependencies — read-only verification of `login/page.tsx`
+- **User Story 3 (P2)**: No dependencies — read-only verification of `login/page.tsx`
+
+### Within User Story 1
+
+- T001, T002, T003 (tests) can run in parallel — all write to the same test file but test different behaviors
+- T004 (implementation) should run after tests are written (TDD approach)
+
+### Parallel Opportunities
+
+- T001, T002, T003 can run in parallel (different test cases, same file but independent)
+- T005 and T006 can run in parallel with Phase 1 (read-only checks on different file)
+- T008 and T009 can run in parallel (different E2E test cases)
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch all unit tests for US1 together:
+Task: "Write unit test: signup page renders only Google button in src/app/(auth)/signup/page.test.tsx"
+Task: "Write unit test: signup page shows error on failed OAuth in src/app/(auth)/signup/page.test.tsx"
+Task: "Write unit test: signup page links to login page in src/app/(auth)/signup/page.test.tsx"
+
+# Then implement:
+Task: "Replace signup page with Google-only UI in src/app/(auth)/signup/page.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Write failing unit tests for Google-only signup page (T001-T003)
+2. Implement Google-only signup page (T004)
+3. **STOP and VALIDATE**: Run `pnpm test` — all unit tests pass
+4. Verify login page unchanged (T005-T006)
+5. Write E2E tests and run full suite (T007-T010)
+
+### Single Developer Flow
+
+1. T001-T003 → Write unit tests (they fail)
+2. T004 → Implement signup page change (tests pass)
+3. T005-T006 → Verify login page untouched
+4. T007-T009 → Write E2E tests
+5. T010 → Run full test suite, confirm green
+
+---
+
+## Notes
+
+- This feature has no database changes, no new dependencies, and no setup/foundational phase
+- The core implementation is a single file change (`signup/page.tsx`)
+- US2 and US3 are verification-only — they confirm existing functionality isn't broken
+- Total: 10 tasks, of which only 1 (T004) is actual implementation code

--- a/src/app/(auth)/signup/page.test.tsx
+++ b/src/app/(auth)/signup/page.test.tsx
@@ -1,58 +1,66 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import SignupPage from './page';
 
-const mockPush = vi.fn();
-const mockRefresh = vi.fn();
-const mockSignUp = vi.fn();
 const mockSignInWithOAuth = vi.fn();
 
 vi.mock('@/lib/supabase/client', () => ({
   createClient: () => ({
     auth: {
-      signInWithPassword: vi.fn(),
       signInWithOAuth: mockSignInWithOAuth,
-      signUp: mockSignUp,
     },
   }),
 }));
 
+let mockSearchParams = new URLSearchParams();
+
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => mockSearchParams,
 }));
 
 describe('SignupPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
   });
 
-  it('renders display name input', () => {
-    render(<SignupPage />);
-    expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
-  });
-
-  it('renders email input', () => {
-    render(<SignupPage />);
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-  });
-
-  it('renders password input', () => {
-    render(<SignupPage />);
-    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
-  });
-
-  it('renders submit button', () => {
+  // T001: Renders only Google button, no email/password form
+  it('renders Google sign-up button', () => {
     render(<SignupPage />);
     expect(
-      screen.getByRole('button', { name: /sign up/i }),
+      screen.getByRole('button', { name: /sign up with google/i }),
     ).toBeInTheDocument();
   });
 
-  it('renders Google button', () => {
+  it('does NOT render email input', () => {
     render(<SignupPage />);
-    expect(screen.getByRole('button', { name: /google/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
   });
 
+  it('does NOT render password input', () => {
+    render(<SignupPage />);
+    expect(screen.queryByLabelText(/password/i)).not.toBeInTheDocument();
+  });
+
+  it('does NOT render display name input', () => {
+    render(<SignupPage />);
+    expect(screen.queryByLabelText(/display name/i)).not.toBeInTheDocument();
+  });
+
+  // T002: Shows error message when error query param is present
+  it('shows error message when error query param is present', () => {
+    mockSearchParams = new URLSearchParams('error=auth_failed');
+    render(<SignupPage />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('does NOT show error message when no error param', () => {
+    render(<SignupPage />);
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // T003: Links to login page
   it('renders login link', () => {
     render(<SignupPage />);
     const link = screen.getByRole('link', { name: /sign in/i });
@@ -60,110 +68,12 @@ describe('SignupPage', () => {
     expect(link).toHaveAttribute('href', '/login');
   });
 
-  it('sanitizes "User already registered" error (no email enumeration)', async () => {
-    mockSignUp.mockResolvedValueOnce({
-      error: { message: 'User already registered' },
-    });
-
-    render(<SignupPage />);
-
-    fireEvent.change(screen.getByLabelText(/display name/i), {
-      target: { value: 'Test User' },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: 'test@example.com' },
-    });
-    fireEvent.change(screen.getByLabelText(/password/i), {
-      target: { value: 'password123' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        'Unable to create account. Try logging in or resetting your password.',
-      );
-    });
-  });
-
-  it('sanitizes network errors to friendly message', async () => {
-    mockSignUp.mockResolvedValueOnce({
-      error: { message: 'fetch failed' },
-    });
-
-    render(<SignupPage />);
-
-    fireEvent.change(screen.getByLabelText(/display name/i), {
-      target: { value: 'Test User' },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: 'test@example.com' },
-    });
-    fireEvent.change(screen.getByLabelText(/password/i), {
-      target: { value: 'password123' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        'Something went wrong. Please try again.',
-      );
-    });
-  });
-
-  it('sanitizes rate limit errors', async () => {
-    mockSignUp.mockResolvedValueOnce({
-      error: {
-        message:
-          'For security purposes, you can only request this after 60 seconds',
-      },
-    });
-
-    render(<SignupPage />);
-
-    fireEvent.change(screen.getByLabelText(/display name/i), {
-      target: { value: 'Test User' },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: 'test@example.com' },
-    });
-    fireEvent.change(screen.getByLabelText(/password/i), {
-      target: { value: 'password123' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert')).toHaveTextContent(
-        'Too many attempts. Please try again later.',
-      );
-    });
-  });
-
-  it('redirects to dashboard on successful signup', async () => {
-    mockSignUp.mockResolvedValueOnce({ error: null });
-
-    render(<SignupPage />);
-
-    fireEvent.change(screen.getByLabelText(/display name/i), {
-      target: { value: 'Test User' },
-    });
-    fireEvent.change(screen.getByLabelText(/email/i), {
-      target: { value: 'test@example.com' },
-    });
-    fireEvent.change(screen.getByLabelText(/password/i), {
-      target: { value: 'password123' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
-
-    await waitFor(() => {
-      expect(mockPush).toHaveBeenCalledWith('/dashboard');
-      expect(mockRefresh).toHaveBeenCalled();
-    });
-  });
-
   it('calls signInWithOAuth when Google button is clicked', () => {
     render(<SignupPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /google/i }));
+    fireEvent.click(
+      screen.getByRole('button', { name: /sign up with google/i }),
+    );
 
     expect(mockSignInWithOAuth).toHaveBeenCalledWith({
       provider: 'google',

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
-import { sanitizeAuthError } from '@/lib/auth-errors';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import {
   Card,
   CardContent,
@@ -17,39 +14,9 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 
-export default function SignupPage() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [displayName, setDisplayName] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-  const router = useRouter();
-
-  async function handleEmailSignup(e: React.FormEvent) {
-    e.preventDefault();
-    setError('');
-    setLoading(true);
-
-    const supabase = createClient();
-    const { error } = await supabase.auth.signUp({
-      email,
-      password,
-      options: {
-        data: {
-          full_name: displayName,
-        },
-      },
-    });
-
-    if (error) {
-      setError(sanitizeAuthError(error));
-      setLoading(false);
-      return;
-    }
-
-    router.push('/dashboard');
-    router.refresh();
-  }
+function SignupForm() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get('error');
 
   async function handleGoogleSignup() {
     const supabase = createClient();
@@ -62,85 +29,42 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl font-bold">Create Account</CardTitle>
-          <CardDescription>Sign up to start taking notes</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleEmailSignup} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="displayName">Display Name</Label>
-              <Input
-                id="displayName"
-                type="text"
-                placeholder="Your name"
-                value={displayName}
-                onChange={(e) => setDisplayName(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="you@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder="At least 6 characters"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                minLength={6}
-              />
-            </div>
-            {error && (
-              <p className="text-sm text-destructive" role="alert">
-                {error}
-              </p>
-            )}
-            <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? 'Creating account...' : 'Sign up'}
-            </Button>
-          </form>
-          <div className="relative my-4">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-card px-2 text-muted-foreground">
-                Or continue with
-              </span>
-            </div>
-          </div>
-          <Button
-            variant="outline"
-            className="w-full"
-            onClick={handleGoogleSignup}
-            type="button"
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <CardTitle className="text-2xl font-bold">Create Account</CardTitle>
+        <CardDescription>Sign up to start taking notes</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {error && (
+          <p
+            className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+            role="alert"
           >
-            Google
-          </Button>
-        </CardContent>
-        <CardFooter className="justify-center">
-          <p className="text-sm text-muted-foreground">
-            Already have an account?{' '}
-            <Link href="/login" className="text-primary underline">
-              Sign in
-            </Link>
+            Sign-up failed. Please try again.
           </p>
-        </CardFooter>
-      </Card>
+        )}
+        <Button className="w-full" onClick={handleGoogleSignup} type="button">
+          Sign up with Google
+        </Button>
+      </CardContent>
+      <CardFooter className="justify-center">
+        <p className="text-sm text-muted-foreground">
+          Already have an account?{' '}
+          <Link href="/login" className="text-primary underline">
+            Sign in
+          </Link>
+        </p>
+      </CardFooter>
+    </Card>
+  );
+}
+
+export default function SignupPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Suspense>
+        <SignupForm />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -3,8 +3,15 @@ import { GET } from './route';
 
 const mockExchangeCodeForSession = vi.fn();
 
-vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn().mockResolvedValue({
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    getAll: () => [],
+    set: vi.fn(),
+  }),
+}));
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
     auth: {
       exchangeCodeForSession: (...args: unknown[]) =>
         mockExchangeCodeForSession(...args),

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
@@ -14,10 +15,45 @@ export async function GET(request: Request) {
       : '/dashboard';
 
   if (code) {
-    const supabase = await createClient();
+    const cookieStore = await cookies();
+
+    // Track cookies that need to be set on the redirect response
+    const cookiesToForward: {
+      name: string;
+      value: string;
+      options: Record<string, unknown>;
+    }[] = [];
+
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          getAll() {
+            return cookieStore.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookiesToForward.push({ name, value, options });
+            });
+          },
+        },
+      },
+    );
+
     const { error } = await supabase.auth.exchangeCodeForSession(code);
+    console.log('[auth/callback] exchangeCodeForSession result:', {
+      error: error?.message ?? null,
+      cookieCount: cookiesToForward.length,
+    });
+
     if (!error) {
-      return NextResponse.redirect(`${origin}${redirectTo}`);
+      const response = NextResponse.redirect(`${origin}${redirectTo}`);
+      // Forward auth cookies onto the redirect response
+      cookiesToForward.forEach(({ name, value, options }) => {
+        response.cookies.set(name, value, options);
+      });
+      return response;
     }
   }
 

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -36,6 +36,20 @@ export async function updateSession(request: NextRequest) {
     // treat as unauthenticated rather than crashing the error overlay.
   }
 
+  // Handle OAuth error redirects (e.g. Google consent screen double-callback).
+  // GoTrue redirects to /?error=... when OAuth state expires. If the user
+  // already has a valid session from the first (successful) callback,
+  // send them to the dashboard instead of showing an error.
+  if (
+    request.nextUrl.searchParams.get('error_code') === 'bad_oauth_state' &&
+    user
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/dashboard';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
+
   // Route protection: unauthenticated users can only access auth pages
   const isAuthPage =
     request.nextUrl.pathname.startsWith('/login') ||

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -149,7 +149,7 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = ["https://127.0.0.1:3000", "http://localhost:3000/**", "http://127.0.0.1:3000/**"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # JWT issuer URL. If not set, defaults to the local API URL (http://127.0.0.1:<port>/auth/v1).
@@ -298,6 +298,15 @@ max_frequency = "5s"
 # Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
 # `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
 # `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.google]
+enabled = true
+client_id = "env(GOOGLE_CLIENT_ID)"
+secret = "env(GOOGLE_CLIENT_SECRET)"
+# Leave redirect_uri empty — GoTrue infers from API_EXTERNAL_URL (http://127.0.0.1:54321)
+redirect_uri = ""
+url = ""
+skip_nonce_check = true
+
 [auth.external.apple]
 enabled = false
 client_id = ""


### PR DESCRIPTION
## Summary

- Replace email/password signup form with a single "Sign up with Google" button
- Login page unchanged — existing users can still use email/password or Google
- Fix auth callback to properly forward session cookies on redirect
- Handle Google consent screen double-callback gracefully in middleware
- Enable Google OAuth in local Supabase config

## Test plan

- [x] Unit tests pass (all callback + signup tests green)
- [x] E2E auth tests updated for Google-only signup
- [x] Manual test: Google sign-up lands on dashboard
- [x] Manual test: existing email/password login still works
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)