### PR TITLE
ci: install pnpm in deploy job before vercel build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,9 +124,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # `vercel build` detects pnpm-lock.yaml and shells out to `pnpm install`.
+      # Without pnpm on PATH it fails with `spawn pnpm ENOENT`.
+      - uses: pnpm/action-setup@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: 'pnpm'
 
       - name: Install Vercel CLI
         run: npm install --global vercel@51


### PR DESCRIPTION
## Summary

After rotating the expired \`VERCEL_TOKEN\` secret, the deploy job now gets past \`vercel pull\` and dies in \`vercel build\` with:

\`\`\`
Error: spawn pnpm ENOENT
\`\`\`

Root cause: \`vercel build\` autodetects \`pnpm-lock.yaml\` and shells out to \`pnpm install\`. The \`deploy\` job only sets up Node 20 + globally installs \`vercel@51\` — it doesn't install pnpm. The sibling \`ci\` job already uses \`pnpm/action-setup@v4\` for the same reason; the deploy job was missing the equivalent step.

## Fix

Add \`pnpm/action-setup@v4\` before \`setup-node\` in the deploy job. Also enable \`cache: pnpm\` on setup-node for cold-start speed.

## Test plan

- [ ] CI \`ci\` job stays green (no touch to its steps)
- [ ] \`deploy\` job's \`Build production bundle\` step now succeeds
- [ ] \`Deploy prebuilt artifacts to production\` finishes, \`typenote-two.vercel.app\` serves the new build

(Production has been stuck since 12:28 UTC today — all 4 main commits failing to deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)