### PR TITLE
fix(ci): source env vars before vercel build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,9 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build production bundle
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -a && source .vercel/.env.production.local && set +a
+          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- **Production is down** — every request returns `500 MIDDLEWARE_INVOCATION_FAILED`
- Root cause: `vercel build --prod` on CI doesn't inline `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` into the edge middleware bundle
- Fix: explicitly `source .vercel/.env.production.local` before running `vercel build` so Next.js can inline the values at build time

## Test plan
- [ ] CI passes
- [ ] After merge, verify `typenote-two.vercel.app` no longer returns 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)