### PR TITLE
fix(dashboard): show "Open sidebar" button on desktop when collapsed

### DIFF
--- a/src/components/dashboard/sidebar-layout.test.tsx
+++ b/src/components/dashboard/sidebar-layout.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUsePathname = vi.fn();
+const mockUseRouter = vi.fn(() => ({ push: vi.fn(), back: vi.fn() }));
+const mockUseMediaQuery = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockUsePathname(),
+  useRouter: () => mockUseRouter(),
+}));
+
+vi.mock('@/hooks/use-media-query', () => ({
+  useMediaQuery: () => mockUseMediaQuery(),
+}));
+
+vi.mock('@/hooks/use-swipe-drawer', () => ({
+  useSwipeDrawer: vi.fn(),
+}));
+
+import { SidebarLayout } from './sidebar-layout';
+
+const STORAGE_KEY = 'typenote-sidebar-collapsed';
+
+function renderLayout() {
+  return render(
+    <SidebarLayout sidebar={<div data-testid="sidebar-inner">menu</div>}>
+      <div data-testid="page-content">page</div>
+    </SidebarLayout>,
+  );
+}
+
+describe('SidebarLayout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockUsePathname.mockReturnValue('/dashboard');
+  });
+
+  describe('desktop (≥1280px)', () => {
+    beforeEach(() => {
+      mockUseMediaQuery.mockReturnValue(true); // isDesktop = true
+    });
+
+    it('exposes an "Open sidebar" button when the user has previously collapsed it', async () => {
+      // Regression: if localStorage has the sidebar collapsed, desktop users
+      // had NO visible toggle anywhere — only mobile/iPad rendered the
+      // hamburger header, and only the canvas editor exposed a toggle.
+      // This left desktop users stuck on the dashboard root or course pages.
+      localStorage.setItem(STORAGE_KEY, 'true');
+
+      renderLayout();
+
+      const reopenButton = screen.getByRole('button', {
+        name: /open sidebar/i,
+      });
+      expect(reopenButton).toBeInTheDocument();
+    });
+
+    it('clicking the "Open sidebar" button reveals the sidebar content', async () => {
+      localStorage.setItem(STORAGE_KEY, 'true');
+      const user = userEvent.setup();
+
+      renderLayout();
+
+      const reopenButton = screen.getByRole('button', {
+        name: /open sidebar/i,
+      });
+      await user.click(reopenButton);
+
+      // After opening, the reopen affordance should no longer be shown.
+      expect(
+        screen.queryByRole('button', { name: /open sidebar/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does NOT render the reopen button when the sidebar is already open', () => {
+      // Default state: sidebar is open on non-document pages.
+      renderLayout();
+
+      expect(
+        screen.queryByRole('button', { name: /open sidebar/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('mobile (<1280px)', () => {
+    beforeEach(() => {
+      mockUseMediaQuery.mockReturnValue(false); // isMobile = true
+    });
+
+    it('does NOT render the desktop reopen button (mobile has its own hamburger)', () => {
+      localStorage.setItem(STORAGE_KEY, 'true');
+
+      renderLayout();
+
+      // The mobile hamburger has aria-label "Open menu", not "Open sidebar".
+      expect(
+        screen.queryByRole('button', { name: /open sidebar/i }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/dashboard/sidebar-layout.tsx
+++ b/src/components/dashboard/sidebar-layout.tsx
@@ -204,6 +204,23 @@ export function SidebarLayout({ sidebar, children }: SidebarLayoutProps) {
           </aside>
         )}
 
+        {/* Desktop: floating reopen button when the sidebar is collapsed.
+            Without this, a user who collapsed the sidebar (state persisted in
+            localStorage) has no way to bring it back from dashboard or course
+            pages — only the canvas editor exposes its own toggle. */}
+        {!isMobile && !isOpen && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            onClick={toggle}
+            aria-label="Open sidebar"
+            className="fixed left-3 top-3 z-50 size-9 border border-border/40 bg-sidebar/95 shadow-sm backdrop-blur-sm hover:bg-primary/10 hover:text-primary"
+          >
+            <Menu className="size-5" />
+          </Button>
+        )}
+
         {/* Main content — overflow-hidden only on document pages where the canvas controls its own scroll */}
         <main
           className={`flex flex-col flex-1 min-h-0 min-w-0 ${


### PR DESCRIPTION
## Summary

A desktop user who had previously collapsed the sidebar (via the toggle inside the canvas editor — state persisted in `localStorage.typenote-sidebar-collapsed`) had **no visible toggle anywhere** on the dashboard root or course pages:

- The mobile/iPad header is `xl:hidden`, so it never renders on desktop
- Only the canvas editor (`canvas-editor.tsx:343`) exposed its own toggle
- The collapsed `<aside>` is `w-0 border-r-0` — invisible

Net effect: locked-out users with no way to bring the sidebar back short of clearing `localStorage` from DevTools. Reproduced in production (`typenote-two.vercel.app`).

## Fix

Adds a small floating reopen button rendered when `!isMobile && !isOpen`, positioned `fixed left-3 top-3 z-50`, with `aria-label="Open sidebar"`. Clicking it calls the existing `toggle()` from the sidebar store, which also writes the new state back to localStorage.

## Test plan

- [x] New regression tests in `sidebar-layout.test.tsx`:
  - Visible on desktop when localStorage has the sidebar collapsed
  - Clicking it opens the sidebar (button disappears)
  - Not rendered on desktop when sidebar is already open
  - Not rendered on mobile (the hamburger header is the mobile affordance)
- [x] `pnpm test` — 866/866 passing
- [x] `pnpm lint` clean
- [ ] Manual: visit prod after deploy with `localStorage.typenote-sidebar-collapsed = 'true'` — confirm the floating button appears and opens the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)