### PR TITLE
fix: Ask AI dropdown hidden by backdrop-filter

### DIFF
--- a/src/components/canvas/canvas-editor.tsx
+++ b/src/components/canvas/canvas-editor.tsx
@@ -355,10 +355,6 @@ export function CanvasEditor({
 
   const [askAiDropdownOpen, setAskAiDropdownOpen] = useState(false);
   const askAiDropdownRef = useRef<HTMLDivElement>(null);
-  const [askAiDropdownPos, setAskAiDropdownPos] = useState<{
-    top: number;
-    left: number;
-  } | null>(null);
 
   // Close Ask AI dropdown on click outside
   useEffect(() => {
@@ -2680,7 +2676,7 @@ export function CanvasEditor({
 
       {/* Toolbar — sticky so it stays visible when zoomed */}
       <div className="flex flex-col items-center z-20 shrink-0 my-2 gap-1">
-        <div className="glass-panel flex items-center mx-auto px-3 py-1.5 overflow-x-auto overflow-y-visible w-fit max-w-full rounded-2xl border border-white/60 shadow-lg">
+        <div className="glass-panel flex items-center mx-auto px-3 py-1.5 overflow-visible w-fit max-w-full rounded-2xl border border-white/60 shadow-lg">
           {/* Mobile: back + home + title (hidden on desktop — shown in header) */}
           <div className="hidden pointer-touch:flex items-center gap-1 mr-2 shrink-0">
             <button
@@ -2762,14 +2758,6 @@ export function CanvasEditor({
               <button
                 onPointerDown={(e) => {
                   e.stopPropagation();
-                  if (!askAiDropdownOpen && askAiDropdownRef.current) {
-                    const rect =
-                      askAiDropdownRef.current.getBoundingClientRect();
-                    setAskAiDropdownPos({
-                      top: rect.bottom + 4,
-                      left: rect.left,
-                    });
-                  }
                   setAskAiDropdownOpen((prev) => !prev);
                 }}
                 className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
@@ -2781,14 +2769,8 @@ export function CanvasEditor({
                 <AiHeadIcon className="h-4 w-4" />
                 Ask AI
               </button>
-              {askAiDropdownOpen && askAiDropdownPos && (
-                <div
-                  className="fixed mt-1 w-44 rounded-lg border bg-popover p-1 shadow-lg z-[100]"
-                  style={{
-                    top: askAiDropdownPos.top,
-                    left: askAiDropdownPos.left,
-                  }}
-                >
+              {askAiDropdownOpen && (
+                <div className="absolute top-full left-0 mt-1 w-44 rounded-lg border bg-popover p-1 shadow-lg z-[100]">
                   <button
                     onPointerDown={(e) => {
                       e.stopPropagation();

--- a/src/components/editor/editor-toolbar.tsx
+++ b/src/components/editor/editor-toolbar.tsx
@@ -101,10 +101,6 @@ const TEXT_HIGHLIGHT_COLORS = [
 function HighlightButton({ editor }: { editor: Editor }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const [popoverPos, setPopoverPos] = useState<{
-    top: number;
-    left: number;
-  } | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -120,10 +116,6 @@ function HighlightButton({ editor }: { editor: Editor }) {
   const activeColor = (editor.getAttributes('highlight').color as string) || '';
 
   const handleToggle = () => {
-    if (!open && ref.current) {
-      const rect = ref.current.getBoundingClientRect();
-      setPopoverPos({ top: rect.bottom + 4, left: rect.left + rect.width / 2 });
-    }
     setOpen((o) => !o);
   };
 
@@ -157,11 +149,8 @@ function HighlightButton({ editor }: { editor: Editor }) {
           <p>Highlight</p>
         </TooltipContent>
       </Tooltip>
-      {open && popoverPos && (
-        <div
-          className="fixed p-2 bg-popover border rounded-lg shadow-lg z-[100] -translate-x-1/2"
-          style={{ top: popoverPos.top, left: popoverPos.left }}
-        >
+      {open && (
+        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-1 p-2 bg-popover border rounded-lg shadow-lg z-[100]">
           <div className="flex gap-1.5">
             {TEXT_HIGHLIGHT_COLORS.map((c) => (
               <button


### PR DESCRIPTION
## Summary
- The glass-panel toolbar's `backdrop-filter: blur()` created a new CSS containing block, breaking `position: fixed` dropdowns (Ask AI menu, highlight color picker) — they were positioned relative to the toolbar and clipped by its overflow
- Switched dropdowns from `position: fixed` to `position: absolute` relative to their parent wrapper
- Changed toolbar from `overflow-x-auto overflow-y-visible` to `overflow-visible`

## Test plan
- [ ] Open a document → click "Ask AI" in toolbar → dropdown appears below button with "Select Text" and "Screenshot" options
- [ ] Click "Screenshot" → draw crop rectangle → "Ask AI" floating button appears → click it → chat opens with screenshot
- [ ] In Type mode, select text in toolbar highlight button → color picker appears below button

🤖 Generated with [Claude Code](https://claude.com/claude-code)