### PR TITLE
fix(ci): pass secrets as env vars to vercel build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,12 +143,17 @@ jobs:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
       - name: Build production bundle
-        run: |
-          set -a && source .vercel/.env.production.local && set +a
-          vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ secrets.NEXT_PUBLIC_POSTHOG_KEY }}
+          NEXT_PUBLIC_POSTHOG_HOST: ${{ secrets.NEXT_PUBLIC_POSTHOG_HOST }}
+          NEXT_PUBLIC_EXTENSION_ID: ${{ secrets.NEXT_PUBLIC_EXTENSION_ID }}
+          GOOGLE_GENERATIVE_AI_API_KEY: ${{ secrets.GOOGLE_GENERATIVE_AI_API_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
 
       - name: Deploy prebuilt artifacts to production
         run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- **Production is down** (500 on every request)
- `vercel pull` writes empty strings for encrypted env vars when run outside Vercel — the middleware can't create a Supabase client
- Fix: pass all `NEXT_PUBLIC_*` and server-side secrets from GitHub Actions secrets directly as env vars to the `vercel build` step

## Test plan
- [ ] CI passes
- [ ] After merge + deploy, `typenote-two.vercel.app` loads without 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)