### PR TITLE
Promote dev to main (rebased): per-user AI chat material access + dev accumulated work

### DIFF
--- a/docs/superpowers/plans/2026-05-22-per-user-material-access.md
+++ b/docs/superpowers/plans/2026-05-22-per-user-material-access.md
@@ -1,0 +1,1557 @@
+# Per-user material access in AI chat — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the AI chat correctly find every Moodle file a user has imported, regardless of who indexed it first. Add a delete-from-notebook UI and clickable source citations.
+
+**Architecture:** Move `content_embeddings.course_id` for `moodle_file` rows from "first-indexer's Typenote course" to the canonical `moodle_courses.id` of the file's upstream course (reached via `moodle_files.section_id → moodle_sections.course_id`). The AI's RAG `match_embeddings` RPC accepts two new params: `match_moodle_course_id` (canonical) and `match_imported_moodle_file_ids` (the caller's `user_file_imports` whitelist). Personal access is derived from `user_file_imports`, so embeddings and storage objects stay shared.
+
+**Tech Stack:** TypeScript / Next.js 16 App Router, Supabase (Postgres + pgvector + Storage), Vitest, Playwright. Branch: `fix/ai-chat-per-user-material-access`. Reference spec: `docs/superpowers/specs/2026-05-22-per-user-material-access-design.md`.
+
+---
+
+## Pre-flight
+
+Before you start: read the spec. The plan below assumes you've read it.
+
+Confirm:
+- Working directory is the worktree at `C:\projects\Typenote\.claude\worktrees\unified-juggling-matsumoto`.
+- On branch `fix/ai-chat-per-user-material-access`.
+- `git status` is clean.
+- `pnpm install` already ran (it has — node_modules exists from earlier work).
+- Local Supabase is running. From the worktree: `pnpm exec supabase status` should list services. If not running, start with Docker Desktop + `pnpm exec supabase start` from `C:\projects\Typenote`. **If Docker isn't available, document this and skip integration/E2E steps — flag those to the human reviewer.**
+
+---
+
+## Task 1: Write the migration SQL
+
+**Files:**
+- Create: `supabase/migrations/20260522123000_per_user_material_access.sql`
+
+**Background:** Today's `match_embeddings` (from `00014_match_embeddings_return_text.sql`) takes 6 args and filters by a single `match_course_id`. We're replacing it with a function that handles two source types (`course_material` keyed by the user's Typenote `course_id`, `moodle_file` keyed by the canonical `moodle_courses.id`) plus a per-user file whitelist. We also backfill existing rows in-place (no embedding API calls).
+
+- [ ] **Step 1.1: Create the migration file with the exact content below**
+
+```sql
+-- Per-user material access in AI chat
+--
+-- Background: moodle_files is a shared registry (one row per file even
+-- when multiple users sync the same Moodle course). Embeddings used to
+-- be tied to the FIRST indexer's Typenote course_id, so only one user
+-- could ever find the file via RAG. This migration:
+--
+--   A. Repoints moodle_file embedding rows from <typenote course_id>
+--      to the canonical moodle_courses.id (reached via
+--      moodle_files.section_id -> moodle_sections.course_id).
+--
+--   B. Replaces match_embeddings with a version that handles two
+--      source-type branches and accepts an imported-file whitelist for
+--      per-user access enforcement.
+
+-- ---------------------------------------------------------------------------
+-- Step A: Backfill embedding course_id for moodle_file rows.
+-- ---------------------------------------------------------------------------
+update public.content_embeddings ce
+set course_id = ms.course_id
+from public.moodle_files mf
+join public.moodle_sections ms on ms.id = mf.section_id
+where ce.source_type = 'moodle_file'
+  and ce.source_id = mf.id
+  and ce.course_id is distinct from ms.course_id;
+
+-- ---------------------------------------------------------------------------
+-- Step B: Replace match_embeddings RPC.
+--
+-- 00014 registered the function with bare `vector` (not extensions.vector),
+-- so we drop using the exact same form to avoid leaving the old function
+-- alongside the new one.
+--
+-- LANGUAGE sql STABLE matches the original 00012 declaration (00014
+-- accidentally regressed to plpgsql). STABLE lets the planner cache
+-- function results within a single query, which matters because RAG
+-- hits this RPC on every chat turn.
+-- ---------------------------------------------------------------------------
+drop function if exists public.match_embeddings(
+  vector, uuid, uuid, uuid, integer, double precision
+);
+
+create or replace function public.match_embeddings(
+  query_embedding extensions.vector(1536),
+  match_user_id uuid,
+  match_course_id uuid default null,
+  match_moodle_course_id uuid default null,
+  match_imported_moodle_file_ids uuid[] default null,
+  match_week_id uuid default null,
+  match_count int default 8,
+  similarity_threshold float default 0.3
+)
+returns table (
+  id bigint,
+  source_type text,
+  source_id uuid,
+  source_name text,
+  segment_text text,
+  page_start integer,
+  page_end integer,
+  course_id uuid,
+  week_id uuid,
+  mime_type text,
+  similarity float
+)
+language sql stable
+as $$
+  select
+    ce.id, ce.source_type, ce.source_id, ce.source_name, ce.segment_text,
+    ce.page_start, ce.page_end, ce.course_id, ce.week_id, ce.mime_type,
+    1 - (ce.embedding <=> query_embedding) as similarity
+  from public.content_embeddings ce
+  where (ce.user_id = match_user_id or ce.user_id is null)
+    and (
+      -- course_material: keyed by Typenote course_id, uploader owns the row
+      (ce.source_type = 'course_material'
+        and match_course_id is not null
+        and ce.course_id = match_course_id)
+      or
+      -- moodle_file: keyed by moodle_courses.id (canonical); access is
+      -- whitelisted by the user's imported file set
+      (ce.source_type = 'moodle_file'
+        and match_moodle_course_id is not null
+        and ce.course_id = match_moodle_course_id
+        and (match_imported_moodle_file_ids is null
+             or ce.source_id = any(match_imported_moodle_file_ids)))
+    )
+    and (match_week_id is null or ce.week_id = match_week_id)
+    and 1 - (ce.embedding <=> query_embedding) > similarity_threshold
+  order by ce.embedding <=> query_embedding
+  limit match_count;
+$$;
+```
+
+- [ ] **Step 1.2: Apply the migration locally (skip if Supabase is unavailable)**
+
+Run from the worktree root:
+
+```bash
+pnpm exec supabase migration up
+```
+
+Expected: prints `Applying migration 20260522123000_per_user_material_access.sql...` and exits 0.
+
+- [ ] **Step 1.3: Smoke-check the new function exists with the right signature (non-destructive)**
+
+Do **not** `supabase db reset` — that wipes seed data needed for later integration tests. Instead, inspect the live database directly:
+
+```bash
+pnpm exec supabase db dump --schema-only -f schema-dump.sql && grep -A 2 "match_embeddings" schema-dump.sql | head -40 && rm schema-dump.sql
+```
+
+Expected: see `match_embeddings(query_embedding...match_moodle_course_id...match_imported_moodle_file_ids...)` in the output.
+
+- [ ] **Step 1.4: Commit**
+
+```bash
+git add supabase/migrations/20260522123000_per_user_material_access.sql
+git commit -m "feat(db): per-user material access migration
+
+Repoints moodle_file content_embeddings rows from the first-indexer's
+Typenote course_id to the canonical moodle_courses.id (reached via
+moodle_files.section_id -> moodle_sections.course_id), and replaces
+match_embeddings with a version that handles two source-type branches
+plus a per-user file whitelist.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Update `matchEmbeddings` TS signature
+
+**Files:**
+- Modify: `src/lib/queries/embeddings.ts` (the `matchEmbeddings` function around line 91)
+- Test: `src/lib/queries/__tests__/embeddings.integration.test.ts` (NEW test for new params)
+
+**Background:** The TS wrapper for the RPC needs the new params. We follow TDD: add the failing test first (it'll fail because the RPC throws when called with old params after the migration, OR because the TS signature is missing the params).
+
+- [ ] **Step 2.1: Write a failing integration test for the new signature**
+
+Append to `src/lib/queries/__tests__/embeddings.integration.test.ts` (this file already has a similar setup):
+
+```ts
+import { matchEmbeddings } from '../embeddings';
+
+describe('matchEmbeddings new signature', () => {
+  it('accepts moodleCourseId and importedMoodleFileIds without throwing', async () => {
+    // Smoke test the new params are wired through the RPC; functional
+    // behavior is covered in subsequent tasks.
+    const result = await matchEmbeddings({
+      queryEmbedding: Array.from({ length: 1536 }, () => 0),
+      userId: TEST_USER_ID,
+      courseId: COURSE_ID,
+      moodleCourseId: null,
+      importedMoodleFileIds: null,
+    });
+    expect(Array.isArray(result)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2.2: Run the test, confirm it fails**
+
+```bash
+pnpm test:integration src/lib/queries/__tests__/embeddings.integration.test.ts -t "new signature"
+```
+
+Expected: type error or "argument missing" — proves the signature isn't there yet.
+
+- [ ] **Step 2.3: Update `matchEmbeddings` signature and body**
+
+Replace the existing `matchEmbeddings` function in `src/lib/queries/embeddings.ts` with:
+
+```ts
+export async function matchEmbeddings(params: {
+  queryEmbedding: number[];
+  userId: string;
+  courseId?: string | null;
+  moodleCourseId?: string | null;
+  importedMoodleFileIds?: string[] | null;
+  weekId?: string | null;
+  matchCount?: number;
+  similarityThreshold?: number;
+}): Promise<MatchResult[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase.rpc('match_embeddings', {
+    query_embedding: JSON.stringify(params.queryEmbedding),
+    match_user_id: params.userId,
+    match_course_id: params.courseId ?? null,
+    match_moodle_course_id: params.moodleCourseId ?? null,
+    match_imported_moodle_file_ids: params.importedMoodleFileIds ?? null,
+    match_week_id: params.weekId ?? null,
+    match_count: params.matchCount ?? 8,
+    similarity_threshold: params.similarityThreshold ?? 0.3,
+  });
+
+  if (error) throw new Error(`match_embeddings failed: ${error.message}`);
+  return (data as MatchResult[]) ?? [];
+}
+```
+
+- [ ] **Step 2.4: Run the test, confirm it passes**
+
+```bash
+pnpm test:integration src/lib/queries/__tests__/embeddings.integration.test.ts -t "new signature"
+```
+
+Expected: PASS.
+
+- [ ] **Step 2.5: Run the full embeddings integration suite to make sure existing tests still pass**
+
+```bash
+pnpm test:integration src/lib/queries/__tests__/embeddings.integration.test.ts
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/lib/queries/embeddings.ts src/lib/queries/__tests__/embeddings.integration.test.ts
+git commit -m "feat(queries): matchEmbeddings accepts moodleCourseId and importedMoodleFileIds
+
+Mirrors the new RPC signature. Existing callers default the new params
+to null (no behavior change yet); searchContext will start passing
+real values in a subsequent task.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: `indexContent` uses canonical `moodle_courses.id` for moodle_file
+
+**Files:**
+- Modify: `src/lib/actions/ai-context.ts` (the `if (source.type === 'moodle_file')` block around line 124)
+- Modify: `src/lib/actions/__tests__/ai-context.test.ts` (the "embeds moodle_file as shared" test and add a new one)
+
+**Background:** Today the embedding row for a moodle_file gets `course_id = source.courseId` (caller's Typenote course). After this task it gets `course_id = moodle_sections.course_id` — the canonical id. We pull `section_id` from `moodle_files`, then join (or do two-step lookup) to `moodle_sections`.
+
+- [ ] **Step 3.1: Update the existing test to assert the canonical id**
+
+Find the test "embeds moodle_file as shared (user_id=null)" in `src/lib/actions/__tests__/ai-context.test.ts` and add an assertion for `course_id`. First, update the `createAdminClient` mock at the top of the file so the `from('moodle_files').select(...).eq(...).single()` chain returns a row with `section_id` set. Locate the mock around lines 58–83 and update it to:
+
+```ts
+vi.mock('@/lib/supabase/admin', () => {
+  const moodleFileRow = {
+    storage_path: 'test/path.pdf',
+    file_name: 'lecture.pdf',
+    mime_type: 'application/pdf',
+    section_id: 'section-1',
+  };
+  const moodleSectionRow = { course_id: 'moodle-course-1' };
+
+  return {
+    createAdminClient: vi.fn(() => ({
+      from: vi.fn((table: string) => {
+        const data =
+          table === 'moodle_files' ? moodleFileRow :
+          table === 'moodle_sections' ? moodleSectionRow :
+          null;
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data, error: null })),
+            })),
+          })),
+        };
+      }),
+      storage: {
+        from: vi.fn(() => ({
+          download: vi.fn(async () => ({
+            data: new Blob(['fake pdf content']),
+            error: null,
+          })),
+        })),
+      },
+    })),
+  };
+});
+```
+
+Then update the moodle_file test to assert the canonical course_id:
+
+```ts
+it('embeds moodle_file with canonical moodle_courses.id (not caller course_id)', async () => {
+  const result = await indexContent({
+    type: 'moodle_file',
+    fileId: 'file-1',
+    courseId: 'callers-typenote-course', // should be IGNORED for the embedding row
+  });
+
+  expect(result.success).toBe(true);
+  expect(upsertEmbeddings).toHaveBeenCalledWith(
+    expect.arrayContaining([
+      expect.objectContaining({
+        user_id: null,
+        course_id: 'moodle-course-1', // looked up via section_id
+      }),
+    ]),
+  );
+});
+```
+
+- [ ] **Step 3.2: Run the test, confirm it fails**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts -t "canonical moodle_courses.id"
+```
+
+Expected: FAIL — current impl writes `course_id = 'callers-typenote-course'`.
+
+- [ ] **Step 3.3: Update `indexContent` for moodle_file**
+
+Locate the `if (source.type === 'moodle_file')` block in `src/lib/actions/ai-context.ts` (around lines 124–164) and:
+
+1. Add `section_id` to the `select(...)` on the moodle_files lookup.
+2. After the existing `fileRow` check, look up the section's course_id.
+3. Reassign `courseId` to the canonical value before the embedding rows are constructed.
+
+Concretely, after the existing block that selects from `moodle_files`, replace:
+
+```ts
+const { data: fileRow, error: fileErr } = await admin
+  .from('moodle_files')
+  .select('storage_path, file_name, mime_type')
+  .eq('id', source.fileId)
+  .single();
+
+if (fileErr || !fileRow?.storage_path) {
+  return {
+    success: false,
+    segmentsIndexed: 0,
+    skipped: false,
+    error: 'Moodle file not found or no storage path',
+  };
+}
+
+sourceName = fileRow.file_name;
+mimeType = fileRow.mime_type ?? 'application/octet-stream';
+storageBucket = 'moodle-materials';
+```
+
+with:
+
+```ts
+const { data: fileRow, error: fileErr } = await admin
+  .from('moodle_files')
+  .select('storage_path, file_name, mime_type, section_id')
+  .eq('id', source.fileId)
+  .single();
+
+if (fileErr || !fileRow?.storage_path) {
+  return {
+    success: false,
+    segmentsIndexed: 0,
+    skipped: false,
+    error: 'Moodle file not found or no storage path',
+  };
+}
+
+// Look up canonical moodle_courses.id via the section. This is the file's
+// upstream home and stays stable across users — using it on the embedding
+// row makes the same file findable for everyone who imports it.
+const { data: sectionRow, error: sectionErr } = await admin
+  .from('moodle_sections')
+  .select('course_id')
+  .eq('id', fileRow.section_id)
+  .single();
+
+if (sectionErr || !sectionRow?.course_id) {
+  return {
+    success: false,
+    segmentsIndexed: 0,
+    skipped: false,
+    error: 'Moodle section not found for file',
+  };
+}
+
+courseId = sectionRow.course_id;
+sourceName = fileRow.file_name;
+mimeType = fileRow.mime_type ?? 'application/octet-stream';
+storageBucket = 'moodle-materials';
+```
+
+- [ ] **Step 3.4: Run the unit tests, confirm they pass**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts
+```
+
+Expected: ALL PASS, including the new assertion.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/lib/actions/ai-context.ts src/lib/actions/__tests__/ai-context.test.ts
+git commit -m "fix(ai): index moodle_file embeddings with canonical moodle_courses.id
+
+Resolves the file's section_id to moodle_sections.course_id and uses
+that as the embedding row's course_id, instead of the caller's Typenote
+course_id. This is the canonical, one-per-file key, so every user who
+imports the file finds the same embedding row via RAG.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `searchContext` resolves moodle_course_id and imported files
+
+**Files:**
+- Modify: `src/lib/actions/ai-context.ts` (the `searchContext` function around line 289)
+- Modify: `src/lib/actions/__tests__/ai-context.test.ts` (the existing `searchContext` describe block)
+
+**Background:** Today `searchContext` passes only `courseId` (Typenote) to the RPC. After this task it also resolves the user's `user_course_syncs` entry to get the canonical `moodle_courses.id`, fetches the user's `user_file_imports`, and passes both to `matchEmbeddings`. Use the regular (RLS-scoped) Supabase client — `user_course_syncs` and `user_file_imports` both have SELECT policies restricting to `auth.uid()`.
+
+- [ ] **Step 4.1: Write a failing test for the new pass-through**
+
+In `src/lib/actions/__tests__/ai-context.test.ts`, add a new test inside the existing `describe('searchContext', ...)` block. First make sure the `createClient` mock at lines 25–56 returns sensible rows for `user_course_syncs` and `user_file_imports`. Replace the existing mock with:
+
+```ts
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: { id: 'test-user-id' } },
+        error: null,
+      })),
+    },
+    from: vi.fn((table: string) => {
+      const data =
+        table === 'user_course_syncs'
+          ? { moodle_course_id: 'moodle-course-1' }
+          : table === 'course_materials'
+            ? {
+                storage_path: 'test/path.pdf',
+                file_name: 'lecture.pdf',
+                mime_type: 'application/pdf',
+              }
+            : null;
+      const imports = [
+        { moodle_file_id: 'imported-file-a' },
+        { moodle_file_id: 'imported-file-b' },
+      ];
+      const result =
+        table === 'user_file_imports' ? { data: imports, error: null } :
+        { data, error: null };
+      const chain: any = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        maybeSingle: vi.fn(async () => result),
+        single: vi.fn(async () => result),
+      };
+      // For non-single queries (user_file_imports), the awaitable form
+      // resolves directly with { data, error }
+      chain.then = (resolve: any) => resolve(result);
+      return chain;
+    }),
+    storage: {
+      from: vi.fn(() => ({
+        download: vi.fn(async () => ({
+          data: new Blob(['fake file content']),
+          error: null,
+        })),
+      })),
+    },
+  })),
+}));
+```
+
+(If the existing test for `searchContext` doesn't depend on the previous mock's `single()` shape, you only need to add `user_course_syncs` and `user_file_imports` handling. Apply the smaller diff and keep existing tests green.)
+
+Then add this test:
+
+```ts
+it('passes resolved moodleCourseId and importedMoodleFileIds to matchEmbeddings', async () => {
+  const { matchEmbeddings } = await import('@/lib/queries/embeddings');
+  vi.mocked(matchEmbeddings).mockResolvedValueOnce([]);
+
+  await searchContext({
+    query: 'what is in lecture 5?',
+    courseId: 'callers-typenote-course',
+  });
+
+  expect(matchEmbeddings).toHaveBeenCalledWith(
+    expect.objectContaining({
+      courseId: 'callers-typenote-course',
+      moodleCourseId: 'moodle-course-1',
+      importedMoodleFileIds: ['imported-file-a', 'imported-file-b'],
+    }),
+  );
+});
+```
+
+- [ ] **Step 4.2: Run the test, confirm it fails**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts -t "passes resolved moodleCourseId"
+```
+
+Expected: FAIL — `searchContext` doesn't look these up yet.
+
+- [ ] **Step 4.3: Update `searchContext`**
+
+Replace the body of `searchContext` in `src/lib/actions/ai-context.ts` (around line 289) with:
+
+```ts
+export async function searchContext(
+  params: SearchParams,
+): Promise<SearchResult[]> {
+  const userId = await getAuthUserId();
+  const supabase = await createClient();
+  const queryEmbedding = await embedQuery(params.query);
+
+  // Resolve Typenote course -> canonical moodle_courses.id (if synced).
+  // RLS restricts user_course_syncs to the caller, so no user_id filter
+  // needed here.
+  let moodleCourseId: string | null = null;
+  let importedMoodleFileIds: string[] | null = null;
+  if (params.courseId) {
+    const { data: sync } = await supabase
+      .from('user_course_syncs')
+      .select('moodle_course_id')
+      .eq('course_id', params.courseId)
+      .maybeSingle();
+    moodleCourseId =
+      (sync as { moodle_course_id: string | null } | null)
+        ?.moodle_course_id ?? null;
+
+    if (moodleCourseId) {
+      // Fetch the user's notebook — the set of moodle files they have
+      // chosen to include. user_file_imports SELECT policy restricts
+      // to the caller already.
+      const { data: imports } = await supabase
+        .from('user_file_imports')
+        .select('moodle_file_id')
+        .eq('status', 'imported');
+      importedMoodleFileIds = (
+        (imports as { moodle_file_id: string }[] | null) ?? []
+      ).map((i) => i.moodle_file_id);
+    }
+  }
+
+  const matches: MatchResult[] = await matchEmbeddings({
+    queryEmbedding,
+    userId,
+    courseId: params.courseId,
+    moodleCourseId,
+    importedMoodleFileIds,
+    weekId: params.weekId ?? null,
+    matchCount: params.maxResults ?? 8,
+  });
+
+  return matches.map((m) => ({
+    id: m.id,
+    sourceType: m.source_type,
+    sourceId: m.source_id,
+    sourceName: m.source_name ?? 'Unknown',
+    segmentText: m.segment_text,
+    pageStart: m.page_start,
+    pageEnd: m.page_end,
+    courseId: params.courseId ?? '',
+    weekId: m.week_id,
+    mimeType: m.mime_type,
+    similarity: m.similarity,
+  }));
+}
+```
+
+- [ ] **Step 4.4: Run unit tests, confirm they pass**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/lib/actions/ai-context.ts src/lib/actions/__tests__/ai-context.test.ts
+git commit -m "fix(ai): searchContext resolves moodle_course_id and per-user imports
+
+Before calling matchEmbeddings, look up the user's user_course_syncs
+row to get the canonical moodle_courses.id and the user_file_imports
+set. Both are RLS-scoped, so the regular client suffices.
+
+Net effect: a user querying their Typenote course only sees moodle_file
+content for the files they actually have in their notebook.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Integration test for the two-user scenario
+
+**Files:**
+- Modify: `src/lib/queries/__tests__/embeddings.integration.test.ts`
+
+**Background:** Verify the migration + code changes against the real DB. Seed two users, one shared moodle_file row, embedding row pointing at `moodle_courses.id`. Both users should match it. Then delete user B's `user_file_imports` row → user B no longer matches.
+
+- [ ] **Step 5.1: Add the integration test**
+
+Append to `src/lib/queries/__tests__/embeddings.integration.test.ts`:
+
+```ts
+describe('per-user moodle_file access', () => {
+  // These ids must match rows seeded in supabase/seed.sql. If they
+  // don't exist yet, document what to add and stop the task here.
+  const USER_A = TEST_USER_ID;
+  const USER_B = 'b0000000-0000-0000-0000-000000000002';
+  const TYPENOTE_COURSE_A = COURSE_ID; // from seed
+  const TYPENOTE_COURSE_B = '30000000-0000-0000-0000-000000000002';
+  const MOODLE_COURSE = 'c0000000-0000-0000-0000-000000000001';
+  const MOODLE_FILE = '70000000-0000-0000-0000-000000000099';
+  const SECTION = '50000000-0000-0000-0000-000000000099';
+
+  beforeAll(async () => {
+    // Idempotent setup: delete-then-insert. If the seed already has
+    // these rows the inserts will be no-ops (we'd see PK conflict —
+    // catch it).
+    await supabase
+      .from('content_embeddings')
+      .delete()
+      .eq('source_id', MOODLE_FILE);
+
+    // Set up the shared registry rows. The seed may already have a
+    // moodle_courses + moodle_sections + moodle_files row — if not,
+    // these inserts create them.
+    await supabase
+      .from('content_embeddings')
+      .insert([
+        {
+          source_type: 'moodle_file',
+          source_id: MOODLE_FILE,
+          segment_index: 0,
+          page_start: null,
+          page_end: null,
+          segment_text: 'shared file content',
+          embedding: JSON.stringify(makeVector(1)),
+          user_id: null,
+          course_id: MOODLE_COURSE, // canonical
+          week_id: null,
+          source_name: 'shared.pdf',
+          mime_type: 'application/pdf',
+          content_hash: 'test-hash-shared',
+        },
+      ]);
+  });
+
+  afterAll(async () => {
+    await supabase
+      .from('content_embeddings')
+      .delete()
+      .eq('source_id', MOODLE_FILE);
+  });
+
+  it('returns the row when the imported file is in the whitelist', async () => {
+    const { data, error } = await supabase.rpc('match_embeddings', {
+      query_embedding: JSON.stringify(makeVector(1)),
+      match_user_id: USER_A,
+      match_course_id: TYPENOTE_COURSE_A,
+      match_moodle_course_id: MOODLE_COURSE,
+      match_imported_moodle_file_ids: [MOODLE_FILE],
+      match_count: 8,
+      similarity_threshold: 0,
+    });
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data[0].source_id).toBe(MOODLE_FILE);
+  });
+
+  it('returns nothing when the imported list is empty', async () => {
+    const { data } = await supabase.rpc('match_embeddings', {
+      query_embedding: JSON.stringify(makeVector(1)),
+      match_user_id: USER_B,
+      match_course_id: TYPENOTE_COURSE_B,
+      match_moodle_course_id: MOODLE_COURSE,
+      match_imported_moodle_file_ids: [],
+      match_count: 8,
+      similarity_threshold: 0,
+    });
+    expect(data).toEqual([]);
+  });
+
+  it('returns nothing when the course is not Moodle-synced (no moodleCourseId)', async () => {
+    const { data } = await supabase.rpc('match_embeddings', {
+      query_embedding: JSON.stringify(makeVector(1)),
+      match_user_id: USER_A,
+      match_course_id: TYPENOTE_COURSE_A,
+      match_moodle_course_id: null,
+      match_imported_moodle_file_ids: null,
+      match_count: 8,
+      similarity_threshold: 0,
+    });
+    // course_material rows might match, but our seeded moodle_file
+    // row must NOT (no moodle branch fires).
+    expect(
+      (data ?? []).some(
+        (r: { source_id: string }) => r.source_id === MOODLE_FILE,
+      ),
+    ).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 5.2: Run the integration test**
+
+```bash
+pnpm test:integration src/lib/queries/__tests__/embeddings.integration.test.ts -t "per-user moodle_file access"
+```
+
+Expected: ALL PASS. If a seeded row is missing (`USER_B` or `TYPENOTE_COURSE_B`), the test will fail with a FK error — at that point update `supabase/seed.sql` to add the missing rows (do this as a separate sub-commit) and re-run.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add src/lib/queries/__tests__/embeddings.integration.test.ts supabase/seed.sql  # seed.sql only if you edited it
+git commit -m "test(integration): per-user moodle_file access via match_embeddings
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Server action — delete moodle file from notebook
+
+**Files:**
+- Create or extend: `src/lib/actions/moodle-sync.ts` (it already has `recordUserFileImport`; add the remove action there)
+- Create: `src/lib/actions/__tests__/moodle-sync.test.ts` (if it doesn't exist; otherwise add to it)
+
+**Background:** Per the spec, the user removing a moodle file from their notebook is just `DELETE` on their `user_file_imports` row. RLS restricts to `auth.uid()`. We add the action with an explicit `user_id` filter (belt-and-suspenders) and revalidate the course page.
+
+- [ ] **Step 6.1: Write the failing test**
+
+Create `src/lib/actions/__tests__/moodle-sync.test.ts` (or add to an existing file) with:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const deleteMock = vi.fn(() => ({
+  eq: vi.fn(function eq1() {
+    return {
+      eq: vi.fn(async () => ({ error: null })),
+    };
+  }),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: { id: 'test-user-id' } },
+        error: null,
+      })),
+    },
+    from: vi.fn(() => ({ delete: deleteMock })),
+  })),
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+import { removeMoodleFileFromNotebook } from '../moodle-sync';
+import { revalidatePath } from 'next/cache';
+
+beforeEach(() => {
+  deleteMock.mockClear();
+  vi.mocked(revalidatePath).mockClear();
+});
+
+describe('removeMoodleFileFromNotebook', () => {
+  it('deletes the user_file_imports row scoped to the current user', async () => {
+    await removeMoodleFileFromNotebook('file-1', 'course-1');
+    expect(deleteMock).toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith('/dashboard/courses/course-1');
+  });
+
+  it('rejects unauthenticated callers', async () => {
+    const { createClient } = await import('@/lib/supabase/server');
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: {
+        getUser: vi.fn(async () => ({ data: { user: null }, error: null })),
+      },
+      from: vi.fn(),
+    } as any);
+
+    await expect(
+      removeMoodleFileFromNotebook('file-1', 'course-1'),
+    ).rejects.toThrow('Unauthorized');
+  });
+});
+```
+
+- [ ] **Step 6.2: Run the test, confirm it fails**
+
+```bash
+pnpm test src/lib/actions/__tests__/moodle-sync.test.ts
+```
+
+Expected: FAIL — `removeMoodleFileFromNotebook` doesn't exist yet.
+
+- [ ] **Step 6.3: Implement the action**
+
+Append to `src/lib/actions/moodle-sync.ts`:
+
+```ts
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createClient } from '@/lib/supabase/server';
+
+export async function removeMoodleFileFromNotebook(
+  moodleFileId: string,
+  courseId: string,
+) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Unauthorized');
+
+  // RLS already restricts user_file_imports.delete to auth.uid() =
+  // user_id; the explicit .eq is belt-and-suspenders.
+  const { error } = await supabase
+    .from('user_file_imports')
+    .delete()
+    .eq('moodle_file_id', moodleFileId)
+    .eq('user_id', user.id);
+
+  if (error) throw new Error(error.message);
+
+  // Codebase convention: literal-path revalidation (see
+  // src/lib/actions/documents.ts:152).
+  revalidatePath('/dashboard/courses/' + courseId);
+}
+```
+
+If `moodle-sync.ts` already has top-level imports for `createClient` or `revalidatePath`, don't duplicate them — just add the function.
+
+- [ ] **Step 6.4: Run the test, confirm it passes**
+
+```bash
+pnpm test src/lib/actions/__tests__/moodle-sync.test.ts
+```
+
+Expected: ALL PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add src/lib/actions/moodle-sync.ts src/lib/actions/__tests__/moodle-sync.test.ts
+git commit -m "feat(moodle): removeMoodleFileFromNotebook server action
+
+Hard-deletes the user's user_file_imports row. Embeddings and storage
+stay shared and untouched — only the caller's notebook entry goes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Trash button on Moodle file rows
+
+**Files:**
+- Create: `src/components/dashboard/moodle-file-row.tsx` (client component for one row with the delete control)
+- Modify: `src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx` (the Moodle Materials section, around lines 358–410)
+
+**Background:** Today each Moodle file is rendered as an `<a>` inline. We extract that to a client component, add a trash icon that calls `removeMoodleFileFromNotebook` after a confirm dialog. Keep the existing `<a>` behavior (open the signed download URL in a new tab) when the row itself is clicked — clicking the trash icon must `stopPropagation`.
+
+- [ ] **Step 7.1: Create the row component**
+
+Create `src/components/dashboard/moodle-file-row.tsx`:
+
+```tsx
+'use client';
+
+import { useTransition } from 'react';
+import { Trash2 } from 'lucide-react';
+
+import { removeMoodleFileFromNotebook } from '@/lib/actions/moodle-sync';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface MoodleFileRowProps {
+  fileId: string;
+  fileName: string;
+  fileType: string; // 'file' | 'link'
+  mimeType: string | null;
+  fileSize: number | null;
+  href: string;
+  isStored: boolean;
+  courseId: string;
+}
+
+export function MoodleFileRow({
+  fileId,
+  fileName,
+  fileType,
+  mimeType,
+  fileSize,
+  href,
+  isStored,
+  courseId,
+}: MoodleFileRowProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const confirmed = window.confirm(
+      `Remove "${fileName}" from your materials? The file stays in the shared registry; only your access record is removed.`,
+    );
+    if (!confirmed) return;
+    startTransition(async () => {
+      try {
+        await removeMoodleFileFromNotebook(fileId, courseId);
+      } catch (err) {
+        // eslint-disable-next-line no-alert
+        alert(
+          `Failed to remove file: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    });
+  };
+
+  return (
+    <a
+      href={href}
+      data-moodle-file-row=""
+      data-file-id={fileId}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-3 px-4 py-2 hover:bg-accent/30 transition-colors"
+      {...(isStored ? { download: fileName } : {})}
+    >
+      <span className="flex-1 text-sm truncate">{fileName}</span>
+      {fileSize && (
+        <span className="text-xs text-muted-foreground shrink-0">
+          {fileSize > 1024 * 1024
+            ? `${(fileSize / (1024 * 1024)).toFixed(1)} MB`
+            : `${Math.round(fileSize / 1024)} KB`}
+        </span>
+      )}
+      <Badge variant="outline" className="text-xs shrink-0">
+        {fileType === 'file' ? (mimeType?.split('/')[1] ?? 'file') : 'link'}
+      </Badge>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleDelete}
+        disabled={isPending}
+        aria-label={`Remove ${fileName} from notebook`}
+        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+      >
+        <Trash2 className="size-3.5" />
+      </Button>
+    </a>
+  );
+}
+```
+
+- [ ] **Step 7.2: Wire it into the course page**
+
+In `src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx`, locate the Moodle Materials section (around lines 358–410 in the version before this PR's earlier edits — search for `Moodle Materials` heading). Replace the inline `<a>` block that renders each file with `<MoodleFileRow .../>`. Add the import at the top:
+
+```ts
+import { MoodleFileRow } from '@/components/dashboard/moodle-file-row';
+```
+
+Replace the inner mapping (within `{section.moodle_files.sort(...).map((file) => { ... })}`) with:
+
+```tsx
+{section.moodle_files
+  .sort((a, b) => a.position - b.position)
+  .map((file) => {
+    const href = file.downloadUrl ?? file.moodle_url;
+    const isStored = !!file.downloadUrl;
+    return (
+      <MoodleFileRow
+        key={file.id}
+        fileId={file.id}
+        fileName={file.file_name}
+        fileType={file.type}
+        mimeType={file.mime_type}
+        fileSize={file.file_size}
+        href={href}
+        isStored={isStored}
+        courseId={courseId}
+      />
+    );
+  })}
+```
+
+- [ ] **Step 7.3: Lint and type-check**
+
+```bash
+pnpm lint
+```
+
+Expected: zero new errors (pre-existing warnings are fine).
+
+- [ ] **Step 7.4: Format the two changed files**
+
+```bash
+npx prettier --write "src/components/dashboard/moodle-file-row.tsx" "src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx"
+```
+
+- [ ] **Step 7.5: Manual smoke test (if Supabase + Docker available)**
+
+```bash
+pnpm dev
+# Open http://localhost:3000/dashboard/courses/<a-moodle-synced-course-id>
+# Click the trash icon next to a Moodle file. Confirm. The row should disappear.
+# Re-sync that Moodle course; the file should come back (recordUserFileImport).
+```
+
+Document the result in your notes. If Docker isn't available, flag this step skipped to the human reviewer.
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add src/components/dashboard/moodle-file-row.tsx src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
+git commit -m "feat(courses): trash button to remove a Moodle file from notebook
+
+New client component MoodleFileRow renders each row with a per-row
+delete control. Clicking it (after confirm) calls the new server
+action; the row disappears via revalidatePath. The underlying storage
+object and shared embedding stay alive for other users.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Signed-URL source citations — backend
+
+**Files:**
+- Modify: `src/lib/actions/ai-context.ts` (the `buildAiContext` function, where `sources` is assembled, around lines 521–533)
+- Modify: `src/lib/actions/__tests__/ai-context.test.ts`
+
+**Background:** Today the `sources` array returned to the chat client contains `{ sourceType, sourceName, weekId, pageRange }`. We add `signedUrl: string | null` by batch-fetching `storage_path` for each cited source and generating 1-hour signed URLs.
+
+- [ ] **Step 8.1: Write the failing test**
+
+Add to the existing `describe('searchContext', ...)` block (or a new `describe('buildAiContext sources', ...)`):
+
+```ts
+describe('buildAiContext attaches signedUrl to sources', () => {
+  it('returns a signed URL for each moodle_file source', async () => {
+    const { matchEmbeddings } = await import('@/lib/queries/embeddings');
+    vi.mocked(matchEmbeddings).mockResolvedValueOnce([
+      {
+        id: 1,
+        source_type: 'moodle_file',
+        source_id: 'file-1',
+        source_name: 'lecture5.pdf',
+        segment_text: 'foo',
+        page_start: null,
+        page_end: null,
+        course_id: 'moodle-course-1',
+        week_id: null,
+        mime_type: 'application/pdf',
+        similarity: 0.9,
+      },
+    ]);
+
+    const { buildAiContext } = await import('../ai-context');
+    const { sources } = await buildAiContext({
+      question: 'q',
+      courseId: 'callers-typenote-course',
+      mode: 'quick',
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].signedUrl).toMatch(/^https?:\/\//);
+  });
+});
+```
+
+You may need to extend the supabase mock to handle `.storage.from('moodle-materials').createSignedUrl(...)` returning a fake URL. Add to the existing storage mock:
+
+```ts
+storage: {
+  from: vi.fn(() => ({
+    download: vi.fn(async () => ({
+      data: new Blob(['fake']),
+      error: null,
+    })),
+    createSignedUrl: vi.fn(async () => ({
+      data: { signedUrl: 'https://example.com/signed/test.pdf' },
+      error: null,
+    })),
+  })),
+},
+```
+
+- [ ] **Step 8.2: Run the test, confirm it fails**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts -t "attaches signedUrl"
+```
+
+Expected: FAIL — `sources[0].signedUrl` is undefined.
+
+- [ ] **Step 8.3: Implement signed-URL generation in `buildAiContext`**
+
+First, update the public `QuestionResult['sources']` type at the top of `src/lib/actions/ai-context.ts` (around line 76):
+
+```ts
+export type QuestionResult = {
+  answer: string;
+  sources: Array<{
+    sourceType: string;
+    sourceName: string;
+    weekId: string | null;
+    pageRange: string | null;
+    signedUrl: string | null;
+  }>;
+  model: 'flash' | 'pro';
+  cached: boolean;
+};
+```
+
+In `buildAiContext`, locate the existing `for (const r of results)` loop that populates `contextTexts` and `sources`. Replace just the `sources.push(...)` call to add `signedUrl: null` and keep using `r.sourceId` directly from the `results` array for the URL lookup that follows. Concretely, the loop body should be:
+
+```ts
+for (const r of results) {
+  if (r.segmentText && !seen.has(r.sourceId)) {
+    seen.add(r.sourceId);
+    contextTexts.push(`--- ${r.sourceName} ---\n${r.segmentText}`);
+    sources.push({
+      sourceType: r.sourceType,
+      sourceName: r.sourceName,
+      weekId: r.weekId,
+      pageRange: null,
+      signedUrl: null, // populated by the URL-attach block below
+    });
+  }
+}
+```
+
+After the loop, add the URL-attach block. We can iterate `results` directly (it has `sourceId`) and write back to `sources` by matching position — same loop pushes into both, so `sources[i]` corresponds to the `i`-th deduplicated result. To make the correspondence explicit, build a parallel array of source ids during the loop:
+
+```ts
+// Track the source_id of each deduplicated source in parallel, so the
+// URL-attach step can look up storage paths without re-deriving.
+const sourceIds: { sourceId: string; sourceType: string; idx: number }[] = [];
+const seen = new Set<string>();
+for (const r of results) {
+  if (r.segmentText && !seen.has(r.sourceId)) {
+    seen.add(r.sourceId);
+    contextTexts.push(`--- ${r.sourceName} ---\n${r.segmentText}`);
+    sources.push({
+      sourceType: r.sourceType,
+      sourceName: r.sourceName,
+      weekId: r.weekId,
+      pageRange: null,
+      signedUrl: null,
+    });
+    sourceIds.push({
+      sourceId: r.sourceId,
+      sourceType: r.sourceType,
+      idx: sources.length - 1,
+    });
+  }
+}
+
+// Batch-fetch storage paths per bucket.
+const moodleIds = sourceIds
+  .filter((s) => s.sourceType === 'moodle_file')
+  .map((s) => s.sourceId);
+const materialIds = sourceIds
+  .filter((s) => s.sourceType === 'course_material')
+  .map((s) => s.sourceId);
+
+const supabase = await createClient();
+const admin = createAdminClient(); // moodle_files is admin-only
+
+const moodlePaths: Record<string, string> = {};
+const materialPaths: Record<string, string> = {};
+
+if (moodleIds.length > 0) {
+  const { data } = await admin
+    .from('moodle_files')
+    .select('id, storage_path')
+    .in('id', moodleIds);
+  for (const row of (data ?? []) as {
+    id: string;
+    storage_path: string | null;
+  }[]) {
+    if (row.storage_path) moodlePaths[row.id] = row.storage_path;
+  }
+}
+if (materialIds.length > 0) {
+  const { data } = await supabase
+    .from('course_materials')
+    .select('id, storage_path')
+    .in('id', materialIds);
+  for (const row of (data ?? []) as { id: string; storage_path: string }[]) {
+    materialPaths[row.id] = row.storage_path;
+  }
+}
+
+// Generate signed URLs in parallel and write into sources by index.
+await Promise.all(
+  sourceIds.map(async ({ sourceId, sourceType, idx }) => {
+    const bucket =
+      sourceType === 'moodle_file'
+        ? 'moodle-materials'
+        : sourceType === 'course_material'
+          ? 'course-materials'
+          : null;
+    const path =
+      sourceType === 'moodle_file'
+        ? moodlePaths[sourceId]
+        : sourceType === 'course_material'
+          ? materialPaths[sourceId]
+          : null;
+    if (!bucket || !path) return;
+    const client = bucket === 'moodle-materials' ? admin : supabase;
+    const { data } = await client.storage
+      .from(bucket)
+      .createSignedUrl(path, 3600);
+    sources[idx].signedUrl = data?.signedUrl ?? null;
+  }),
+);
+```
+
+This avoids the `delete`-an-internal-property trick and keeps `sources` as a plain public type throughout.
+
+- [ ] **Step 8.4: Run the test, confirm it passes**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts -t "attaches signedUrl"
+```
+
+Expected: PASS.
+
+- [ ] **Step 8.5: Run the full ai-context test file**
+
+```bash
+pnpm test src/lib/actions/__tests__/ai-context.test.ts
+```
+
+Expected: ALL PASS. Other tests may need the `createSignedUrl` mock — add it if they fail.
+
+- [ ] **Step 8.6: Commit**
+
+```bash
+git add src/lib/actions/ai-context.ts src/lib/actions/__tests__/ai-context.test.ts
+git commit -m "feat(ai): attach signed URLs to source citations
+
+Each source in the AI response now carries a 1-hour signed Storage URL
+when one can be generated. Frontend can render the citation badge as a
+link. Fallback is a non-clickable badge (signedUrl=null) when the
+lookup fails or the source isn't stored.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Clickable source citations — frontend
+
+**Files:**
+- Modify: `src/components/ai/ai-chat-panel.tsx` (the `ChatSource` interface and the source badge rendering, around lines 23–28 and 615–627)
+
+**Background:** Add `signedUrl: string | null` to the `ChatSource` type, then render the badge as `<a>` when present.
+
+- [ ] **Step 9.1: Update the type and rendering**
+
+In `src/components/ai/ai-chat-panel.tsx`, update the `ChatSource` interface (around line 23):
+
+```ts
+interface ChatSource {
+  sourceType: string;
+  sourceName: string;
+  weekId: string | null;
+  pageRange: string | null;
+  signedUrl: string | null;
+}
+```
+
+Replace the badge rendering (around lines 615–627) — the `{msg.sources.map(...)}` block — with:
+
+```tsx
+{msg.sources.map((src, j) => {
+  const content = (
+    <>
+      <BookOpen className="h-2.5 w-2.5" />
+      {src.sourceName}
+      {src.pageRange && ` (${src.pageRange})`}
+    </>
+  );
+  const className =
+    'inline-flex items-center gap-1 rounded-full border bg-background px-2.5 py-0.5 text-[10px] text-muted-foreground';
+  return src.signedUrl ? (
+    <a
+      key={j}
+      href={src.signedUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className + ' hover:bg-accent hover:text-foreground transition-colors'}
+    >
+      {content}
+    </a>
+  ) : (
+    <span key={j} className={className}>
+      {content}
+    </span>
+  );
+})}
+```
+
+- [ ] **Step 9.2: Lint and format**
+
+```bash
+pnpm lint
+npx prettier --write src/components/ai/ai-chat-panel.tsx
+```
+
+Expected: zero new errors.
+
+- [ ] **Step 9.3: Run any existing ai-chat-panel tests**
+
+```bash
+pnpm test src/components/ai/ai-chat-panel.test.tsx
+```
+
+Expected: PASS. If the test asserts the exact source DOM shape, update it to handle the conditional `<a>` vs `<span>`.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add src/components/ai/ai-chat-panel.tsx src/components/ai/ai-chat-panel.test.tsx
+git commit -m "feat(ai-chat): clickable source citations when signedUrl present
+
+The badge renders as <a> with target=_blank when the backend supplied
+a signed URL; falls back to <span> otherwise. No styling changes
+besides a hover state on the link variant.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: E2E spec — two-user notebook + delete
+
+**Files:**
+- Modify: `e2e/TEST_REGISTRY.md`
+- Create: `e2e/ai-chat-per-user-materials.spec.ts`
+
+**Background:** Per CLAUDE.md, every feature needs a real-flow Playwright spec using `e2e/helpers/auth.ts`. Two test scenarios: (1) user A imports a Moodle file → AI cites it; (2) user A deletes the file from notebook → AI no longer cites it but user B (who also imported the same upstream file) still does.
+
+- [ ] **Step 10.1: Register the test scenarios**
+
+Open `e2e/TEST_REGISTRY.md` and add a new section (location: under whatever heading matches "AI Chat" or "AI Tutor"; if none, add one):
+
+```markdown
+### AI chat — per-user material access
+
+- `ai-chat-per-user-materials.spec.ts`
+  - "user sees materials they imported in chat"
+  - "removing a file from notebook hides it from chat"
+  - "removing a file from one user's notebook does not affect another user"
+```
+
+- [ ] **Step 10.2: Write the Playwright spec**
+
+Create `e2e/ai-chat-per-user-materials.spec.ts`. The exact selectors below assume the existing chat-panel DOM (open via bubble, send a question, wait for assistant message). Adjust if reality differs:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { loginAs } from './helpers/auth';
+
+const COURSE_NAME = 'CS101'; // matches seed
+const TEST_QUESTION = 'What is in lecture 5?';
+
+test.describe('AI chat — per-user material access', () => {
+  test('user sees materials they imported in chat', async ({ page }) => {
+    await loginAs(page, 'user-a');
+    await page.goto('/dashboard');
+    await page.getByRole('link', { name: COURSE_NAME }).click();
+    // Open chat
+    await page.getByRole('button', { name: 'Open AI chat' }).click();
+    // Send question
+    await page.getByPlaceholder(/Ask anything/).fill(TEST_QUESTION);
+    await page.getByRole('button', { name: /Send|submit/ }).click();
+    // Wait for at least one source badge
+    await expect(page.getByRole('link', { name: /\.pdf|\.docx|\.pptx/i }).first())
+      .toBeVisible({ timeout: 30_000 });
+  });
+
+  test('removing a file from notebook hides it from chat', async ({ page }) => {
+    await loginAs(page, 'user-a');
+    await page.goto('/dashboard');
+    await page.getByRole('link', { name: COURSE_NAME }).click();
+
+    // Capture the file name we'll delete (first visible Moodle file row)
+    const fileRow = page.locator('[data-moodle-file-row]').first();
+    // If the row component doesn't expose a data-attr yet, use the
+    // visible filename and grep by aria-label of the trash button.
+    const fileName = await fileRow.locator('span.flex-1').innerText();
+
+    // Confirm dialog: stub it
+    page.once('dialog', (d) => d.accept());
+    await fileRow.getByRole('button', { name: /Remove .* from notebook/ }).click();
+    await expect(page.getByText(fileName)).toHaveCount(0);
+
+    // Re-open chat and ask the question
+    await page.getByRole('button', { name: 'Open AI chat' }).click();
+    await page.getByPlaceholder(/Ask anything/).fill(TEST_QUESTION);
+    await page.getByRole('button', { name: /Send|submit/ }).click();
+
+    // The deleted file must NOT appear as a source
+    const responses = page.locator('[role="article"]'); // adjust if needed
+    await expect(responses.last()).not.toContainText(fileName, { timeout: 30_000 });
+  });
+});
+```
+
+If your `loginAs` helper doesn't support `'user-a'` as an alias, use whatever the registry provides (`test@typenote.dev` + `Test1234` from seed for one user, and add a second seeded user if needed — same approach as Task 5).
+
+- [ ] **Step 10.3: Run the spec**
+
+```bash
+pnpm test:e2e e2e/ai-chat-per-user-materials.spec.ts
+```
+
+Expected: PASS. If any assertion fails because the selectors don't match the real DOM, fix the selectors — the assertions themselves are correct.
+
+- [ ] **Step 10.4: Commit**
+
+```bash
+git add e2e/TEST_REGISTRY.md e2e/ai-chat-per-user-materials.spec.ts
+git commit -m "test(e2e): per-user AI chat material access
+
+Two-scenario spec: (1) imported files appear as sources, (2) deleting
+a file from the notebook hides it from chat. Uses the shared loginAs
+helper.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Force-push PR #184 and update its description
+
+**Files:** None (git + GitHub operations only)
+
+- [ ] **Step 11.1: Push the branch**
+
+```bash
+git push --force-with-lease origin fix/ai-chat-per-user-material-access
+```
+
+Use `--force-with-lease`, not `--force`, so the push fails if someone else has updated the branch.
+
+- [ ] **Step 11.2: Update the PR description**
+
+```bash
+gh pr edit 184 --body-file - <<'EOF'
+## Summary
+
+Closes the bug: *"for one user (maybe the one who uploaded the files) chat has access to material and for other it doesn't."*
+
+`moodle_files` is a shared registry — one file row even when many users sync the same upstream Moodle course. But the AI's embeddings used to be tied to the **first** indexer's Typenote `course_id`, so only that one user could find the file via RAG. After this PR:
+
+- **One canonical set of embeddings per Moodle file**, keyed by `moodle_courses.id` (the file's upstream home, reached via `moodle_files.section_id → moodle_sections.course_id`).
+- **Per-user access** derived from `user_file_imports`: the AI search filters embeddings by the caller's notebook.
+- **Delete-from-notebook**: trash button on each Moodle file row hard-deletes the user's `user_file_imports` row. Shared storage + embeddings untouched.
+- **Clickable source citations**: AI response sources are now `<a>` to a 1-hour signed Storage URL.
+
+## What changed
+
+Design doc: [`docs/superpowers/specs/2026-05-22-per-user-material-access-design.md`](docs/superpowers/specs/2026-05-22-per-user-material-access-design.md). Reviewed by two independent subagent passes.
+
+- Migration `20260522123000_per_user_material_access.sql` — backfills moodle_file embedding `course_id` to canonical, replaces `match_embeddings` RPC with two new params (`match_moodle_course_id`, `match_imported_moodle_file_ids`), restores `LANGUAGE sql STABLE`.
+- `indexContent` for moodle_file resolves `section_id → moodle_sections.course_id` and writes that to the embedding row.
+- `searchContext` resolves user's Typenote course → moodle_courses.id, fetches the user's notebook, passes both to the RPC.
+- New `removeMoodleFileFromNotebook` server action + `MoodleFileRow` client component on the course page.
+- `buildAiContext` batch-fetches storage paths + generates signed URLs for each source; `ai-chat-panel.tsx` renders linked citations.
+- E2E spec `ai-chat-per-user-materials.spec.ts` for the two-user flow + delete.
+
+## Test plan
+- [x] `pnpm test` — full unit suite
+- [x] `pnpm test:integration` — RPC behavior with seeded two-user data
+- [x] `pnpm test:e2e` — the new spec
+- [x] `pnpm lint`, `pnpm format:check`
+- [ ] Manual: two users, same Moodle source, both ask the AI about an imported file (both see it). Delete from B's notebook (B no longer sees it; A still does). Click a source citation in chat — opens the file.
+
+Targets `dev`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+```
+
+---
+
+## Self-review notes (already applied)
+
+- Migration uses bare `vector` in `DROP FUNCTION` to match how `00014` registered it.
+- `LANGUAGE sql STABLE` restored.
+- `matchEmbeddings` returns `MatchResult[]`; tasks 2, 3, 4, 5, 8 all use the same property names (`source_id`, `course_id`, `mime_type`, `similarity`).
+- `removeMoodleFileFromNotebook(fileId, courseId)` signature used consistently in tasks 6, 7, 10.
+- `signedUrl: string | null` added to `ChatSource` in task 9 matches `QuestionResult['sources'][number].signedUrl` in task 8.
+- No "TBD"/"TODO" in any step; every code step contains the actual code.
+
+---
+
+## Out-of-scope follow-ups (do NOT do in this PR)
+
+- Bulk-select delete on the course page.
+- "Restore from removed" UI.
+- NotebookLM-style personal uploads (would extend `course_materials`).
+- Source citations for `personal_files` (separate code path not touched here).

--- a/docs/superpowers/plans/2026-05-22-per-user-material-access.md
+++ b/docs/superpowers/plans/2026-05-22-per-user-material-access.md
@@ -15,6 +15,7 @@
 Before you start: read the spec. The plan below assumes you've read it.
 
 Confirm:
+
 - Working directory is the worktree at `C:\projects\Typenote\.claude\worktrees\unified-juggling-matsumoto`.
 - On branch `fix/ai-chat-per-user-material-access`.
 - `git status` is clean.
@@ -26,6 +27,7 @@ Confirm:
 ## Task 1: Write the migration SQL
 
 **Files:**
+
 - Create: `supabase/migrations/20260522123000_per_user_material_access.sql`
 
 **Background:** Today's `match_embeddings` (from `00014_match_embeddings_return_text.sql`) takes 6 args and filters by a single `match_course_id`. We're replacing it with a function that handles two source types (`course_material` keyed by the user's Typenote `course_id`, `moodle_file` keyed by the canonical `moodle_courses.id`) plus a per-user file whitelist. We also backfill existing rows in-place (no embedding API calls).
@@ -167,6 +169,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 2: Update `matchEmbeddings` TS signature
 
 **Files:**
+
 - Modify: `src/lib/queries/embeddings.ts` (the `matchEmbeddings` function around line 91)
 - Test: `src/lib/queries/__tests__/embeddings.integration.test.ts` (NEW test for new params)
 
@@ -269,6 +272,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 3: `indexContent` uses canonical `moodle_courses.id` for moodle_file
 
 **Files:**
+
 - Modify: `src/lib/actions/ai-context.ts` (the `if (source.type === 'moodle_file')` block around line 124)
 - Modify: `src/lib/actions/__tests__/ai-context.test.ts` (the "embeds moodle_file as shared" test and add a new one)
 
@@ -292,9 +296,11 @@ vi.mock('@/lib/supabase/admin', () => {
     createAdminClient: vi.fn(() => ({
       from: vi.fn((table: string) => {
         const data =
-          table === 'moodle_files' ? moodleFileRow :
-          table === 'moodle_sections' ? moodleSectionRow :
-          null;
+          table === 'moodle_files'
+            ? moodleFileRow
+            : table === 'moodle_sections'
+              ? moodleSectionRow
+              : null;
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
@@ -446,6 +452,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 4: `searchContext` resolves moodle_course_id and imported files
 
 **Files:**
+
 - Modify: `src/lib/actions/ai-context.ts` (the `searchContext` function around line 289)
 - Modify: `src/lib/actions/__tests__/ai-context.test.ts` (the existing `searchContext` describe block)
 
@@ -480,8 +487,9 @@ vi.mock('@/lib/supabase/server', () => ({
         { moodle_file_id: 'imported-file-b' },
       ];
       const result =
-        table === 'user_file_imports' ? { data: imports, error: null } :
-        { data, error: null };
+        table === 'user_file_imports'
+          ? { data: imports, error: null }
+          : { data, error: null };
       const chain: any = {
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
@@ -561,8 +569,8 @@ export async function searchContext(
       .eq('course_id', params.courseId)
       .maybeSingle();
     moodleCourseId =
-      (sync as { moodle_course_id: string | null } | null)
-        ?.moodle_course_id ?? null;
+      (sync as { moodle_course_id: string | null } | null)?.moodle_course_id ??
+      null;
 
     if (moodleCourseId) {
       // Fetch the user's notebook — the set of moodle files they have
@@ -633,6 +641,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 5: Integration test for the two-user scenario
 
 **Files:**
+
 - Modify: `src/lib/queries/__tests__/embeddings.integration.test.ts`
 
 **Background:** Verify the migration + code changes against the real DB. Seed two users, one shared moodle_file row, embedding row pointing at `moodle_courses.id`. Both users should match it. Then delete user B's `user_file_imports` row → user B no longer matches.
@@ -665,25 +674,23 @@ describe('per-user moodle_file access', () => {
     // Set up the shared registry rows. The seed may already have a
     // moodle_courses + moodle_sections + moodle_files row — if not,
     // these inserts create them.
-    await supabase
-      .from('content_embeddings')
-      .insert([
-        {
-          source_type: 'moodle_file',
-          source_id: MOODLE_FILE,
-          segment_index: 0,
-          page_start: null,
-          page_end: null,
-          segment_text: 'shared file content',
-          embedding: JSON.stringify(makeVector(1)),
-          user_id: null,
-          course_id: MOODLE_COURSE, // canonical
-          week_id: null,
-          source_name: 'shared.pdf',
-          mime_type: 'application/pdf',
-          content_hash: 'test-hash-shared',
-        },
-      ]);
+    await supabase.from('content_embeddings').insert([
+      {
+        source_type: 'moodle_file',
+        source_id: MOODLE_FILE,
+        segment_index: 0,
+        page_start: null,
+        page_end: null,
+        segment_text: 'shared file content',
+        embedding: JSON.stringify(makeVector(1)),
+        user_id: null,
+        course_id: MOODLE_COURSE, // canonical
+        week_id: null,
+        source_name: 'shared.pdf',
+        mime_type: 'application/pdf',
+        content_hash: 'test-hash-shared',
+      },
+    ]);
   });
 
   afterAll(async () => {
@@ -764,6 +771,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 6: Server action — delete moodle file from notebook
 
 **Files:**
+
 - Create or extend: `src/lib/actions/moodle-sync.ts` (it already has `recordUserFileImport`; add the remove action there)
 - Create: `src/lib/actions/__tests__/moodle-sync.test.ts` (if it doesn't exist; otherwise add to it)
 
@@ -901,6 +909,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 7: Trash button on Moodle file rows
 
 **Files:**
+
 - Create: `src/components/dashboard/moodle-file-row.tsx` (client component for one row with the delete control)
 - Modify: `src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx` (the Moodle Materials section, around lines 358–410)
 
@@ -1011,25 +1020,27 @@ import { MoodleFileRow } from '@/components/dashboard/moodle-file-row';
 Replace the inner mapping (within `{section.moodle_files.sort(...).map((file) => { ... })}`) with:
 
 ```tsx
-{section.moodle_files
-  .sort((a, b) => a.position - b.position)
-  .map((file) => {
-    const href = file.downloadUrl ?? file.moodle_url;
-    const isStored = !!file.downloadUrl;
-    return (
-      <MoodleFileRow
-        key={file.id}
-        fileId={file.id}
-        fileName={file.file_name}
-        fileType={file.type}
-        mimeType={file.mime_type}
-        fileSize={file.file_size}
-        href={href}
-        isStored={isStored}
-        courseId={courseId}
-      />
-    );
-  })}
+{
+  section.moodle_files
+    .sort((a, b) => a.position - b.position)
+    .map((file) => {
+      const href = file.downloadUrl ?? file.moodle_url;
+      const isStored = !!file.downloadUrl;
+      return (
+        <MoodleFileRow
+          key={file.id}
+          fileId={file.id}
+          fileName={file.file_name}
+          fileType={file.type}
+          mimeType={file.mime_type}
+          fileSize={file.file_size}
+          href={href}
+          isStored={isStored}
+          courseId={courseId}
+        />
+      );
+    });
+}
 ```
 
 - [ ] **Step 7.3: Lint and type-check**
@@ -1076,6 +1087,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 8: Signed-URL source citations — backend
 
 **Files:**
+
 - Modify: `src/lib/actions/ai-context.ts` (the `buildAiContext` function, where `sources` is assembled, around lines 521–533)
 - Modify: `src/lib/actions/__tests__/ai-context.test.ts`
 
@@ -1304,6 +1316,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 9: Clickable source citations — frontend
 
 **Files:**
+
 - Modify: `src/components/ai/ai-chat-panel.tsx` (the `ChatSource` interface and the source badge rendering, around lines 23–28 and 615–627)
 
 **Background:** Add `signedUrl: string | null` to the `ChatSource` type, then render the badge as `<a>` when present.
@@ -1325,32 +1338,36 @@ interface ChatSource {
 Replace the badge rendering (around lines 615–627) — the `{msg.sources.map(...)}` block — with:
 
 ```tsx
-{msg.sources.map((src, j) => {
-  const content = (
-    <>
-      <BookOpen className="h-2.5 w-2.5" />
-      {src.sourceName}
-      {src.pageRange && ` (${src.pageRange})`}
-    </>
-  );
-  const className =
-    'inline-flex items-center gap-1 rounded-full border bg-background px-2.5 py-0.5 text-[10px] text-muted-foreground';
-  return src.signedUrl ? (
-    <a
-      key={j}
-      href={src.signedUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={className + ' hover:bg-accent hover:text-foreground transition-colors'}
-    >
-      {content}
-    </a>
-  ) : (
-    <span key={j} className={className}>
-      {content}
-    </span>
-  );
-})}
+{
+  msg.sources.map((src, j) => {
+    const content = (
+      <>
+        <BookOpen className="h-2.5 w-2.5" />
+        {src.sourceName}
+        {src.pageRange && ` (${src.pageRange})`}
+      </>
+    );
+    const className =
+      'inline-flex items-center gap-1 rounded-full border bg-background px-2.5 py-0.5 text-[10px] text-muted-foreground';
+    return src.signedUrl ? (
+      <a
+        key={j}
+        href={src.signedUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={
+          className + ' hover:bg-accent hover:text-foreground transition-colors'
+        }
+      >
+        {content}
+      </a>
+    ) : (
+      <span key={j} className={className}>
+        {content}
+      </span>
+    );
+  });
+}
 ```
 
 - [ ] **Step 9.2: Lint and format**
@@ -1388,6 +1405,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 ## Task 10: E2E spec — two-user notebook + delete
 
 **Files:**
+
 - Modify: `e2e/TEST_REGISTRY.md`
 - Create: `e2e/ai-chat-per-user-materials.spec.ts`
 
@@ -1428,8 +1446,9 @@ test.describe('AI chat — per-user material access', () => {
     await page.getByPlaceholder(/Ask anything/).fill(TEST_QUESTION);
     await page.getByRole('button', { name: /Send|submit/ }).click();
     // Wait for at least one source badge
-    await expect(page.getByRole('link', { name: /\.pdf|\.docx|\.pptx/i }).first())
-      .toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.getByRole('link', { name: /\.pdf|\.docx|\.pptx/i }).first(),
+    ).toBeVisible({ timeout: 30_000 });
   });
 
   test('removing a file from notebook hides it from chat', async ({ page }) => {
@@ -1445,7 +1464,9 @@ test.describe('AI chat — per-user material access', () => {
 
     // Confirm dialog: stub it
     page.once('dialog', (d) => d.accept());
-    await fileRow.getByRole('button', { name: /Remove .* from notebook/ }).click();
+    await fileRow
+      .getByRole('button', { name: /Remove .* from notebook/ })
+      .click();
     await expect(page.getByText(fileName)).toHaveCount(0);
 
     // Re-open chat and ask the question
@@ -1455,7 +1476,9 @@ test.describe('AI chat — per-user material access', () => {
 
     // The deleted file must NOT appear as a source
     const responses = page.locator('[role="article"]'); // adjust if needed
-    await expect(responses.last()).not.toContainText(fileName, { timeout: 30_000 });
+    await expect(responses.last()).not.toContainText(fileName, {
+      timeout: 30_000,
+    });
   });
 });
 ```

--- a/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
+++ b/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
@@ -1,0 +1,277 @@
+# Per-user material access in AI chat
+
+**Date:** 2026-05-22
+**Status:** Draft — awaiting user approval
+**Branch / PR:** `fix/ai-chat-per-user-material-access` → PR #184 (force-push)
+
+---
+
+## 1. Problem
+
+The shared `moodle_files` registry is one row per file even when many users sync the same upstream Moodle course. Storage objects are already deduplicated by content hash. **Embeddings are not.**
+
+`indexContent({ type: 'moodle_file', courseId })` writes embedding rows with `course_id = <caller's Typenote course_id>`, plus a `(source_type, source_id, segment_index)` unique constraint that forbids multiple rows per file segment. The chain of effects when two users (A then B) sync the same Moodle course and import the same file F:
+
+1. User A imports F → `indexContent` runs → no rows exist → rows inserted with `course_id = A's Typenote course`.
+2. User B imports F → `indexContent` runs → content-hash matches (same file bytes) → **skipped**. No rows for B's Typenote course exist.
+3. User B's chat queries `match_embeddings` with `match_course_id = B's Typenote course` → zero rows match → AI replies "no materials".
+
+If step 2 *had* re-indexed instead of skipping (e.g. a content change), `upsertEmbeddings` deletes by `source_id` alone — so A's rows would be wiped and replaced with B's.
+
+Reported symptom: *"for one user (maybe the one who uploaded the files) chat has access to material and for other it doesn't."* This is consistent with the bug.
+
+## 2. Goals
+
+1. **One canonical set of embeddings per Moodle file.** Storage and embedding compute cost both stay at O(1) per file regardless of how many users sync.
+2. **Per-user access** to those embeddings is derived from `user_file_imports` — *"if you have it in your materials list, the AI can see it."*
+3. **Delete-from-notebook** for Moodle files: removes only the caller's `user_file_imports` row. The shared storage object and the shared embedding stay alive for other users.
+4. **Forward-compatible** with two near-term features:
+   - personal user-uploaded files indexed like NotebookLM (each user's own files indexed into their own course),
+   - clickable source citations in AI responses (the citation badge becomes a link to the source file).
+
+## 3. Non-goals
+
+- Bulk-delete UI for the notebook (per-row delete only in this PR).
+- Changing the `course_materials` model. Course materials are inherently per-user (one upload per user) and already work correctly; we touch nothing there.
+- Background re-embedding of historical files. The migration backfills metadata via SQL UPDATE; no embedding API calls.
+
+## 4. Data model
+
+### `content_embeddings`
+
+| Column | `moodle_file` rows (today) | `moodle_file` rows (after fix) | `course_material` rows |
+| --- | --- | --- | --- |
+| `user_id` | `NULL` (shared) | `NULL` (unchanged) | `<uploader>` (unchanged) |
+| `course_id` | `<first-indexer's Typenote course>` (buggy) | `<moodle_files.course_id>` = upstream Moodle course id (canonical) | `<uploader's Typenote course>` (unchanged) |
+| `week_id` | `NULL` typically | `NULL` (unchanged) | `<material's week>` (unchanged) |
+| `UNIQUE (source_type, source_id, segment_index)` | enforced | **unchanged** — one row per file segment globally | unchanged |
+
+Key insight: a Moodle file belongs to exactly one upstream Moodle course. That's its canonical home and never changes. Different users mirror that course into different Typenote courses, but the file's home in the upstream registry is invariant. So `moodle_course_id` is the right key for the embedding row.
+
+### `user_file_imports`
+
+No schema change. Hard-delete the row when the user removes a file from their notebook.
+
+The existing `status` enum (`'imported'`, `'removed_from_moodle'`) stays. `'removed_from_moodle'` continues to mean *"upstream removed this; we preserved an audit row"*. User-initiated delete is just a `DELETE`, which is simpler and lossless (the user can re-import to re-create).
+
+## 5. Code changes
+
+### 5.1 `src/lib/actions/ai-context.ts` — `indexContent`
+
+For `source.type === 'moodle_file'`:
+- Select `course_id` from `moodle_files` along with `storage_path`, `file_name`, `mime_type`.
+- Use `fileRow.course_id` (the upstream Moodle course id) as the `courseId` variable for the embedding rows. **Ignore** `source.courseId` (the caller's Typenote course id) for the embedding row.
+- The content-hash gate is now stable: any user importing file F looks up the row with `course_id = mf.course_id`, sees the existing hash, and short-circuits. No wasted re-embedding.
+
+For `source.type === 'course_material'`: unchanged.
+
+### 5.2 `src/lib/actions/ai-context.ts` — `searchContext`
+
+Add a "resolve user's view" pre-step:
+
+```ts
+// 1. Resolve Typenote course → upstream Moodle course (if synced)
+const { data: sync } = await admin
+  .from('user_course_syncs')
+  .select('moodle_course_id')
+  .eq('user_id', userId)
+  .eq('course_id', params.courseId)
+  .maybeSingle();
+const moodleCourseId = sync?.moodle_course_id ?? null;
+
+// 2. Fetch the set of moodle files the user has imported
+let importedMoodleFileIds: string[] | null = null;
+if (moodleCourseId) {
+  const { data: imports } = await admin
+    .from('user_file_imports')
+    .select('moodle_file_id')
+    .eq('user_id', userId)
+    .eq('status', 'imported');
+  importedMoodleFileIds = (imports ?? []).map((i) => i.moodle_file_id);
+}
+
+// 3. Pass both to the RPC
+const matches = await matchEmbeddings({
+  queryEmbedding,
+  userId,
+  courseId: params.courseId,
+  moodleCourseId,
+  importedMoodleFileIds,
+  ...
+});
+```
+
+### 5.3 `src/lib/queries/embeddings.ts` — `matchEmbeddings`
+
+Signature extends with two optional params; both default null:
+
+```ts
+matchEmbeddings({
+  queryEmbedding, userId,
+  courseId, moodleCourseId, importedMoodleFileIds,
+  weekId, matchCount, similarityThreshold,
+})
+```
+
+### 5.4 `supabase/migrations/20260522123000_per_user_material_access.sql`
+
+```sql
+-- Step A: Backfill — repoint moodle_file embeddings to the canonical
+-- Moodle course id (today they point at the first-indexer's Typenote
+-- course id, which causes the access bug for every later user).
+UPDATE public.content_embeddings ce
+SET course_id = mf.course_id
+FROM public.moodle_files mf
+WHERE ce.source_type = 'moodle_file'
+  AND ce.source_id = mf.id
+  AND ce.course_id IS DISTINCT FROM mf.course_id;
+
+-- Step B: Replace match_embeddings RPC with the new signature.
+DROP FUNCTION IF EXISTS public.match_embeddings(
+  extensions.vector, uuid, uuid, uuid, integer, double precision
+);
+
+CREATE OR REPLACE FUNCTION public.match_embeddings(
+  query_embedding extensions.vector(1536),
+  match_user_id uuid,
+  match_course_id uuid DEFAULT NULL,
+  match_moodle_course_id uuid DEFAULT NULL,
+  match_imported_moodle_file_ids uuid[] DEFAULT NULL,
+  match_week_id uuid DEFAULT NULL,
+  match_count int DEFAULT 8,
+  similarity_threshold float DEFAULT 0.3
+)
+RETURNS TABLE (
+  id bigint,
+  source_type text,
+  source_id uuid,
+  source_name text,
+  segment_text text,
+  page_start integer,
+  page_end integer,
+  course_id uuid,
+  week_id uuid,
+  mime_type text,
+  similarity float
+)
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    ce.id, ce.source_type, ce.source_id, ce.source_name, ce.segment_text,
+    ce.page_start, ce.page_end, ce.course_id, ce.week_id, ce.mime_type,
+    1 - (ce.embedding <=> query_embedding) AS similarity
+  FROM public.content_embeddings ce
+  WHERE (ce.user_id = match_user_id OR ce.user_id IS NULL)
+    AND (
+      -- course_material: keyed by Typenote course_id, uploader owns the row
+      (ce.source_type = 'course_material'
+        AND match_course_id IS NOT NULL
+        AND ce.course_id = match_course_id)
+      OR
+      -- moodle_file: keyed by upstream Moodle course_id; access is
+      -- whitelisted by the user's imported file set
+      (ce.source_type = 'moodle_file'
+        AND match_moodle_course_id IS NOT NULL
+        AND ce.course_id = match_moodle_course_id
+        AND (match_imported_moodle_file_ids IS NULL
+             OR ce.source_id = ANY(match_imported_moodle_file_ids)))
+    )
+    AND (match_week_id IS NULL OR ce.week_id = match_week_id)
+    AND 1 - (ce.embedding <=> query_embedding) > similarity_threshold
+  ORDER BY ce.embedding <=> query_embedding
+  LIMIT match_count;
+END;
+$$;
+```
+
+### 5.5 Delete-from-notebook
+
+**Server action** (new): `src/lib/actions/personal-materials.ts` (or extend an existing moodle-sync action file)
+
+```ts
+'use server';
+export async function removeMoodleFileFromNotebook(moodleFileId: string) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) throw new Error('Unauthorized');
+
+  // RLS already enforces user_id = auth.uid(); the .eq() is belt-and-suspenders.
+  const { error } = await supabase
+    .from('user_file_imports')
+    .delete()
+    .eq('moodle_file_id', moodleFileId)
+    .eq('user_id', user.id);
+
+  if (error) throw new Error(error.message);
+  revalidatePath('/dashboard/courses/[courseId]', 'page');
+}
+```
+
+**UI:** add a trash-icon button on each Moodle file row in `src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx`'s Moodle Materials section. Click → confirm dialog → server action → page revalidates and the row disappears.
+
+For `course_materials`, the existing delete flow stays — same UX, different action.
+
+### 5.6 Clickable source citations (in this PR)
+
+The AI's source array currently looks like:
+
+```ts
+{ sourceType, sourceName, weekId, pageRange }
+```
+
+To make citations linkable:
+
+1. In `buildAiContext`, after assembling `sources` from the match results, batch-fetch `storage_path` for each:
+   - `moodle_file` source_ids → `SELECT id, storage_path FROM moodle_files WHERE id IN (...)`
+   - `course_material` source_ids → `SELECT id, storage_path FROM course_materials WHERE id IN (...)`
+2. Generate signed URLs in a single `Promise.all` over all storage paths: `supabase.storage.from(bucket).createSignedUrl(path, 3600)` (1 hr expiry).
+3. Add `signedUrl: string | null` to each source.
+4. In `ai-chat-panel.tsx`, render the citation badge as an `<a href={signedUrl} target="_blank" rel="noopener noreferrer">` when `signedUrl` is present; fall back to `<span>` otherwise.
+
+Two batched DB queries + N parallel signed-URL generations adds well under 500 ms to the first SSE chunk. Acceptable for chat latency.
+
+The SSE event `{ type: 'sources', sources: [...] }` payload gains the optional `signedUrl` field — backward compatible (older clients ignore unknown fields).
+
+## 6. Backwards compatibility
+
+- Existing embedding rows: the migration's `UPDATE` repoints them to `moodle_course_id` in-place. No row deletions, no embedding API calls.
+- API contract: `match_embeddings` RPC signature changes, but only `searchContext` (in this repo) calls it. No external consumers.
+- `user_file_imports` schema: unchanged. Existing rows untouched.
+
+## 6.1 Edge-case behavior of the new RPC
+
+| Caller state | `match_course_id` | `match_moodle_course_id` | `match_imported_moodle_file_ids` | Result for moodle_file rows |
+| --- | --- | --- | --- | --- |
+| Course is Moodle-synced, user has imports | typenote uuid | moodle uuid | non-empty `uuid[]` | matched iff in the imported set |
+| Course is Moodle-synced, user has no imports yet | typenote uuid | moodle uuid | `[]` | none (correct — nothing in notebook) |
+| Course is not Moodle-synced | typenote uuid | `NULL` | `NULL` | none (no moodle branch) |
+| Caller passes `NULL` for imported list explicitly | typenote uuid | moodle uuid | `NULL` | all moodle files in that Moodle course (today's permissive behavior) |
+
+We deliberately treat `NULL` as "no filter" so the RPC remains usable for admin/diagnostic queries without changing its semantics from the caller side. `searchContext` always passes a concrete array (possibly empty); it never passes `NULL` for `match_imported_moodle_file_ids` when `match_moodle_course_id` is set.
+
+## 7. Risk + rollback
+
+- Risk: a user whose `user_course_syncs` row is missing (edge case — they imported files but the sync row got cleaned up) would not be able to see their moodle files in chat because `moodle_course_id` resolves to null. Mitigation: defensive null-check in `searchContext`; we can fall back to "no moodle results" cleanly, never to "leak other users' data".
+- Rollback: revert the migration commit + re-deploy. The old RPC signature is preserved in `00012_create_content_embeddings.sql` history; resurrecting it is a small inverse migration.
+
+## 8. Test plan
+
+- **Unit (Vitest):**
+  - `indexContent` for `moodle_file` writes embedding row with `course_id = fileRow.course_id` (not `source.courseId`).
+  - `searchContext` calls `matchEmbeddings` with both `courseId` and `moodleCourseId`/`importedMoodleFileIds` derived from the user's sync + imports.
+  - `removeMoodleFileFromNotebook` deletes the right row and rejects unauthenticated calls.
+- **Integration (against local Supabase):**
+  - Seed two users, one shared moodle_file row, both users have `user_file_imports` for it. Both users' `match_embeddings` calls return the row.
+  - Delete user B's import row. User B's `match_embeddings` no longer returns it. User A still does.
+  - Verify the backfill `UPDATE` repoints existing rows without violating the `UNIQUE` constraint.
+- **E2E (Playwright):** two-user scenario per the original symptom. Logged in as A, import file, ask AI — answer cites the file. Logged in as B (same Moodle source), import the same file via the course page, ask AI — answer cites the file. Then delete from B's notebook, ask AI — no longer cited; A still works.
+- **Manual:** clickable citation opens the file in a new tab via signed URL.
+- **TEST_REGISTRY:** add the two-user RAG visibility scenario and the delete-from-notebook scenario to `e2e/TEST_REGISTRY.md`.
+
+## 9. Out of scope follow-ups
+
+- Bulk-select delete on the course page.
+- "Restore from removed" UI if we later want to reverse `removed_from_moodle` rows.
+- NotebookLM-style personal uploads at course scope — likely a small extension of `course_materials` with no model changes.

--- a/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
+++ b/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
@@ -16,14 +16,14 @@ The shared `moodle_files` registry is one row per file even when many users sync
 2. User B imports F → `indexContent` runs → content-hash matches (same file bytes) → **skipped**. No rows for B's Typenote course exist.
 3. User B's chat queries `match_embeddings` with `match_course_id = B's Typenote course` → zero rows match → AI replies "no materials".
 
-If step 2 *had* re-indexed instead of skipping (e.g. a content change), `upsertEmbeddings` deletes by `source_id` alone — so A's rows would be wiped and replaced with B's.
+If step 2 _had_ re-indexed instead of skipping (e.g. a content change), `upsertEmbeddings` deletes by `source_id` alone — so A's rows would be wiped and replaced with B's.
 
-Reported symptom: *"for one user (maybe the one who uploaded the files) chat has access to material and for other it doesn't."* This is consistent with the bug.
+Reported symptom: _"for one user (maybe the one who uploaded the files) chat has access to material and for other it doesn't."_ This is consistent with the bug.
 
 ## 2. Goals
 
 1. **One canonical set of embeddings per Moodle file.** Storage and embedding compute cost both stay at O(1) per file regardless of how many users sync.
-2. **Per-user access** to those embeddings is derived from `user_file_imports` — *"if you have it in your materials list, the AI can see it."*
+2. **Per-user access** to those embeddings is derived from `user_file_imports` — _"if you have it in your materials list, the AI can see it."_
 3. **Delete-from-notebook** for Moodle files: removes only the caller's `user_file_imports` row. The shared storage object and the shared embedding stay alive for other users.
 4. **Forward-compatible** with two near-term features:
    - personal user-uploaded files indexed like NotebookLM (each user's own files indexed into their own course),
@@ -39,12 +39,12 @@ Reported symptom: *"for one user (maybe the one who uploaded the files) chat has
 
 ### `content_embeddings`
 
-| Column | `moodle_file` rows (today) | `moodle_file` rows (after fix) | `course_material` rows |
-| --- | --- | --- | --- |
-| `user_id` | `NULL` (shared) | `NULL` (unchanged) | `<uploader>` (unchanged) |
-| `course_id` | `<first-indexer's Typenote course>` (buggy) | `moodle_sections.course_id` (= `moodle_courses.id`, the Typenote-side UUID PK of the upstream Moodle course; canonical, one-per-file) | `<uploader's Typenote course>` (unchanged) |
-| `week_id` | `NULL` typically | `NULL` (unchanged) | `<material's week>` (unchanged) |
-| `UNIQUE (source_type, source_id, segment_index)` | enforced | **unchanged** — one row per file segment globally | unchanged |
+| Column                                           | `moodle_file` rows (today)                  | `moodle_file` rows (after fix)                                                                                                        | `course_material` rows                     |
+| ------------------------------------------------ | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `user_id`                                        | `NULL` (shared)                             | `NULL` (unchanged)                                                                                                                    | `<uploader>` (unchanged)                   |
+| `course_id`                                      | `<first-indexer's Typenote course>` (buggy) | `moodle_sections.course_id` (= `moodle_courses.id`, the Typenote-side UUID PK of the upstream Moodle course; canonical, one-per-file) | `<uploader's Typenote course>` (unchanged) |
+| `week_id`                                        | `NULL` typically                            | `NULL` (unchanged)                                                                                                                    | `<material's week>` (unchanged)            |
+| `UNIQUE (source_type, source_id, segment_index)` | enforced                                    | **unchanged** — one row per file segment globally                                                                                     | unchanged                                  |
 
 Key insight: a Moodle file belongs to exactly one upstream Moodle course (reached in our schema via `moodle_files.section_id → moodle_sections.course_id → moodle_courses.id`). That's its canonical home and never changes. Different users mirror that course into different Typenote courses, but the file's home in the registry is invariant. So `moodle_courses.id` (referred to throughout this doc as the "moodle_course_id" — which is also how `user_course_syncs.moodle_course_id` is named, distinct from the upstream text identifier `moodle_courses.moodle_course_id`) is the right key for the embedding row.
 
@@ -52,7 +52,7 @@ Key insight: a Moodle file belongs to exactly one upstream Moodle course (reache
 
 No schema change. Hard-delete the row when the user removes a file from their notebook.
 
-The existing `status` enum (`'imported'`, `'removed_from_moodle'`) stays. `'removed_from_moodle'` continues to mean *"upstream removed this; we preserved an audit row"* and is already excluded from the import-list filter in §5.2, so those rows correctly produce no RAG hits. If upstream later re-adds a file, the existing moodle-sync flow flips the status back to `'imported'` (via `recordUserFileImport`) on the user's next sync — no spec change needed.
+The existing `status` enum (`'imported'`, `'removed_from_moodle'`) stays. `'removed_from_moodle'` continues to mean _"upstream removed this; we preserved an audit row"_ and is already excluded from the import-list filter in §5.2, so those rows correctly produce no RAG hits. If upstream later re-adds a file, the existing moodle-sync flow flips the status back to `'imported'` (via `recordUserFileImport`) on the user's next sync — no spec change needed.
 
 User-initiated delete is just a `DELETE`, which is simpler and lossless (the user can re-import to re-create).
 
@@ -61,6 +61,7 @@ User-initiated delete is just a `DELETE`, which is simpler and lossless (the use
 ### 5.1 `src/lib/actions/ai-context.ts` — `indexContent`
 
 For `source.type === 'moodle_file'`:
+
 - Select `storage_path, file_name, mime_type, section_id` from `moodle_files`, then resolve `section_id → moodle_sections.course_id`. (Alternatively: a single query with an inner-join via Supabase's `.select('storage_path, file_name, mime_type, moodle_sections!inner(course_id)')`.)
 - Use the resolved `moodle_sections.course_id` (the `moodle_courses.id` of the file's upstream course) as the `courseId` variable for the embedding rows. **Ignore** `source.courseId` (the caller's Typenote course id) for the embedding row.
 - The content-hash gate is now stable: any user importing file F looks up the row by `(source_type, source_id)` — the existing `(source_type, source_id, segment_index)` UNIQUE ensures there is only one row, with the canonical `course_id` — sees the existing hash, and short-circuits. No wasted re-embedding.
@@ -111,10 +112,15 @@ Signature extends with two optional params; both default null:
 
 ```ts
 matchEmbeddings({
-  queryEmbedding, userId,
-  courseId, moodleCourseId, importedMoodleFileIds,
-  weekId, matchCount, similarityThreshold,
-})
+  queryEmbedding,
+  userId,
+  courseId,
+  moodleCourseId,
+  importedMoodleFileIds,
+  weekId,
+  matchCount,
+  similarityThreshold,
+});
 ```
 
 ### 5.4 `supabase/migrations/20260522123000_per_user_material_access.sql`
@@ -239,7 +245,9 @@ For `course_materials`, the existing delete flow stays — same UX, different ac
 The AI's source array currently looks like:
 
 ```ts
-{ sourceType, sourceName, weekId, pageRange }
+{
+  (sourceType, sourceName, weekId, pageRange);
+}
 ```
 
 To make citations linkable:
@@ -265,12 +273,12 @@ The SSE event `{ type: 'sources', sources: [...] }` payload gains the optional `
 
 ## 6.1 Edge-case behavior of the new RPC
 
-| Caller state | `match_course_id` | `match_moodle_course_id` | `match_imported_moodle_file_ids` | Result for moodle_file rows |
-| --- | --- | --- | --- | --- |
-| Course is Moodle-synced, user has imports | typenote uuid | moodle uuid | non-empty `uuid[]` | matched iff in the imported set |
-| Course is Moodle-synced, user has no imports yet | typenote uuid | moodle uuid | `[]` | none (correct — nothing in notebook) |
-| Course is not Moodle-synced | typenote uuid | `NULL` | `NULL` | none (no moodle branch fires). `course_material` rows still match via `match_course_id`. |
-| Caller passes `NULL` for imported list explicitly | typenote uuid | moodle uuid | `NULL` | all moodle files in that Moodle course (today's permissive behavior) |
+| Caller state                                      | `match_course_id` | `match_moodle_course_id` | `match_imported_moodle_file_ids` | Result for moodle_file rows                                                              |
+| ------------------------------------------------- | ----------------- | ------------------------ | -------------------------------- | ---------------------------------------------------------------------------------------- |
+| Course is Moodle-synced, user has imports         | typenote uuid     | moodle uuid              | non-empty `uuid[]`               | matched iff in the imported set                                                          |
+| Course is Moodle-synced, user has no imports yet  | typenote uuid     | moodle uuid              | `[]`                             | none (correct — nothing in notebook)                                                     |
+| Course is not Moodle-synced                       | typenote uuid     | `NULL`                   | `NULL`                           | none (no moodle branch fires). `course_material` rows still match via `match_course_id`. |
+| Caller passes `NULL` for imported list explicitly | typenote uuid     | moodle uuid              | `NULL`                           | all moodle files in that Moodle course (today's permissive behavior)                     |
 
 We deliberately treat `NULL` as "no filter" so the RPC remains usable for admin/diagnostic queries without changing its semantics from the caller side. `searchContext` always passes a concrete array (possibly empty); it never passes `NULL` for `match_imported_moodle_file_ids` when `match_moodle_course_id` is set.
 

--- a/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
+++ b/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
@@ -71,12 +71,15 @@ For `source.type === 'course_material'`: unchanged.
 
 Add a "resolve user's view" pre-step:
 
+Use the regular (RLS-scoped) client — both `user_course_syncs` and `user_file_imports` have SELECT policies of `auth.uid() = user_id`, so the regular client naturally restricts results to the caller. No admin client needed.
+
 ```ts
-// 1. Resolve Typenote course → upstream Moodle course (if synced)
-const { data: sync } = await admin
+const supabase = await createClient();
+
+// 1. Resolve Typenote course → moodle_courses.id (if synced)
+const { data: sync } = await supabase
   .from('user_course_syncs')
   .select('moodle_course_id')
-  .eq('user_id', userId)
   .eq('course_id', params.courseId)
   .maybeSingle();
 const moodleCourseId = sync?.moodle_course_id ?? null;
@@ -84,10 +87,9 @@ const moodleCourseId = sync?.moodle_course_id ?? null;
 // 2. Fetch the set of moodle files the user has imported
 let importedMoodleFileIds: string[] | null = null;
 if (moodleCourseId) {
-  const { data: imports } = await admin
+  const { data: imports } = await supabase
     .from('user_file_imports')
     .select('moodle_file_id')
-    .eq('user_id', userId)
     .eq('status', 'imported');
   importedMoodleFileIds = (imports ?? []).map((i) => i.moodle_file_id);
 }
@@ -201,12 +203,18 @@ $$;
 
 ```ts
 'use server';
-export async function removeMoodleFileFromNotebook(moodleFileId: string) {
+export async function removeMoodleFileFromNotebook(
+  moodleFileId: string,
+  courseId: string,
+) {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) throw new Error('Unauthorized');
 
-  // RLS already enforces user_id = auth.uid(); the .eq() is belt-and-suspenders.
+  // RLS already enforces user_id = auth.uid(); the .eq() is
+  // belt-and-suspenders.
   const { error } = await supabase
     .from('user_file_imports')
     .delete()
@@ -214,15 +222,10 @@ export async function removeMoodleFileFromNotebook(moodleFileId: string) {
     .eq('user_id', user.id);
 
   if (error) throw new Error(error.message);
-  // Codebase convention is literal-path revalidation (see
-  // src/lib/actions/documents.ts:152). The caller passes courseId from
-  // the page so we don't have to derive it.
-}
 
-export async function removeMoodleFileFromNotebook(
-  moodleFileId: string,
-  courseId: string,
-) { /* ... as above; then: */
+  // Codebase convention is literal-path revalidation
+  // (src/lib/actions/documents.ts:152). The caller passes courseId
+  // from the page so we don't derive it here.
   revalidatePath('/dashboard/courses/' + courseId);
 }
 ```
@@ -274,7 +277,7 @@ We deliberately treat `NULL` as "no filter" so the RPC remains usable for admin/
 ## 7. Risk + rollback
 
 - Risk: a user whose `user_course_syncs` row is missing (edge case — they imported files but the sync row got cleaned up) would not be able to see their moodle files in chat because `moodle_course_id` resolves to null. Mitigation: defensive null-check in `searchContext`; we can fall back to "no moodle results" cleanly, never to "leak other users' data".
-- Rollback: revert the migration commit + re-deploy. The old RPC signature is preserved in `00012_create_content_embeddings.sql` history; resurrecting it is a small inverse migration.
+- Rollback: revert the migration commit **and** the TS caller change in `src/lib/queries/embeddings.ts` (`matchEmbeddings` signature gains two params, all callers must revert in lockstep with the RPC). The old RPC signature is preserved in `00014_match_embeddings_return_text.sql` history; resurrecting it is a small inverse migration.
 
 ## 8. Test plan
 

--- a/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
+++ b/docs/superpowers/specs/2026-05-22-per-user-material-access-design.md
@@ -42,26 +42,28 @@ Reported symptom: *"for one user (maybe the one who uploaded the files) chat has
 | Column | `moodle_file` rows (today) | `moodle_file` rows (after fix) | `course_material` rows |
 | --- | --- | --- | --- |
 | `user_id` | `NULL` (shared) | `NULL` (unchanged) | `<uploader>` (unchanged) |
-| `course_id` | `<first-indexer's Typenote course>` (buggy) | `<moodle_files.course_id>` = upstream Moodle course id (canonical) | `<uploader's Typenote course>` (unchanged) |
+| `course_id` | `<first-indexer's Typenote course>` (buggy) | `moodle_sections.course_id` (= `moodle_courses.id`, the Typenote-side UUID PK of the upstream Moodle course; canonical, one-per-file) | `<uploader's Typenote course>` (unchanged) |
 | `week_id` | `NULL` typically | `NULL` (unchanged) | `<material's week>` (unchanged) |
 | `UNIQUE (source_type, source_id, segment_index)` | enforced | **unchanged** — one row per file segment globally | unchanged |
 
-Key insight: a Moodle file belongs to exactly one upstream Moodle course. That's its canonical home and never changes. Different users mirror that course into different Typenote courses, but the file's home in the upstream registry is invariant. So `moodle_course_id` is the right key for the embedding row.
+Key insight: a Moodle file belongs to exactly one upstream Moodle course (reached in our schema via `moodle_files.section_id → moodle_sections.course_id → moodle_courses.id`). That's its canonical home and never changes. Different users mirror that course into different Typenote courses, but the file's home in the registry is invariant. So `moodle_courses.id` (referred to throughout this doc as the "moodle_course_id" — which is also how `user_course_syncs.moodle_course_id` is named, distinct from the upstream text identifier `moodle_courses.moodle_course_id`) is the right key for the embedding row.
 
 ### `user_file_imports`
 
 No schema change. Hard-delete the row when the user removes a file from their notebook.
 
-The existing `status` enum (`'imported'`, `'removed_from_moodle'`) stays. `'removed_from_moodle'` continues to mean *"upstream removed this; we preserved an audit row"*. User-initiated delete is just a `DELETE`, which is simpler and lossless (the user can re-import to re-create).
+The existing `status` enum (`'imported'`, `'removed_from_moodle'`) stays. `'removed_from_moodle'` continues to mean *"upstream removed this; we preserved an audit row"* and is already excluded from the import-list filter in §5.2, so those rows correctly produce no RAG hits. If upstream later re-adds a file, the existing moodle-sync flow flips the status back to `'imported'` (via `recordUserFileImport`) on the user's next sync — no spec change needed.
+
+User-initiated delete is just a `DELETE`, which is simpler and lossless (the user can re-import to re-create).
 
 ## 5. Code changes
 
 ### 5.1 `src/lib/actions/ai-context.ts` — `indexContent`
 
 For `source.type === 'moodle_file'`:
-- Select `course_id` from `moodle_files` along with `storage_path`, `file_name`, `mime_type`.
-- Use `fileRow.course_id` (the upstream Moodle course id) as the `courseId` variable for the embedding rows. **Ignore** `source.courseId` (the caller's Typenote course id) for the embedding row.
-- The content-hash gate is now stable: any user importing file F looks up the row with `course_id = mf.course_id`, sees the existing hash, and short-circuits. No wasted re-embedding.
+- Select `storage_path, file_name, mime_type, section_id` from `moodle_files`, then resolve `section_id → moodle_sections.course_id`. (Alternatively: a single query with an inner-join via Supabase's `.select('storage_path, file_name, mime_type, moodle_sections!inner(course_id)')`.)
+- Use the resolved `moodle_sections.course_id` (the `moodle_courses.id` of the file's upstream course) as the `courseId` variable for the embedding rows. **Ignore** `source.courseId` (the caller's Typenote course id) for the embedding row.
+- The content-hash gate is now stable: any user importing file F looks up the row by `(source_type, source_id)` — the existing `(source_type, source_id, segment_index)` UNIQUE ensures there is only one row, with the canonical `course_id` — sees the existing hash, and short-circuits. No wasted re-embedding.
 
 For `source.type === 'course_material'`: unchanged.
 
@@ -117,20 +119,30 @@ matchEmbeddings({
 
 ```sql
 -- Step A: Backfill — repoint moodle_file embeddings to the canonical
--- Moodle course id (today they point at the first-indexer's Typenote
+-- moodle_courses.id (today they point at the first-indexer's Typenote
 -- course id, which causes the access bug for every later user).
+-- moodle_files has no course_id — we reach the course through
+-- moodle_sections.
 UPDATE public.content_embeddings ce
-SET course_id = mf.course_id
+SET course_id = ms.course_id
 FROM public.moodle_files mf
+JOIN public.moodle_sections ms ON ms.id = mf.section_id
 WHERE ce.source_type = 'moodle_file'
   AND ce.source_id = mf.id
-  AND ce.course_id IS DISTINCT FROM mf.course_id;
+  AND ce.course_id IS DISTINCT FROM ms.course_id;
 
--- Step B: Replace match_embeddings RPC with the new signature.
+-- Step B: Replace match_embeddings RPC. The 00014 migration registered
+-- the function with bare `vector` (not `extensions.vector`); we drop
+-- using the exact form it was created with to avoid leaving the old
+-- function alongside the new one.
 DROP FUNCTION IF EXISTS public.match_embeddings(
-  extensions.vector, uuid, uuid, uuid, integer, double precision
+  vector, uuid, uuid, uuid, integer, double precision
 );
 
+-- LANGUAGE sql STABLE matches the original 00012 declaration (00014
+-- accidentally regressed to plpgsql). STABLE lets the planner cache
+-- function results within a single query, which matters because RAG
+-- hits this RPC on every chat turn.
 CREATE OR REPLACE FUNCTION public.match_embeddings(
   query_embedding extensions.vector(1536),
   match_user_id uuid,
@@ -154,10 +166,8 @@ RETURNS TABLE (
   mime_type text,
   similarity float
 )
-LANGUAGE plpgsql
+LANGUAGE sql STABLE
 AS $$
-BEGIN
-  RETURN QUERY
   SELECT
     ce.id, ce.source_type, ce.source_id, ce.source_name, ce.segment_text,
     ce.page_start, ce.page_end, ce.course_id, ce.week_id, ce.mime_type,
@@ -170,7 +180,7 @@ BEGIN
         AND match_course_id IS NOT NULL
         AND ce.course_id = match_course_id)
       OR
-      -- moodle_file: keyed by upstream Moodle course_id; access is
+      -- moodle_file: keyed by moodle_courses.id (canonical); access is
       -- whitelisted by the user's imported file set
       (ce.source_type = 'moodle_file'
         AND match_moodle_course_id IS NOT NULL
@@ -182,7 +192,6 @@ BEGIN
     AND 1 - (ce.embedding <=> query_embedding) > similarity_threshold
   ORDER BY ce.embedding <=> query_embedding
   LIMIT match_count;
-END;
 $$;
 ```
 
@@ -205,7 +214,16 @@ export async function removeMoodleFileFromNotebook(moodleFileId: string) {
     .eq('user_id', user.id);
 
   if (error) throw new Error(error.message);
-  revalidatePath('/dashboard/courses/[courseId]', 'page');
+  // Codebase convention is literal-path revalidation (see
+  // src/lib/actions/documents.ts:152). The caller passes courseId from
+  // the page so we don't have to derive it.
+}
+
+export async function removeMoodleFileFromNotebook(
+  moodleFileId: string,
+  courseId: string,
+) { /* ... as above; then: */
+  revalidatePath('/dashboard/courses/' + courseId);
 }
 ```
 
@@ -234,6 +252,8 @@ Two batched DB queries + N parallel signed-URL generations adds well under 500 m
 
 The SSE event `{ type: 'sources', sources: [...] }` payload gains the optional `signedUrl` field — backward compatible (older clients ignore unknown fields).
 
+**Known wart:** signed URLs live for 1 hour. If a user deletes a file from their notebook after the AI cites it, the existing chat message's link will still resolve until expiry. Acceptable for v1 — the file isn't gone, the user just removed their personal access record; the signed URL is a direct storage handle that doesn't go through `user_file_imports`.
+
 ## 6. Backwards compatibility
 
 - Existing embedding rows: the migration's `UPDATE` repoints them to `moodle_course_id` in-place. No row deletions, no embedding API calls.
@@ -246,7 +266,7 @@ The SSE event `{ type: 'sources', sources: [...] }` payload gains the optional `
 | --- | --- | --- | --- | --- |
 | Course is Moodle-synced, user has imports | typenote uuid | moodle uuid | non-empty `uuid[]` | matched iff in the imported set |
 | Course is Moodle-synced, user has no imports yet | typenote uuid | moodle uuid | `[]` | none (correct — nothing in notebook) |
-| Course is not Moodle-synced | typenote uuid | `NULL` | `NULL` | none (no moodle branch) |
+| Course is not Moodle-synced | typenote uuid | `NULL` | `NULL` | none (no moodle branch fires). `course_material` rows still match via `match_course_id`. |
 | Caller passes `NULL` for imported list explicitly | typenote uuid | moodle uuid | `NULL` | all moodle files in that Moodle course (today's permissive behavior) |
 
 We deliberately treat `NULL` as "no filter" so the RPC remains usable for admin/diagnostic queries without changing its semantics from the caller side. `searchContext` always passes a concrete array (possibly empty); it never passes `NULL` for `match_imported_moodle_file_ids` when `match_moodle_course_id` is set.
@@ -265,7 +285,10 @@ We deliberately treat `NULL` as "no filter" so the RPC remains usable for admin/
 - **Integration (against local Supabase):**
   - Seed two users, one shared moodle_file row, both users have `user_file_imports` for it. Both users' `match_embeddings` calls return the row.
   - Delete user B's import row. User B's `match_embeddings` no longer returns it. User A still does.
+  - User has `user_course_syncs` but **zero imports** → `match_embeddings` returns no moodle_file rows (even though the embeddings exist).
+  - Course with no Moodle sync but with `course_material` uploads → `match_embeddings` still returns the course_material rows via `match_course_id`.
   - Verify the backfill `UPDATE` repoints existing rows without violating the `UNIQUE` constraint.
+  - Orphan-row resilience: an embedding row whose `moodle_files` parent was hard-deleted upstream remains in the table with a stale `course_id`. The backfill `UPDATE` simply skips it (no row in `mf`). Verify it doesn't break the migration; verify that orphaned moodle_file embeddings are eventually cleaned by `deleteEmbeddingsBySource` when the upstream sync flags the file removed (existing behavior — sanity-check it still runs).
 - **E2E (Playwright):** two-user scenario per the original symptom. Logged in as A, import file, ask AI — answer cites the file. Logged in as B (same Moodle source), import the same file via the course page, ask AI — answer cites the file. Then delete from B's notebook, ask AI — no longer cited; A still works.
 - **Manual:** clickable citation opens the file in a new tab via signed URL.
 - **TEST_REGISTRY:** add the two-user RAG visibility scenario and the delete-from-notebook scenario to `e2e/TEST_REGISTRY.md`.

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -130,6 +130,13 @@ Follow-up to issue #118. Guards against cursor jumps when a multi-page overflow 
 
 ---
 
+### AI chat — per-user material access (`e2e/ai-chat-per-user-materials.spec.ts`) — PLANNED
+
+- [ ] user sees materials they imported in chat — ⚠️ SKIPPED IN CI (needs AI API key)
+- [ ] removing a file from notebook hides it from chat — ⚠️ SKIPPED IN CI (needs AI API key)
+
+---
+
 ## PDF Export — IMPLEMENTED
 
 - [x] Export as PDF option in dashboard context menu (`e2e/export-pdf-dashboard.spec.ts`)
@@ -236,6 +243,7 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 | Courses               | Implemented | `e2e/courses.spec.ts`               | 5/6       |
 | File Upload           | Implemented | `e2e/file-upload.spec.ts`           | 3/4       |
 | AI Chat               | Implemented | `e2e/ai-chat.spec.ts`               | 6/6       |
+| AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2  |
 | PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`          | 6/7       |
 | Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`         | 3/3       |
 | Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`    | 8/8       |
@@ -243,7 +251,7 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 | Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`        | 3/3       |
 | Version History       | Planned     | `e2e/version-history.spec.ts`       | 0/5       |
 | PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts` | 8/8       |
-| **Total**             |             |                                     | **88/94** |
+| **Total**             |             |                                     | **88/96** |
 
 ---
 

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -210,6 +210,14 @@ context-menu entry point works end-to-end.
 
 ---
 
+## Security — API Auth Boundary (`e2e/security-api-auth.spec.ts`) — IMPLEMENTED
+
+- [x] Unauthenticated POST to protected routes (`/api/ai/ask`, `/api/ai/latex`, `/api/ai/search`, `/api/ai/reindex`) returns 401/400/405 (never reaches DB/AI)
+- [x] Unauthenticated GET to protected routes (`/api/ai/quota`, `/api/ai/conversations`) returns 401/400/405
+- [x] Unauthenticated POST with malformed/empty body returns <500 (no crash path reachable without auth)
+
+---
+
 ## Summary
 
 | Feature               | Status      | Spec File                           | Tests     |

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -233,25 +233,25 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 
 ## Summary
 
-| Feature               | Status      | Spec File                           | Tests     |
-| --------------------- | ----------- | ----------------------------------- | --------- |
-| Auth                  | Implemented | `e2e/auth.spec.ts`                  | 7/7       |
-| Documents             | Implemented | `e2e/documents.spec.ts`             | 6/6       |
-| Canvas Editor         | Implemented | `e2e/canvas-editor.spec.ts`         | 15/15     |
-| Text Editor Toolbar   | Implemented | `e2e/editor-toolbar.spec.ts`        | 12/12     |
-| LaTeX Math            | Implemented | `e2e/latex-math.spec.ts`            | 5/5       |
-| Courses               | Implemented | `e2e/courses.spec.ts`               | 5/6       |
-| File Upload           | Implemented | `e2e/file-upload.spec.ts`           | 3/4       |
-| AI Chat               | Implemented | `e2e/ai-chat.spec.ts`               | 6/6       |
-| AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2  |
-| PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`          | 6/7       |
-| Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`         | 3/3       |
-| Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`    | 8/8       |
-| Moodle Ext Gating     | Implemented | `e2e/moodle-touch-gating.spec.ts`   | 2/2       |
-| Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`        | 3/3       |
-| Version History       | Planned     | `e2e/version-history.spec.ts`       | 0/5       |
-| PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts` | 8/8       |
-| **Total**             |             |                                     | **88/96** |
+| Feature               | Status      | Spec File                                | Tests     |
+| --------------------- | ----------- | ---------------------------------------- | --------- |
+| Auth                  | Implemented | `e2e/auth.spec.ts`                       | 7/7       |
+| Documents             | Implemented | `e2e/documents.spec.ts`                  | 6/6       |
+| Canvas Editor         | Implemented | `e2e/canvas-editor.spec.ts`              | 15/15     |
+| Text Editor Toolbar   | Implemented | `e2e/editor-toolbar.spec.ts`             | 12/12     |
+| LaTeX Math            | Implemented | `e2e/latex-math.spec.ts`                 | 5/5       |
+| Courses               | Implemented | `e2e/courses.spec.ts`                    | 5/6       |
+| File Upload           | Implemented | `e2e/file-upload.spec.ts`                | 3/4       |
+| AI Chat               | Implemented | `e2e/ai-chat.spec.ts`                    | 6/6       |
+| AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2       |
+| PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`               | 6/7       |
+| Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`              | 3/3       |
+| Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`         | 8/8       |
+| Moodle Ext Gating     | Implemented | `e2e/moodle-touch-gating.spec.ts`        | 2/2       |
+| Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`             | 3/3       |
+| Version History       | Planned     | `e2e/version-history.spec.ts`            | 0/5       |
+| PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts`      | 8/8       |
+| **Total**             |             |                                          | **88/96** |
 
 ---
 

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -218,6 +218,12 @@ context-menu entry point works end-to-end.
 
 ---
 
+## Security — Storage RLS (integration test, not E2E)
+
+Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verifies path-prefix RLS on the `personal-files` Storage bucket: list/download/upload/delete attempts on a path NOT owned by the calling user are rejected.
+
+---
+
 ## Summary
 
 | Feature               | Status      | Spec File                           | Tests     |

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -188,6 +188,28 @@ context-menu entry point works end-to-end.
 
 ---
 
+## Security — XSS (`e2e/security-xss.spec.ts`) — IMPLEMENTED
+
+- [x] XSS payload in document title renders as text on the dashboard and does not execute
+- [x] XSS payload in document title renders as text in the editor header and does not execute
+
+---
+
+## Security — Prompt Injection (`e2e/security-prompt-injection.spec.ts`) — IMPLEMENTED
+
+- [x] AI response containing `<script>` / `<img onerror>` / `<svg onload>` renders as text and does NOT execute
+- [x] Markdown link with `javascript:` URL in AI response is sanitized — no click execution
+
+---
+
+## Security — File Upload Validation (`e2e/security-file-upload.spec.ts`) — IMPLEMENTED
+
+- [x] Non-PDF file rejected by MIME type — inline error visible, no success toast
+- [x] File >50MB rejected — inline error visible, no success toast
+- [x] Double-extension file (`report.pdf.exe`) rejected by MIME type, not just extension
+
+---
+
 ## Summary
 
 | Feature               | Status      | Spec File                           | Tests     |

--- a/e2e/ai-chat-per-user-materials.spec.ts
+++ b/e2e/ai-chat-per-user-materials.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { login } from './helpers/auth';
+import { goToSeededCourse } from './helpers/navigate';
+
+/**
+ * AI chat — per-user material access
+ *
+ * These tests verify that:
+ *   1. A user can see source citations for files they have imported into their
+ *      course notebook when they ask the AI a question.
+ *   2. After removing a file from the notebook, that file no longer appears as
+ *      a citation in subsequent AI responses.
+ *
+ * Both tests use the single seeded user (test@typenote.dev / Test1234).
+ * A true two-user isolation test would require a second seeded user — that is
+ * out of scope here and noted as a follow-up in TEST_REGISTRY.md.
+ *
+ * These tests are skipped in CI because they require:
+ *   - A live AI API key (GOOGLE_AI_API_KEY)
+ *   - A course page that renders correctly in the CI environment
+ */
+
+// Seeded course — matches `goToSeededCourse` in helpers/navigate.ts
+const TEST_QUESTION = 'What topics are covered in the course materials?';
+
+test.describe('AI chat — per-user material access', () => {
+  test.skip(
+    !!process.env.CI,
+    'Per-user AI chat tests need a real AI API key and stable course page; skipped in CI',
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToSeededCourse(page);
+  });
+
+  test('user sees materials they imported in chat', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    // Open AI chat panel
+    const aiButton = page.getByRole('button', { name: /AI|Ask AI|Tutor/i });
+    await expect(aiButton.first()).toBeVisible({ timeout: 10_000 });
+    await aiButton.first().click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    // Send a question that should draw on uploaded course materials
+    const input = page.locator(
+      'input[placeholder*="Ask about your course materials"]',
+    );
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill(TEST_QUESTION);
+    await page.keyboard.press('Enter');
+
+    // Wait for a response to appear — the AI response bubble
+    await expect(page.locator('div.bg-muted.rounded-2xl').first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // At least one source citation link referencing an uploaded file should
+    // be visible (PDF, DOCX, or PPTX attachment).
+    await expect(
+      page.getByRole('link', { name: /\.pdf|\.docx|\.pptx/i }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test('removing a file from notebook hides it from chat', async ({ page }) => {
+    test.setTimeout(90_000);
+
+    // Locate the first Moodle / personal file row visible on the course page.
+    // The data-moodle-file-row attribute is set on each file-list row.
+    const fileRow = page.locator('[data-moodle-file-row]').first();
+
+    // If no file rows are visible the test cannot proceed — skip gracefully.
+    const rowVisible = await fileRow
+      .isVisible({ timeout: 10_000 })
+      .catch(() => false);
+    if (!rowVisible) {
+      test.skip(true, 'No file rows with [data-moodle-file-row] visible — seed data may be missing');
+    }
+
+    // Capture the display name of the first file so we can check it disappears.
+    const fileName = await fileRow.locator('span.flex-1').innerText();
+
+    // Accept any browser confirmation dialog (some delete flows use window.confirm).
+    page.once('dialog', (d) => d.accept());
+
+    // Click the remove-from-notebook button on the row.
+    // The button label matches the remove/delete action rendered in the UI.
+    await fileRow
+      .getByRole('button', { name: /Remove|Delete/i })
+      .first()
+      .click();
+
+    // The file row should disappear from the page.
+    await expect(page.getByText(fileName, { exact: true })).toHaveCount(0, {
+      timeout: 10_000,
+    });
+
+    // Now open AI chat and ask a question.
+    const aiButton = page.getByRole('button', { name: /AI|Ask AI|Tutor/i });
+    await expect(aiButton.first()).toBeVisible({ timeout: 10_000 });
+    await aiButton.first().click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    const input = page.locator(
+      'input[placeholder*="Ask about your course materials"]',
+    );
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill(TEST_QUESTION);
+    await page.keyboard.press('Enter');
+
+    // Wait for the AI response to appear.
+    await expect(page.locator('div.bg-muted.rounded-2xl').first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The deleted file must NOT appear in any source citation in the response.
+    const chatPanel = page.locator('[data-chat-panel]').or(
+      page.locator('div').filter({ hasText: 'AI Tutor' }).last(),
+    );
+    await expect(chatPanel.getByText(fileName)).toHaveCount(0, {
+      timeout: 5_000,
+    });
+  });
+});

--- a/e2e/ai-chat-per-user-materials.spec.ts
+++ b/e2e/ai-chat-per-user-materials.spec.ts
@@ -75,7 +75,10 @@ test.describe('AI chat — per-user material access', () => {
       .isVisible({ timeout: 10_000 })
       .catch(() => false);
     if (!rowVisible) {
-      test.skip(true, 'No file rows with [data-moodle-file-row] visible — seed data may be missing');
+      test.skip(
+        true,
+        'No file rows with [data-moodle-file-row] visible — seed data may be missing',
+      );
     }
 
     // Capture the display name of the first file so we can check it disappears.
@@ -115,9 +118,9 @@ test.describe('AI chat — per-user material access', () => {
     });
 
     // The deleted file must NOT appear in any source citation in the response.
-    const chatPanel = page.locator('[data-chat-panel]').or(
-      page.locator('div').filter({ hasText: 'AI Tutor' }).last(),
-    );
+    const chatPanel = page
+      .locator('[data-chat-panel]')
+      .or(page.locator('div').filter({ hasText: 'AI Tutor' }).last());
     await expect(chatPanel.getByText(fileName)).toHaveCount(0, {
       timeout: 5_000,
     });

--- a/e2e/file-upload.spec.ts
+++ b/e2e/file-upload.spec.ts
@@ -96,6 +96,10 @@ test.describe('File Upload', () => {
     await expect(fileRow).toBeVisible({ timeout: 10_000 });
     await fileRow.hover();
 
+    // Delete uses window.confirm — Playwright dismisses dialogs by
+    // default, so opt into accepting this one before triggering it.
+    page.once('dialog', (d) => d.accept());
+
     // Click the delete button (trash icon, appears on hover)
     const deleteButton = fileRow.locator('button').last();
     await deleteButton.click();

--- a/e2e/file-upload.spec.ts
+++ b/e2e/file-upload.spec.ts
@@ -87,26 +87,30 @@ test.describe('File Upload', () => {
       timeout: 15_000,
     });
 
-    // Find the file row and hover to reveal delete button
+    // Find the file row by scoping to the PersonalFileItem button that
+    // displays the file name, then walking up to its row container. Using
+    // `.locator('div').filter({ hasText }).first()` returned the whole
+    // page, so the delete-button selector grabbed the wrong button.
     const displayName = fileName.replace('.pdf', '');
-    const fileRow = page
-      .locator('div')
-      .filter({ hasText: displayName })
+    const fileNameButton = page
+      .locator('button', { hasText: displayName })
       .first();
-    await expect(fileRow).toBeVisible({ timeout: 10_000 });
+    await expect(fileNameButton).toBeVisible({ timeout: 10_000 });
+    const fileRow = fileNameButton.locator(
+      'xpath=ancestor::div[contains(@class, "group")][1]',
+    );
     await fileRow.hover();
 
     // Delete uses window.confirm — Playwright dismisses dialogs by
     // default, so opt into accepting this one before triggering it.
     page.once('dialog', (d) => d.accept());
 
-    // Click the delete button (trash icon, appears on hover)
+    // Click the trash icon (the row has two buttons: the filename button
+    // and the trash button, which is rendered last).
     const deleteButton = fileRow.locator('button').last();
     await deleteButton.click();
 
-    // File should disappear
-    await expect(
-      page.locator('button', { hasText: displayName }),
-    ).not.toBeVisible({ timeout: 10_000 });
+    // The filename button for this file should disappear from the page.
+    await expect(fileNameButton).not.toBeVisible({ timeout: 10_000 });
   });
 });

--- a/e2e/security-api-auth.spec.ts
+++ b/e2e/security-api-auth.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Security: API auth-boundary tests.
+ *
+ * Every authenticated API route in this app must return 401 when the
+ * caller does not have a valid Supabase session cookie. A single
+ * forgotten `getUser()` check on a new route would let any anonymous
+ * request hit downstream resources (DB, AI provider, storage).
+ *
+ * These tests use a request context with NO storageState (no cookies),
+ * so they exercise the "unauthenticated" branch deterministically.
+ */
+import { test, expect, request } from '@playwright/test';
+
+const PROTECTED_POST_ROUTES = [
+  { path: '/api/ai/ask', body: { question: 'hi', mode: 'quick' } },
+  { path: '/api/ai/latex', body: { text: 'x^2' } },
+  { path: '/api/ai/search', body: { query: 'derivative', courseId: 'x' } },
+  { path: '/api/ai/reindex', body: { materialId: 'x' } },
+];
+
+const PROTECTED_GET_ROUTES = [
+  '/api/ai/quota',
+  '/api/ai/conversations?courseId=x',
+];
+
+test.describe('Security — API auth boundary', () => {
+  test('unauthenticated POST to protected routes returns 401', async () => {
+    // Fresh context with no cookies / storageState.
+    const ctx = await request.newContext();
+    try {
+      for (const { path, body } of PROTECTED_POST_ROUTES) {
+        const res = await ctx.post(path, {
+          data: body,
+          headers: { 'Content-Type': 'application/json' },
+        });
+        // The route handler short-circuits on missing user with 401.
+        // 400 (validator runs first), 401 (auth-rejected), or 405
+        // (route doesn't accept POST at all) all prove the request did
+        // NOT reach a model call or DB write — the security property
+        // we need. Anything 2xx/3xx or 5xx is a bug.
+        expect(
+          [400, 401, 405],
+          `${path} returned ${res.status()} (expected 400/401/405)`,
+        ).toContain(res.status());
+        if (res.status() === 401) {
+          const json = await res.json().catch(() => ({}));
+          expect(JSON.stringify(json).toLowerCase()).toMatch(/unauth/);
+        }
+      }
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('unauthenticated GET to protected routes returns 401', async () => {
+    const ctx = await request.newContext();
+    try {
+      for (const path of PROTECTED_GET_ROUTES) {
+        const res = await ctx.get(path);
+        expect(
+          [401, 400],
+          `${path} returned ${res.status()} (expected 401 or 400)`,
+        ).toContain(res.status());
+      }
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('unauthenticated POST with empty body still rejected (not 500)', async () => {
+    // A common misconfiguration: route checks auth AFTER trying to parse
+    // request body. A malformed-body unauthenticated request must NOT
+    // return 500 — that would leak server internals and indicate a
+    // crash path reachable without auth.
+    const ctx = await request.newContext();
+    try {
+      const res = await ctx.post('/api/ai/ask', {
+        data: '', // empty body — no JSON
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(res.status()).toBeLessThan(500);
+      expect([400, 401, 405]).toContain(res.status());
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});

--- a/e2e/security-file-upload.spec.ts
+++ b/e2e/security-file-upload.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Security: file-upload validation.
+ *
+ * The course-material upload pipeline validates client-side via
+ * `useFileUpload` (`src/hooks/use-file-upload.ts`) — MIME-type allowlist
+ * (PDF only by default) and a 50 MB cap. Bypassing either of these would
+ * let a user push arbitrary binaries into Supabase Storage under their
+ * own user-id prefix, where they could be served back to the browser
+ * with `application/pdf` content-type at view-time, or simply exhaust
+ * the free-tier storage quota.
+ *
+ * These tests exercise the validation at the browser level, not the
+ * hook unit. The hook unit-test (`use-file-upload.test.ts`) covers the
+ * pure validation function in isolation — but if the consuming component
+ * forgets to render the error or call `validateFile`, the unit test
+ * passes and the bug ships. This E2E test guards the wiring.
+ */
+import { test, expect } from '@playwright/test';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { login } from './helpers/auth';
+import { goToSeededCourse } from './helpers/navigate';
+
+test.describe('Security — file upload validation', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await goToSeededCourse(page);
+    await expect(page.getByRole('button', { name: 'Import File' })).toBeVisible(
+      { timeout: 15_000 },
+    );
+  });
+
+  test('rejects a non-PDF file by MIME type — error visible, no toast success', async ({
+    page,
+  }) => {
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'malicious.exe',
+      mimeType: 'application/octet-stream',
+      // Real PE-header prefix to make the file look "executable-ish".
+      // The validation runs on file.type (MIME), not on the magic bytes,
+      // so contents are irrelevant — but real-looking bytes make the
+      // test scenario closer to an actual attack attempt.
+      buffer: Buffer.from('MZ\x90\x00\x03\x00\x00\x00fake-binary'),
+    });
+
+    // The hook surfaces validation errors as toast.error(...) AND/OR an
+    // inline <p class="text-destructive">. The exact text matches the
+    // hook's `Accepted file types: ...` template. Either surface must
+    // contain that string.
+    // Error renders both inline (<p class="text-destructive">) AND as a
+    // Sonner toast. Either surface is acceptable — assert on the first
+    // match so strict-mode doesn't complain about the duplicate.
+    await expect(page.getByText(/Accepted file types:/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // No success toast should ever appear for a rejected file.
+    await expect(page.getByText('File imported')).not.toBeVisible({
+      timeout: 1_000,
+    });
+  });
+
+  test('rejects a file larger than 50 MB — error visible, no toast success', async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+
+    // Playwright's `setInputFiles({ buffer })` caps inline payloads at
+    // 50 MB. To exercise the >50 MB branch we write the bytes to disk
+    // first and pass the path. Clean up after.
+    const tmpPath = join(tmpdir(), `typenote-oversized-${Date.now()}.pdf`);
+    const oversized = Buffer.alloc(50 * 1024 * 1024 + 1, 0x20);
+    await fs.writeFile(tmpPath, oversized);
+
+    try {
+      const fileInput = page.locator('input[type="file"]').first();
+      await fileInput.setInputFiles(tmpPath);
+
+      await expect(page.getByText(/under 50MB/i).first()).toBeVisible({
+        timeout: 5_000,
+      });
+
+      await expect(page.getByText('File imported')).not.toBeVisible({
+        timeout: 1_000,
+      });
+    } finally {
+      await fs.unlink(tmpPath).catch(() => {
+        /* best-effort cleanup */
+      });
+    }
+  });
+
+  test('rejects a double-extension file whose MIME is not application/pdf', async ({
+    page,
+  }) => {
+    // Classic disguise attempt: `report.pdf.exe`. Browser sets file.type
+    // from the OS MIME mapping; on a controlled fixture we pass the MIME
+    // explicitly. The hook validates `file.type`, NOT the name, so the
+    // .pdf in the middle does not save the file.
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: 'report.pdf.exe',
+      mimeType: 'application/x-msdownload',
+      buffer: Buffer.from('MZ\x90fake'),
+    });
+
+    // Error renders both inline (<p class="text-destructive">) AND as a
+    // Sonner toast. Either surface is acceptable — assert on the first
+    // match so strict-mode doesn't complain about the duplicate.
+    await expect(page.getByText(/Accepted file types:/i).first()).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+});

--- a/e2e/security-prompt-injection.spec.ts
+++ b/e2e/security-prompt-injection.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Security: prompt-injection resistance in AI chat responses.
+ *
+ * Threat model: An LLM can be coaxed (intentionally or accidentally) into
+ * emitting raw HTML in its response — `<script>`, `<img onerror>`, etc.
+ * If the chat panel ever switches its markdown renderer to allow raw HTML
+ * (e.g. by adding `rehype-raw`), an attacker who controls course content
+ * or the user's own prior chat history could persist a payload that
+ * executes inside another session.
+ *
+ * `react-markdown` defaults to NOT rendering raw HTML, but that's a
+ * single dependency-config flip from breaking. These tests pin the
+ * behavior end-to-end.
+ *
+ * Strategy:
+ *   - Mock /api/ai/ask to stream back a deterministic SSE response
+ *     containing common HTML/JS payloads.
+ *   - Send any question through the real chat UI.
+ *   - Assert: payload text is visible as text; no dialog fires;
+ *     no sentinel global was set.
+ */
+import { test, expect, type Dialog } from '@playwright/test';
+import { login } from './helpers/auth';
+import { goToSeededCourse } from './helpers/navigate';
+
+const PAYLOADS = {
+  scriptTag: '<script>window.__pi_fired_1=true;alert(1)</script>',
+  imgOnerror: '<img src=x onerror="window.__pi_fired_2=true">',
+  svgOnload: '<svg onload="window.__pi_fired_3=true"></svg>',
+};
+
+/** Build a single SSE stream that the chat panel will parse and render. */
+function buildSseBody(text: string): string {
+  // The client splits on \n\n and parses lines starting with "data: ".
+  const event = (obj: unknown) => `data: ${JSON.stringify(obj)}\n\n`;
+  return [
+    event({ type: 'sources', sources: [], model: 'flash' }),
+    event({ type: 'text', text }),
+  ].join('');
+}
+
+test.describe('Security — prompt-injection resistance in AI chat', () => {
+  test.beforeEach(async ({ page }) => {
+    // Generous quota so the chat input isn't disabled.
+    await page.route('**/api/ai/quota**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          chat: { used: 0, limit: 1000, remaining: 1000 },
+          latex: { used: 0, limit: 1000, remaining: 1000 },
+          tier: 'beta',
+        }),
+      });
+    });
+
+    // Suppress conversation history so the chat opens empty — keeps the
+    // test deterministic regardless of any stored conversations from
+    // previous E2E runs.
+    await page.route('**/api/ai/conversations**', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ conversations: [] }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await login(page);
+    await page.goto('/dashboard');
+    await goToSeededCourse(page);
+  });
+
+  test('AI response containing <script>/<img onerror>/<svg onload> renders as text and does NOT execute', async ({
+    page,
+  }) => {
+    // Capture any dialog as a hard failure signal.
+    const dialogs: Dialog[] = [];
+    page.on('dialog', async (d) => {
+      dialogs.push(d);
+      await d.dismiss();
+    });
+
+    const responseText = [
+      'Here is some content:',
+      PAYLOADS.scriptTag,
+      PAYLOADS.imgOnerror,
+      PAYLOADS.svgOnload,
+      'End.',
+    ].join('\n\n');
+
+    // Mock the chat endpoint to stream back the injection payload.
+    await page.route('**/api/ai/ask', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: buildSseBody(responseText),
+      });
+    });
+
+    // Open the chat bubble.
+    const openChat = page.getByRole('button', { name: 'Open AI chat' });
+    await expect(openChat).toBeVisible({ timeout: 10_000 });
+    await openChat.click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    // Send any question — the response is mocked, the content doesn't matter.
+    const input = page.locator('input[placeholder*="course materials"]');
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill('hello');
+    await page.keyboard.press('Enter');
+
+    // Wait for the assistant response bubble to appear.
+    // Assistant-rendered markdown lives in a `.prose` wrapper produced by
+    // <MarkdownResponse>. The streaming and the finalized message both
+    // render it. The mocked response is the most-recent assistant bubble
+    // — use `.last()` so any stored conversation history doesn't shadow it.
+    const responseBubble = page.locator('div.prose').last();
+    await expect(responseBubble).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the streamed text to settle (the "End." marker confirms the
+    // full payload was processed).
+    await expect(responseBubble).toContainText('End.', { timeout: 5_000 });
+
+    // The payload text must be visible as TEXT in the rendered bubble.
+    // react-markdown escapes raw HTML, so the literal `<script>` characters
+    // appear as text content.
+    const bubbleText = await responseBubble.textContent();
+    expect(bubbleText).toContain('<script>');
+    expect(bubbleText).toContain('onerror');
+
+    // None of the payloads' sentinel side-effects must have happened.
+    const fired = await page.evaluate(() => ({
+      f1: (window as unknown as { __pi_fired_1?: boolean }).__pi_fired_1,
+      f2: (window as unknown as { __pi_fired_2?: boolean }).__pi_fired_2,
+      f3: (window as unknown as { __pi_fired_3?: boolean }).__pi_fired_3,
+    }));
+    expect(fired.f1).toBeFalsy();
+    expect(fired.f2).toBeFalsy();
+    expect(fired.f3).toBeFalsy();
+    expect(dialogs).toHaveLength(0);
+
+    // Defense-in-depth: assert no live <script> in the bubble subtree
+    // (react-markdown should never emit one from response markdown).
+    const scriptCount = await responseBubble.evaluate(
+      (el) => el.querySelectorAll('script').length,
+    );
+    expect(scriptCount).toBe(0);
+  });
+
+  test('markdown-link with javascript: URL in AI response does not become a clickable execution sink', async ({
+    page,
+  }) => {
+    const dialogs: Dialog[] = [];
+    page.on('dialog', async (d) => {
+      dialogs.push(d);
+      await d.dismiss();
+    });
+
+    // A standard markdown link with a javascript: URL. react-markdown sanitizes
+    // URL protocols on `<a>` by default and replaces `javascript:` with a
+    // safe placeholder. This test pins that behavior.
+    const responseText = '[click me](javascript:window.__pi_fired_4=true)';
+
+    await page.route('**/api/ai/ask', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/event-stream',
+        body: buildSseBody(responseText),
+      });
+    });
+
+    const openChat = page.getByRole('button', { name: 'Open AI chat' });
+    await expect(openChat).toBeVisible({ timeout: 10_000 });
+    await openChat.click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    const input = page.locator('input[placeholder*="course materials"]');
+    await input.fill('hello');
+    await page.keyboard.press('Enter');
+
+    // Assistant-rendered markdown lives in a `.prose` wrapper produced by
+    // <MarkdownResponse>. The streaming and the finalized message both
+    // render it. The mocked response is the most-recent assistant bubble
+    // — use `.last()` so any stored conversation history doesn't shadow it.
+    const responseBubble = page.locator('div.prose').last();
+    await expect(responseBubble).toBeVisible({ timeout: 10_000 });
+    await expect(responseBubble).toContainText('click me', { timeout: 5_000 });
+
+    // Find the rendered link and check its href.
+    const link = responseBubble.locator('a', { hasText: 'click me' }).first();
+    const href = await link.getAttribute('href');
+    // react-markdown's default URL sanitizer replaces javascript: with
+    // `javascript:void(0)` or strips the protocol — either way, clicking
+    // must NOT execute. The cleanest assertion is: no live javascript:
+    // protocol survives.
+    expect(href ?? '').not.toMatch(/^javascript:/i);
+
+    // Attempt the click; nothing should fire.
+    await link.click().catch(() => {
+      /* link may be inert — that's a successful sanitization outcome */
+    });
+
+    const fired = await page.evaluate(
+      () => (window as unknown as { __pi_fired_4?: boolean }).__pi_fired_4,
+    );
+    expect(fired).toBeFalsy();
+    expect(dialogs).toHaveLength(0);
+  });
+});

--- a/src/__tests__/integration/storage-rls-buckets.integration.test.ts
+++ b/src/__tests__/integration/storage-rls-buckets.integration.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Storage RLS — coverage for the OTHER two storage buckets the app uses,
+ * with their distinct access models. Companion to
+ * `storage-rls.integration.test.ts` which covers `personal-files`.
+ *
+ *   - `course-materials`:  same per-user path-prefix RLS as personal-files
+ *   - `moodle-materials`:  shared "any authenticated user can read"; no
+ *                          regular-user writes (service-role only)
+ *
+ * Why this matters: each bucket has its OWN policy set. A migration
+ * could drop one bucket's policy without affecting the other, and the
+ * existing personal-files test would still pass. Per-bucket tests
+ * catch that.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import {
+  SUPABASE_ANON_KEY,
+  TEST_USER_A,
+  TEST_USER_B,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const SUPABASE_URL = process.env.SUPABASE_URL ?? 'http://127.0.0.1:54321';
+
+const admin = createAdminClient();
+
+const PDF_BYTES = new Uint8Array(
+  Buffer.from('%PDF-1.4\n%fake pdf for storage rls\n%%EOF'),
+);
+
+// ─── course-materials ──────────────────────────────────────────────
+
+describe('storage RLS — course-materials bucket (per-user path prefix)', () => {
+  const BUCKET = 'course-materials';
+  const FILE_NAME = `rls-cm-${Date.now()}.pdf`;
+  const PATH_A = `${TEST_USER_A.id}/${FILE_NAME}`;
+  const PATH_B = `${TEST_USER_B.id}/${FILE_NAME}`;
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  async function cleanup() {
+    await admin.storage
+      .from(BUCKET)
+      .remove([PATH_A, PATH_B])
+      .catch(() => {});
+  }
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    clientB = await createUserClient(TEST_USER_B);
+    await cleanup();
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const upA = await clientA.storage.from(BUCKET).upload(PATH_A, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upA.error) throw new Error(`seed A: ${upA.error.message}`);
+    const upB = await clientB.storage.from(BUCKET).upload(PATH_B, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upB.error) throw new Error(`seed B: ${upB.error.message}`);
+  });
+
+  afterAll(cleanup);
+
+  it("User A cannot list User B's folder", async () => {
+    const { data } = await clientA.storage.from(BUCKET).list(TEST_USER_B.id);
+    expect((data ?? []).map((o) => o.name)).not.toContain(FILE_NAME);
+  });
+
+  it("User A's upload to User B's path is rejected", async () => {
+    const spoofPath = `${TEST_USER_B.id}/spoof-cm.pdf`;
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const { error } = await clientA.storage
+      .from(BUCKET)
+      .upload(spoofPath, blob, {
+        contentType: 'application/pdf',
+        upsert: false,
+      });
+    expect(error).not.toBeNull();
+    await admin.storage
+      .from(BUCKET)
+      .remove([spoofPath])
+      .catch(() => {});
+  });
+
+  it("User A's delete of User B's file is silently noop'd", async () => {
+    await clientA.storage.from(BUCKET).remove([PATH_B]);
+    const { data } = await admin.storage.from(BUCKET).list(TEST_USER_B.id);
+    expect((data ?? []).map((o) => o.name)).toContain(FILE_NAME);
+  });
+});
+
+// ─── moodle-materials ──────────────────────────────────────────────
+
+describe('storage RLS — moodle-materials bucket (shared read, no user writes)', () => {
+  const BUCKET = 'moodle-materials';
+  // moodle-materials is a SHARED bucket — paths are NOT prefixed by
+  // user id. We seed a known fixture as admin (the only role allowed
+  // to write) and verify each access mode.
+  const FIXTURE_PATH = `rls-fixtures/moodle-fixture-${Date.now()}.pdf`;
+  let clientA: SupabaseClient;
+  let anonClient: SupabaseClient;
+
+  async function cleanup() {
+    await admin.storage
+      .from(BUCKET)
+      .remove([FIXTURE_PATH])
+      .catch(() => {});
+  }
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    anonClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    await cleanup();
+
+    // Seed with admin (service role); no user policy permits INSERT.
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const { error } = await admin.storage
+      .from(BUCKET)
+      .upload(FIXTURE_PATH, blob, {
+        contentType: 'application/pdf',
+        upsert: true,
+      });
+    if (error) throw new Error(`moodle seed: ${error.message}`);
+  });
+
+  afterAll(cleanup);
+
+  it('any authenticated user CAN download the fixture (shared-read policy)', async () => {
+    const { data, error } = await clientA.storage
+      .from(BUCKET)
+      .download(FIXTURE_PATH);
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+    const text = await data!.text();
+    // The bytes we uploaded survive a round-trip.
+    expect(text).toContain('%PDF-1.4');
+  });
+
+  it('an anon (signed-out) client CANNOT download the fixture', async () => {
+    const { data, error } = await anonClient.storage
+      .from(BUCKET)
+      .download(FIXTURE_PATH);
+    if (!error && data) {
+      const text = await data.text();
+      // Anything other than a failure must NOT contain the PDF bytes.
+      expect(text).not.toContain('%PDF-1.4');
+    }
+  });
+
+  it('a regular authenticated user CANNOT upload to moodle-materials (service-role only)', async () => {
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const sneakyPath = `rls-fixtures/sneak-by-user-${Date.now()}.pdf`;
+    const { error } = await clientA.storage
+      .from(BUCKET)
+      .upload(sneakyPath, blob, {
+        contentType: 'application/pdf',
+        upsert: false,
+      });
+    expect(error).not.toBeNull();
+    await admin.storage
+      .from(BUCKET)
+      .remove([sneakyPath])
+      .catch(() => {});
+  });
+
+  it('a regular authenticated user CANNOT delete from moodle-materials', async () => {
+    await clientA.storage.from(BUCKET).remove([FIXTURE_PATH]);
+    // Admin can still see the fixture — it was not actually removed.
+    const { data, error } = await admin.storage
+      .from(BUCKET)
+      .download(FIXTURE_PATH);
+    expect(error).toBeNull();
+    expect(data).not.toBeNull();
+  });
+});

--- a/src/__tests__/integration/storage-rls.integration.test.ts
+++ b/src/__tests__/integration/storage-rls.integration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Storage-bucket RLS isolation tests.
+ *
+ * The `personal-files` and `course-materials` buckets are PRIVATE
+ * (`public: false`) and guard cross-user access via path-prefix RLS:
+ *
+ *   USING (
+ *     bucket_id = 'personal-files'
+ *     AND auth.uid()::text = (storage.foldername(name))[1]
+ *   )
+ *
+ * In plain English: a file at `{user_id}/anything.pdf` is only
+ * readable/writable by the user whose UUID is the first path segment.
+ *
+ * Existing tests verify the *table* RLS (`rls-isolation.integration.test.ts`)
+ * but not the storage layer. If the path-prefix policy is dropped or
+ * mis-written, a forged path could let user A list and download every
+ * other user's private files. These tests pin the storage policy.
+ */
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+const BUCKET = 'personal-files';
+const FILE_NAME = `rls-test-${Date.now()}.pdf`;
+const PATH_A = `${TEST_USER_A.id}/${FILE_NAME}`;
+const PATH_B = `${TEST_USER_B.id}/${FILE_NAME}`;
+
+const PDF_BYTES = new Uint8Array(
+  Buffer.from('%PDF-1.4\n%fake pdf for rls test\n%%EOF'),
+);
+
+async function cleanup() {
+  // Use admin to remove any leftover fixtures. Best-effort.
+  await admin.storage
+    .from(BUCKET)
+    .remove([PATH_A, PATH_B])
+    .catch(() => {
+      /* ignore */
+    });
+}
+
+describe('storage RLS — personal-files bucket', () => {
+  let clientA: SupabaseClient;
+  let clientB: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    clientB = await createUserClient(TEST_USER_B);
+    await cleanup();
+
+    // Seed: each user uploads ONE file under their own user-id prefix.
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const upA = await clientA.storage.from(BUCKET).upload(PATH_A, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upA.error) throw new Error(`seed A: ${upA.error.message}`);
+
+    const upB = await clientB.storage.from(BUCKET).upload(PATH_B, blob, {
+      contentType: 'application/pdf',
+      upsert: true,
+    });
+    if (upB.error) throw new Error(`seed B: ${upB.error.message}`);
+  });
+
+  afterAll(cleanup);
+
+  it("User A's list of their own folder returns only their file (RLS scope by path prefix)", async () => {
+    const { data, error } = await clientA.storage
+      .from(BUCKET)
+      .list(TEST_USER_A.id);
+    expect(error).toBeNull();
+    const names = (data ?? []).map((o) => o.name);
+    expect(names).toContain(FILE_NAME);
+  });
+
+  it("User A's list of User B's folder returns empty (RLS blocks cross-user listing)", async () => {
+    const { data } = await clientA.storage.from(BUCKET).list(TEST_USER_B.id);
+    // Storage RLS makes the listing return empty rather than an error.
+    // Either way, the file must not appear.
+    const names = (data ?? []).map((o) => o.name);
+    expect(names).not.toContain(FILE_NAME);
+  });
+
+  it("User A's download of User B's file fails (RLS blocks cross-user read)", async () => {
+    const { data, error } = await clientA.storage.from(BUCKET).download(PATH_B);
+    // Storage returns either `error` or `null`/empty data. We accept
+    // either failure mode but never a successful cross-user read.
+    if (!error && data) {
+      const text = await data.text();
+      // If we got bytes, they must not contain the PDF header — a
+      // common false-pass mode is getting back a public placeholder.
+      expect(text).not.toContain('%PDF');
+    }
+  });
+
+  it("User A's upload to User B's path fails (RLS WITH CHECK blocks spoofed prefix)", async () => {
+    const spoofPath = `${TEST_USER_B.id}/spoof-by-a.pdf`;
+    const blob = new Blob([PDF_BYTES], { type: 'application/pdf' });
+    const { error } = await clientA.storage
+      .from(BUCKET)
+      .upload(spoofPath, blob, {
+        contentType: 'application/pdf',
+        upsert: false,
+      });
+    expect(error).not.toBeNull();
+    // Best-effort cleanup if the policy missed and the upload landed.
+    await admin.storage
+      .from(BUCKET)
+      .remove([spoofPath])
+      .catch(() => {});
+  });
+
+  it("User A's delete of User B's file fails (RLS blocks cross-user delete)", async () => {
+    await clientA.storage.from(BUCKET).remove([PATH_B]);
+
+    // Verify B's file still exists by admin-listing the folder.
+    const { data } = await admin.storage.from(BUCKET).list(TEST_USER_B.id);
+    const names = (data ?? []).map((o) => o.name);
+    expect(names).toContain(FILE_NAME);
+  });
+});

--- a/src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
@@ -10,13 +10,13 @@ import { WeekDialog } from '@/components/dashboard/week-dialog';
 import { EmptyState } from '@/components/dashboard/empty-state';
 import { PersonalFileUpload } from '@/components/dashboard/personal-file-upload';
 import { PersonalFileItem } from '@/components/dashboard/personal-file-item';
+import { MoodleFileRow } from '@/components/dashboard/moodle-file-row';
 import {
   getPersonalFilesByCourse,
   getPersonalFilesByWeeks,
 } from '@/lib/queries/personal-files';
 import type { PersonalFile } from '@/types/database';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { ChevronLeft } from 'lucide-react';
 import {
   Breadcrumb,
@@ -373,35 +373,17 @@ export default async function CoursePage({
                           const href = file.downloadUrl ?? file.moodle_url;
                           const isStored = !!file.downloadUrl;
                           return (
-                            <a
+                            <MoodleFileRow
                               key={file.id}
+                              fileId={file.id}
+                              fileName={file.file_name}
+                              fileType={file.type}
+                              mimeType={file.mime_type}
+                              fileSize={file.file_size}
                               href={href}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="flex items-center gap-3 px-4 py-2 hover:bg-accent/30 transition-colors"
-                              {...(isStored
-                                ? { download: file.file_name }
-                                : {})}
-                            >
-                              <span className="flex-1 text-sm truncate">
-                                {file.file_name}
-                              </span>
-                              {file.file_size && (
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                  {file.file_size > 1024 * 1024
-                                    ? `${(file.file_size / (1024 * 1024)).toFixed(1)} MB`
-                                    : `${Math.round(file.file_size / 1024)} KB`}
-                                </span>
-                              )}
-                              <Badge
-                                variant="outline"
-                                className="text-xs shrink-0"
-                              >
-                                {file.type === 'file'
-                                  ? (file.mime_type?.split('/')[1] ?? 'file')
-                                  : 'link'}
-                              </Badge>
-                            </a>
+                              isStored={isStored}
+                              courseId={courseId}
+                            />
                           );
                         })}
                     </div>

--- a/src/app/api/ai/search/validation.test.ts
+++ b/src/app/api/ai/search/validation.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Input-validation tests for GET /api/ai/search.
+ *
+ * The route is the RAG entry point — callers pass `query` and `courseId`
+ * (plus optional `weekId`, `maxResults`). Bad inputs must return 4xx
+ * BEFORE touching `searchContext`, otherwise a malformed call could
+ * trigger a costly embedding lookup or DB scan on every request.
+ *
+ * Mirrors the existing `src/app/api/ai/ask/validation.test.ts` pattern:
+ * mock `searchContext` at module level, then drive the route with
+ * various URLs and assert response status + error shape.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSearchContext = vi.fn();
+vi.mock('@/lib/actions/ai-context', () => ({
+  searchContext: (...args: unknown[]) => mockSearchContext(...args),
+}));
+
+import { GET } from './route';
+
+function makeReq(query: Record<string, string>): Request {
+  const url = new URL('http://test/api/ai/search');
+  for (const [k, v] of Object.entries(query)) url.searchParams.set(k, v);
+  return new Request(url, { method: 'GET' });
+}
+
+describe('GET /api/ai/search — input validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchContext.mockResolvedValue([]);
+  });
+
+  it('rejects missing query with 400', async () => {
+    const res = await GET(makeReq({ courseId: 'c1' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/query/i);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty/whitespace-only query with 400', async () => {
+    const res = await GET(makeReq({ query: '   ', courseId: 'c1' }));
+    expect(res.status).toBe(400);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing courseId with 400', async () => {
+    const res = await GET(makeReq({ query: 'derivative' }));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/courseId/i);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-integer maxResults with 400', async () => {
+    const res = await GET(
+      makeReq({ query: 'q', courseId: 'c1', maxResults: 'banana' }),
+    );
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(data.error).toMatch(/maxResults/i);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('rejects negative or zero maxResults with 400', async () => {
+    const res = await GET(
+      makeReq({ query: 'q', courseId: 'c1', maxResults: '0' }),
+    );
+    expect(res.status).toBe(400);
+    expect(mockSearchContext).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid request and trims the query before passing it on', async () => {
+    mockSearchContext.mockResolvedValue([{ id: 'x', sourceName: 'lec01.pdf' }]);
+    const res = await GET(makeReq({ query: '  derivative  ', courseId: 'c1' }));
+    expect(res.status).toBe(200);
+    expect(mockSearchContext).toHaveBeenCalledWith({
+      query: 'derivative',
+      courseId: 'c1',
+      weekId: undefined,
+      maxResults: undefined,
+    });
+  });
+
+  it('forwards weekId and maxResults when provided', async () => {
+    mockSearchContext.mockResolvedValue([]);
+    await GET(
+      makeReq({
+        query: 'q',
+        courseId: 'c1',
+        weekId: 'w1',
+        maxResults: '5',
+      }),
+    );
+    expect(mockSearchContext).toHaveBeenCalledWith({
+      query: 'q',
+      courseId: 'c1',
+      weekId: 'w1',
+      maxResults: 5,
+    });
+  });
+
+  it('maps an "Unauthorized" thrown by searchContext to a 401 response', async () => {
+    mockSearchContext.mockRejectedValue(new Error('Unauthorized'));
+    const res = await GET(makeReq({ query: 'q', courseId: 'c1' }));
+    expect(res.status).toBe(401);
+    const data = await res.json();
+    expect(data.error).toMatch(/unauth/i);
+  });
+
+  it('maps any other thrown error to a 500 without leaking the message', async () => {
+    mockSearchContext.mockRejectedValue(new Error('internal connection wat'));
+    const res = await GET(makeReq({ query: 'q', courseId: 'c1' }));
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    // The route returns a generic "Failed to search context" — the raw
+    // error message must NOT leak to the client.
+    expect(data.error).not.toContain('connection wat');
+  });
+});

--- a/src/components/ai/__tests__/markdown-response.test.tsx
+++ b/src/components/ai/__tests__/markdown-response.test.tsx
@@ -94,3 +94,56 @@ describe('MarkdownResponse', () => {
     expect(container.innerHTML).toBe('');
   });
 });
+
+/**
+ * XSS-safety: unit-level guard for the same property the E2E
+ * `e2e/security-prompt-injection.spec.ts` covers.
+ *
+ * react-markdown by default does NOT render raw HTML. The moment
+ * someone adds `rehype-raw` (or any plugin that emits raw HTML), the
+ * `<script>` count below jumps from 0 and this test fails — much
+ * cheaper than catching the regression 30s into an E2E run.
+ */
+describe('MarkdownResponse — XSS safety', () => {
+  it('does not emit a live <script> for inline <script> in markdown', () => {
+    const { container } = render(
+      <MarkdownResponse content="hello <script>window.__md_xss=true</script> world" />,
+    );
+    expect(container.querySelectorAll('script')).toHaveLength(0);
+    // The literal characters appear as text (escaped) so a reader sees
+    // what the model said.
+    expect(container.textContent).toContain('<script>');
+  });
+
+  it('does not emit an <img> with an onerror sink', () => {
+    const { container } = render(
+      <MarkdownResponse content='<img src=x onerror="window.__md_xss=true">' />,
+    );
+    for (const img of Array.from(container.querySelectorAll('img'))) {
+      expect(img.getAttribute('onerror')).toBeNull();
+    }
+    expect(container.textContent).toContain('onerror');
+  });
+
+  it('sanitizes javascript: URLs in markdown links', () => {
+    const { container } = render(
+      <MarkdownResponse content="[click](javascript:window.__md_xss=true)" />,
+    );
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    // react-markdown's URL allowlist replaces unsafe protocols. Either
+    // the protocol is stripped (href becomes empty/about:blank) or
+    // replaced — what matters is that no live javascript: remains.
+    expect(link!.getAttribute('href') ?? '').not.toMatch(/^javascript:/i);
+    expect(link!.textContent).toBe('click');
+  });
+
+  it('preserves safe https:// URLs (regression guard against over-sanitization)', () => {
+    const { container } = render(
+      <MarkdownResponse content="[docs](https://example.com)" />,
+    );
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link!.getAttribute('href')).toBe('https://example.com');
+  });
+});

--- a/src/components/ai/ai-chat-panel.tsx
+++ b/src/components/ai/ai-chat-panel.tsx
@@ -25,6 +25,7 @@ interface ChatSource {
   sourceName: string;
   weekId: string | null;
   pageRange: string | null;
+  signedUrl: string | null;
 }
 
 interface ChatMessage {
@@ -614,16 +615,35 @@ export function AiChatPanel({
                         {/* Sources */}
                         {msg.sources && msg.sources.length > 0 && (
                           <div className="mt-2 flex flex-wrap gap-1.5">
-                            {msg.sources.map((src, j) => (
-                              <span
-                                key={j}
-                                className="inline-flex items-center gap-1 rounded-full border bg-background px-2.5 py-0.5 text-[10px] text-muted-foreground"
-                              >
-                                <BookOpen className="h-2.5 w-2.5" />
-                                {src.sourceName}
-                                {src.pageRange && ` (${src.pageRange})`}
-                              </span>
-                            ))}
+                            {msg.sources.map((src, j) => {
+                              const content = (
+                                <>
+                                  <BookOpen className="h-2.5 w-2.5" />
+                                  {src.sourceName}
+                                  {src.pageRange && ` (${src.pageRange})`}
+                                </>
+                              );
+                              const className =
+                                'inline-flex items-center gap-1 rounded-full border bg-background px-2.5 py-0.5 text-[10px] text-muted-foreground';
+                              return src.signedUrl ? (
+                                <a
+                                  key={j}
+                                  href={src.signedUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className={
+                                    className +
+                                    ' hover:bg-accent hover:text-foreground transition-colors'
+                                  }
+                                >
+                                  {content}
+                                </a>
+                              ) : (
+                                <span key={j} className={className}>
+                                  {content}
+                                </span>
+                              );
+                            })}
                           </div>
                         )}
 

--- a/src/components/dashboard/moodle-file-row.tsx
+++ b/src/components/dashboard/moodle-file-row.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useTransition } from 'react';
+import { Trash2 } from 'lucide-react';
+
+import { removeMoodleFileFromNotebook } from '@/lib/actions/moodle-sync';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface MoodleFileRowProps {
+  fileId: string;
+  fileName: string;
+  fileType: string; // 'file' | 'link'
+  mimeType: string | null;
+  fileSize: number | null;
+  href: string;
+  isStored: boolean;
+  courseId: string;
+}
+
+export function MoodleFileRow({
+  fileId,
+  fileName,
+  fileType,
+  mimeType,
+  fileSize,
+  href,
+  isStored,
+  courseId,
+}: MoodleFileRowProps) {
+  const [isPending, startTransition] = useTransition();
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const confirmed = window.confirm(
+      `Remove "${fileName}" from your materials? The file stays in the shared registry; only your access record is removed.`,
+    );
+    if (!confirmed) return;
+    startTransition(async () => {
+      try {
+        await removeMoodleFileFromNotebook(fileId, courseId);
+      } catch (err) {
+        // eslint-disable-next-line no-alert
+        alert(
+          `Failed to remove file: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    });
+  };
+
+  return (
+    <a
+      href={href}
+      data-moodle-file-row=""
+      data-file-id={fileId}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-3 px-4 py-2 hover:bg-accent/30 transition-colors"
+      {...(isStored ? { download: fileName } : {})}
+    >
+      <span className="flex-1 text-sm truncate">{fileName}</span>
+      {fileSize && (
+        <span className="text-xs text-muted-foreground shrink-0">
+          {fileSize > 1024 * 1024
+            ? `${(fileSize / (1024 * 1024)).toFixed(1)} MB`
+            : `${Math.round(fileSize / 1024)} KB`}
+        </span>
+      )}
+      <Badge variant="outline" className="text-xs shrink-0">
+        {fileType === 'file' ? (mimeType?.split('/')[1] ?? 'file') : 'link'}
+      </Badge>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleDelete}
+        disabled={isPending}
+        aria-label={`Remove ${fileName} from notebook`}
+        className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+      >
+        <Trash2 className="size-3.5" />
+      </Button>
+    </a>
+  );
+}

--- a/src/lib/actions/__tests__/ai-context.test.ts
+++ b/src/lib/actions/__tests__/ai-context.test.ts
@@ -69,10 +69,7 @@ vi.mock('@/lib/supabase/server', () => ({
         };
         return chain;
       }
-      const data =
-        table === 'user_course_syncs'
-          ? syncRow
-          : null;
+      const data = table === 'user_course_syncs' ? syncRow : null;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const chain: any = {
         select: vi.fn(() => chain),
@@ -136,10 +133,7 @@ vi.mock('@/lib/supabase/admin', () => {
           };
           return chain;
         }
-        const data =
-          table === 'moodle_sections'
-            ? moodleSectionRow
-            : null;
+        const data = table === 'moodle_sections' ? moodleSectionRow : null;
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
@@ -181,7 +175,12 @@ vi.mock('@/lib/ai/prompts', () => ({
 import { extractPdfText } from '@/lib/ai/extraction/pdf';
 import { getContentHash, upsertEmbeddings } from '@/lib/queries/embeddings';
 
-import { askQuestion, buildAiContext, indexContent, searchContext } from '../ai-context';
+import {
+  askQuestion,
+  buildAiContext,
+  indexContent,
+  searchContext,
+} from '../ai-context';
 
 afterEach(() => {
   vi.clearAllMocks();

--- a/src/lib/actions/__tests__/ai-context.test.ts
+++ b/src/lib/actions/__tests__/ai-context.test.ts
@@ -48,12 +48,31 @@ vi.mock('@/lib/supabase/server', () => ({
         };
         return chain;
       }
+      if (table === 'course_materials') {
+        const rows = [{ id: 'mat-1', storage_path: 'materials/mat-1.pdf' }];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          in: vi.fn(() => chain),
+          maybeSingle: vi.fn(async () => ({
+            data: courseMaterialRow,
+            error: null,
+          })),
+          single: vi.fn(async () => ({
+            data: courseMaterialRow,
+            error: null,
+          })),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          then: (resolve: (value: any) => any) =>
+            resolve({ data: rows, error: null }),
+        };
+        return chain;
+      }
       const data =
         table === 'user_course_syncs'
           ? syncRow
-          : table === 'course_materials'
-            ? courseMaterialRow
-            : null;
+          : null;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const chain: any = {
         select: vi.fn(() => chain),
@@ -78,6 +97,10 @@ vi.mock('@/lib/supabase/server', () => ({
             data: new Blob(['fake file content']),
             error: null,
           })),
+          createSignedUrl: vi.fn(async () => ({
+            data: { signedUrl: 'https://example.com/signed/test.pdf' },
+            error: null,
+          })),
         })),
       },
     };
@@ -96,12 +119,27 @@ vi.mock('@/lib/supabase/admin', () => {
   return {
     createAdminClient: vi.fn(() => ({
       from: vi.fn((table: string) => {
+        if (table === 'moodle_files') {
+          const rows = [{ id: 'file-1', storage_path: 'moodle/file-1.pdf' }];
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const chain: any = {
+            select: vi.fn(() => chain),
+            eq: vi.fn(() => chain),
+            in: vi.fn(() => chain),
+            single: vi.fn(async () => ({
+              data: moodleFileRow,
+              error: null,
+            })),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            then: (resolve: (value: any) => any) =>
+              resolve({ data: rows, error: null }),
+          };
+          return chain;
+        }
         const data =
-          table === 'moodle_files'
-            ? moodleFileRow
-            : table === 'moodle_sections'
-              ? moodleSectionRow
-              : null;
+          table === 'moodle_sections'
+            ? moodleSectionRow
+            : null;
         return {
           select: vi.fn(() => ({
             eq: vi.fn(() => ({
@@ -114,6 +152,10 @@ vi.mock('@/lib/supabase/admin', () => {
         from: vi.fn(() => ({
           download: vi.fn(async () => ({
             data: new Blob(['fake pdf content']),
+            error: null,
+          })),
+          createSignedUrl: vi.fn(async () => ({
+            data: { signedUrl: 'https://example.com/signed/test.pdf' },
             error: null,
           })),
         })),
@@ -139,7 +181,7 @@ vi.mock('@/lib/ai/prompts', () => ({
 import { extractPdfText } from '@/lib/ai/extraction/pdf';
 import { getContentHash, upsertEmbeddings } from '@/lib/queries/embeddings';
 
-import { askQuestion, indexContent, searchContext } from '../ai-context';
+import { askQuestion, buildAiContext, indexContent, searchContext } from '../ai-context';
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -315,5 +357,35 @@ describe('askQuestion', () => {
         model: 'gemini-2.5-pro',
       }),
     );
+  });
+});
+
+describe('buildAiContext attaches signedUrl to sources', () => {
+  it('returns a signed URL for each moodle_file source', async () => {
+    const { matchEmbeddings } = await import('@/lib/queries/embeddings');
+    vi.mocked(matchEmbeddings).mockResolvedValueOnce([
+      {
+        id: 1,
+        source_type: 'moodle_file',
+        source_id: 'file-1',
+        source_name: 'lecture5.pdf',
+        segment_text: 'foo',
+        page_start: null,
+        page_end: null,
+        course_id: 'moodle-course-1',
+        week_id: null,
+        mime_type: 'application/pdf',
+        similarity: 0.9,
+      },
+    ]);
+
+    const { sources } = await buildAiContext({
+      question: 'q',
+      courseId: 'callers-typenote-course',
+      mode: 'quick',
+    });
+
+    expect(sources).toHaveLength(1);
+    expect(sources[0].signedUrl).toMatch(/^https?:\/\//);
   });
 });

--- a/src/lib/actions/__tests__/ai-context.test.ts
+++ b/src/lib/actions/__tests__/ai-context.test.ts
@@ -23,36 +23,65 @@ vi.mock('@/lib/queries/embeddings', () => ({
 }));
 
 vi.mock('@/lib/supabase/server', () => ({
-  createClient: vi.fn(async () => ({
-    auth: {
-      getUser: vi.fn(async () => ({
-        data: { user: { id: 'test-user-id' } },
-        error: null,
-      })),
-    },
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn(async () => ({
-            data: {
-              storage_path: 'test/path.pdf',
-              file_name: 'lecture.pdf',
-              mime_type: 'application/pdf',
-            },
+  createClient: vi.fn(async () => {
+    const courseMaterialRow = {
+      storage_path: 'test/path.pdf',
+      file_name: 'lecture.pdf',
+      mime_type: 'application/pdf',
+    };
+    const syncRow = { moodle_course_id: 'moodle-course-1' };
+    const importsRows = [
+      { moodle_file_id: 'imported-file-a' },
+      { moodle_file_id: 'imported-file-b' },
+    ];
+
+    const from = vi.fn((table: string) => {
+      if (table === 'user_file_imports') {
+        // Awaitable directly (no .single/.maybeSingle in our usage)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const chain: any = {
+          select: vi.fn(() => chain),
+          eq: vi.fn(() => chain),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          then: (resolve: (value: any) => any) =>
+            resolve({ data: importsRows, error: null }),
+        };
+        return chain;
+      }
+      const data =
+        table === 'user_course_syncs'
+          ? syncRow
+          : table === 'course_materials'
+            ? courseMaterialRow
+            : null;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const chain: any = {
+        select: vi.fn(() => chain),
+        eq: vi.fn(() => chain),
+        maybeSingle: vi.fn(async () => ({ data, error: null })),
+        single: vi.fn(async () => ({ data, error: null })),
+      };
+      return chain;
+    });
+
+    return {
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: { user: { id: 'test-user-id' } },
+          error: null,
+        })),
+      },
+      from,
+      storage: {
+        from: vi.fn(() => ({
+          download: vi.fn(async () => ({
+            data: new Blob(['fake file content']),
             error: null,
           })),
         })),
-      })),
-    })),
-    storage: {
-      from: vi.fn(() => ({
-        download: vi.fn(async () => ({
-          data: new Blob(['fake file content']),
-          error: null,
-        })),
-      })),
-    },
-  })),
+      },
+    };
+  }),
 }));
 
 vi.mock('@/lib/supabase/admin', () => {
@@ -200,6 +229,24 @@ describe('searchContext', () => {
     expect(results[0].sourceName).toBe('Lecture 5.pdf');
     expect(results[0].segmentText).toBe('Extracted text from lecture 5');
     expect(results[0].similarity).toBe(0.92);
+  });
+
+  it('passes resolved moodleCourseId and importedMoodleFileIds to matchEmbeddings', async () => {
+    const { matchEmbeddings } = await import('@/lib/queries/embeddings');
+    vi.mocked(matchEmbeddings).mockResolvedValueOnce([]);
+
+    await searchContext({
+      query: 'what is in lecture 5?',
+      courseId: 'callers-typenote-course',
+    });
+
+    expect(matchEmbeddings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        courseId: 'callers-typenote-course',
+        moodleCourseId: 'moodle-course-1',
+        importedMoodleFileIds: ['imported-file-a', 'imported-file-b'],
+      }),
+    );
   });
 });
 

--- a/src/lib/actions/__tests__/ai-context.test.ts
+++ b/src/lib/actions/__tests__/ai-context.test.ts
@@ -29,7 +29,7 @@ vi.mock('@/lib/supabase/server', () => ({
       file_name: 'lecture.pdf',
       mime_type: 'application/pdf',
     };
-    const syncRow = { moodle_course_id: 'moodle-course-1' };
+    const syncRow = { id: 'sync-1', moodle_course_id: 'moodle-course-1' };
     const importsRows = [
       { moodle_file_id: 'imported-file-a' },
       { moodle_file_id: 'imported-file-b' },

--- a/src/lib/actions/__tests__/ai-context.test.ts
+++ b/src/lib/actions/__tests__/ai-context.test.ts
@@ -55,32 +55,43 @@ vi.mock('@/lib/supabase/server', () => ({
   })),
 }));
 
-vi.mock('@/lib/supabase/admin', () => ({
-  createAdminClient: vi.fn(() => ({
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn(async () => ({
-            data: {
-              storage_path: 'test/path.pdf',
-              file_name: 'lecture.pdf',
-              mime_type: 'application/pdf',
-            },
+vi.mock('@/lib/supabase/admin', () => {
+  const moodleFileRow = {
+    storage_path: 'test/path.pdf',
+    file_name: 'lecture.pdf',
+    mime_type: 'application/pdf',
+    section_id: 'section-1',
+  };
+  const moodleSectionRow = { course_id: 'moodle-course-1' };
+
+  return {
+    createAdminClient: vi.fn(() => ({
+      from: vi.fn((table: string) => {
+        const data =
+          table === 'moodle_files'
+            ? moodleFileRow
+            : table === 'moodle_sections'
+              ? moodleSectionRow
+              : null;
+        return {
+          select: vi.fn(() => ({
+            eq: vi.fn(() => ({
+              single: vi.fn(async () => ({ data, error: null })),
+            })),
+          })),
+        };
+      }),
+      storage: {
+        from: vi.fn(() => ({
+          download: vi.fn(async () => ({
+            data: new Blob(['fake pdf content']),
             error: null,
           })),
         })),
-      })),
+      },
     })),
-    storage: {
-      from: vi.fn(() => ({
-        download: vi.fn(async () => ({
-          data: new Blob(['fake pdf content']),
-          error: null,
-        })),
-      })),
-    },
-  })),
-}));
+  };
+});
 
 const mockGenerateContent = vi.fn(async () => ({
   text: 'This is the AI answer based on the lecture materials.',
@@ -142,16 +153,21 @@ describe('indexContent', () => {
     expect(getContentHash).toHaveBeenCalledWith('course_material', 'mat-1');
   });
 
-  it('embeds moodle_file as shared (user_id=null)', async () => {
+  it('embeds moodle_file with canonical moodle_courses.id (not caller course_id)', async () => {
     const result = await indexContent({
       type: 'moodle_file',
       fileId: 'file-1',
-      courseId: 'course-1',
+      courseId: 'callers-typenote-course', // should be IGNORED for the embedding row
     });
 
     expect(result.success).toBe(true);
     expect(upsertEmbeddings).toHaveBeenCalledWith(
-      expect.arrayContaining([expect.objectContaining({ user_id: null })]),
+      expect.arrayContaining([
+        expect.objectContaining({
+          user_id: null,
+          course_id: 'moodle-course-1', // looked up via section_id
+        }),
+      ]),
     );
   });
 });

--- a/src/lib/actions/__tests__/document-versions-rpc.integration.test.ts
+++ b/src/lib/actions/__tests__/document-versions-rpc.integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Integration tests for the two SECURITY DEFINER RPCs that power version
+ * history:
+ *
+ *   - public.create_document_version(p_document_id, p_trigger)
+ *   - public.restore_document_version(p_version_id)
+ *
+ * The existing `document-versions.integration.test.ts` covers the table
+ * shape and cascade behavior but explicitly NOT these RPCs, because they
+ * use `auth.uid()` and need a real authenticated session.
+ *
+ * We use `createUserClient` (anon-key client signed in as TEST_USER_A) so
+ * the RPCs see a real JWT. SECURITY DEFINER executes with elevated
+ * privileges but reads `auth.uid()` from the request JWT, so the
+ * ownership checks behave as they would in production.
+ *
+ * Tested invariants:
+ *   - create_document_version inserts a row with the document's current
+ *     content/title/trigger and the calling user's user_id
+ *   - 8-version ring-buffer cap: the 9th call prunes the oldest, never
+ *     leaves >8 versions for a single document
+ *   - create_document_version on a doc owned by a different user raises
+ *     "Document not found" (RLS-style ownership check inside the RPC)
+ *   - restore_document_version atomically (a) inserts a `before_restore`
+ *     snapshot of the current doc, (b) overwrites the doc with the
+ *     target version, and (c) leaves the table within the 8-row cap
+ *   - restore_document_version on a version owned by a different user
+ *     raises "Version not found"
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+const DOC_A = '7a000000-0000-0000-0000-00000000000a';
+const DOC_B = '7a000000-0000-0000-0000-00000000000b';
+
+function docContent(text: string) {
+  return {
+    type: 'doc',
+    content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+  };
+}
+
+async function seedDocAs(userId: string, docId: string, text: string) {
+  // Force a known starting state.
+  await admin.from('document_versions').delete().eq('document_id', docId);
+  await admin.from('documents').delete().eq('id', docId);
+  const { error } = await admin.from('documents').insert({
+    id: docId,
+    user_id: userId,
+    title: `Doc ${docId.slice(-4)}`,
+    subject: 'other',
+    canvas_type: 'blank',
+    content: docContent(text),
+    position: 0,
+  });
+  if (error) throw new Error(`seedDocAs: ${error.message}`);
+}
+
+async function cleanupAll() {
+  for (const id of [DOC_A, DOC_B]) {
+    await admin.from('document_versions').delete().eq('document_id', id);
+    await admin.from('documents').delete().eq('id', id);
+  }
+}
+
+describe('create_document_version RPC', () => {
+  let clientA: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    await cleanupAll();
+  });
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it("inserts a row that reflects the document's current state and the caller's user_id", async () => {
+    await seedDocAs(TEST_USER_A.id, DOC_A, 'state-1');
+
+    const { data, error } = await clientA.rpc('create_document_version', {
+      p_document_id: DOC_A,
+      p_trigger: 'idle',
+    });
+    expect(error).toBeNull();
+    const inserted = (data as Array<{ version_id: string }>)[0];
+    expect(inserted?.version_id).toBeTruthy();
+
+    const { data: row } = await admin
+      .from('document_versions')
+      .select('document_id, user_id, trigger, content')
+      .eq('id', inserted.version_id)
+      .single();
+    expect(row).toMatchObject({
+      document_id: DOC_A,
+      user_id: TEST_USER_A.id,
+      trigger: 'idle',
+    });
+    expect(JSON.stringify(row!.content)).toContain('state-1');
+  });
+
+  it('enforces the 8-version ring buffer (9th call prunes the oldest)', async () => {
+    await seedDocAs(TEST_USER_A.id, DOC_A, 'state-cap');
+
+    // Fire 9 calls back-to-back. Each one re-reads the document's current
+    // state (which doesn't change here), so they will be created with the
+    // same content but distinct ids and timestamps.
+    for (let i = 0; i < 9; i++) {
+      const { error } = await clientA.rpc('create_document_version', {
+        p_document_id: DOC_A,
+        p_trigger: 'idle',
+      });
+      expect(error).toBeNull();
+      // Small spacing to guarantee strictly-increasing created_at so the
+      // "ORDER BY created_at ASC LIMIT 1" prune is deterministic.
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    const { count } = await admin
+      .from('document_versions')
+      .select('id', { count: 'exact', head: true })
+      .eq('document_id', DOC_A);
+    expect(count).toBe(8);
+  });
+
+  it('raises "Document not found" when calling on a doc owned by another user', async () => {
+    await seedDocAs(TEST_USER_B.id, DOC_B, 'B-only');
+
+    const { error } = await clientA.rpc('create_document_version', {
+      p_document_id: DOC_B,
+      p_trigger: 'idle',
+    });
+    // The ownership check inside the RPC raises an exception; supabase-js
+    // surfaces it on `error.message`.
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/Document not found/);
+
+    // …and the call had no side-effects.
+    const { count } = await admin
+      .from('document_versions')
+      .select('id', { count: 'exact', head: true })
+      .eq('document_id', DOC_B);
+    expect(count).toBe(0);
+  });
+});
+
+describe('restore_document_version RPC', () => {
+  let clientA: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    await cleanupAll();
+  });
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it('atomically creates a before_restore snapshot AND overwrites the document', async () => {
+    // Start with a doc at V3 and an explicit V1 in history.
+    await seedDocAs(TEST_USER_A.id, DOC_A, 'V3-current');
+
+    const { data: v1Insert } = await admin
+      .from('document_versions')
+      .insert({
+        document_id: DOC_A,
+        user_id: TEST_USER_A.id,
+        title: 'V1',
+        content: docContent('V1-original'),
+        trigger: 'idle',
+      })
+      .select('id')
+      .single();
+    const v1Id = v1Insert!.id as string;
+
+    const { error } = await clientA.rpc('restore_document_version', {
+      p_version_id: v1Id,
+    });
+    expect(error).toBeNull();
+
+    // 1. The document's content is now V1.
+    const { data: doc } = await admin
+      .from('documents')
+      .select('content')
+      .eq('id', DOC_A)
+      .single();
+    expect(JSON.stringify(doc!.content)).toContain('V1-original');
+
+    // 2. A "before_restore" snapshot of the OLD V3 state was created in
+    //    the same transaction — this is the safety net that lets a user
+    //    undo an unwanted restore.
+    const { data: snapshots } = await admin
+      .from('document_versions')
+      .select('content, trigger')
+      .eq('document_id', DOC_A)
+      .eq('trigger', 'before_restore');
+    expect(snapshots).toHaveLength(1);
+    expect(JSON.stringify(snapshots![0].content)).toContain('V3-current');
+  });
+
+  it('raises "Version not found" when calling with a version owned by another user', async () => {
+    await seedDocAs(TEST_USER_B.id, DOC_B, 'B-only');
+    const { data: bVer } = await admin
+      .from('document_versions')
+      .insert({
+        document_id: DOC_B,
+        user_id: TEST_USER_B.id,
+        title: "B's version",
+        content: docContent("B's old text"),
+        trigger: 'idle',
+      })
+      .select('id')
+      .single();
+
+    const { error } = await clientA.rpc('restore_document_version', {
+      p_version_id: bVer!.id,
+    });
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/Version not found/);
+
+    // B's document is unchanged.
+    const { data: doc } = await admin
+      .from('documents')
+      .select('content')
+      .eq('id', DOC_B)
+      .single();
+    expect(JSON.stringify(doc!.content)).toContain('B-only');
+  });
+});

--- a/src/lib/actions/__tests__/moodle-sync.test.ts
+++ b/src/lib/actions/__tests__/moodle-sync.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({
+    auth: {
+      getUser: vi.fn(async () => ({
+        data: { user: { id: 'test-user-id' } },
+        error: null,
+      })),
+    },
+    from: vi.fn(() => ({
+      delete: vi.fn(() => ({
+        eq: vi.fn(function eq1() {
+          return {
+            eq: vi.fn(async () => ({ error: null })),
+          };
+        }),
+      })),
+    })),
+  })),
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+import { removeMoodleFileFromNotebook } from '../moodle-sync';
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('removeMoodleFileFromNotebook', () => {
+  it('deletes the user_file_imports row scoped to the current user', async () => {
+    await removeMoodleFileFromNotebook('file-1', 'course-1');
+
+    expect(revalidatePath).toHaveBeenCalledWith('/dashboard/courses/course-1');
+  });
+
+  it('rejects unauthenticated callers', async () => {
+    vi.mocked(createClient).mockResolvedValueOnce({
+      auth: {
+        getUser: vi.fn(async () => ({
+          data: { user: null },
+          error: null,
+        })),
+      },
+      from: vi.fn(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    await expect(
+      removeMoodleFileFromNotebook('file-1', 'course-1'),
+    ).rejects.toThrow('Unauthorized');
+  });
+});

--- a/src/lib/actions/ai-context.ts
+++ b/src/lib/actions/ai-context.ts
@@ -79,6 +79,7 @@ export type QuestionResult = {
     sourceName: string;
     weekId: string | null;
     pageRange: string | null;
+    signedUrl: string | null;
   }>;
   model: 'flash' | 'pro';
   cached: boolean;
@@ -422,6 +423,7 @@ export async function askQuestion(
         sourceName: r.sourceName,
         weekId: r.weekId,
         pageRange: null,
+        signedUrl: null,
       });
     }
   }
@@ -549,6 +551,7 @@ export async function buildAiContext(params: QuestionParams): Promise<{
   sources: QuestionResult['sources'];
 }> {
   await getAuthUserId();
+  const supabase = await createClient();
   const {
     question,
     courseId,
@@ -577,6 +580,7 @@ export async function buildAiContext(params: QuestionParams): Promise<{
 
   const contextTexts: string[] = [];
   const sources: QuestionResult['sources'] = [];
+  const sourceIds: { sourceId: string; sourceType: string; idx: number }[] = [];
   const seen = new Set<string>();
 
   for (const r of results) {
@@ -588,9 +592,74 @@ export async function buildAiContext(params: QuestionParams): Promise<{
         sourceName: r.sourceName,
         weekId: r.weekId,
         pageRange: null,
+        signedUrl: null, // populated by the URL-attach block below
+      });
+      sourceIds.push({
+        sourceId: r.sourceId,
+        sourceType: r.sourceType,
+        idx: sources.length - 1,
       });
     }
   }
+
+  // Batch-fetch storage paths per source type, then generate signed URLs
+  // in parallel. If anything fails, leave signedUrl null — the chat
+  // falls back to a non-clickable badge.
+  const moodleIds = sourceIds
+    .filter((s) => s.sourceType === 'moodle_file')
+    .map((s) => s.sourceId);
+  const materialIds = sourceIds
+    .filter((s) => s.sourceType === 'course_material')
+    .map((s) => s.sourceId);
+
+  const admin = createAdminClient();
+  const moodlePaths: Record<string, string> = {};
+  const materialPaths: Record<string, string> = {};
+
+  if (moodleIds.length > 0) {
+    const { data } = await admin
+      .from('moodle_files')
+      .select('id, storage_path')
+      .in('id', moodleIds);
+    for (const row of (data ?? []) as {
+      id: string;
+      storage_path: string | null;
+    }[]) {
+      if (row.storage_path) moodlePaths[row.id] = row.storage_path;
+    }
+  }
+  if (materialIds.length > 0) {
+    const { data } = await supabase
+      .from('course_materials')
+      .select('id, storage_path')
+      .in('id', materialIds);
+    for (const row of (data ?? []) as { id: string; storage_path: string }[]) {
+      materialPaths[row.id] = row.storage_path;
+    }
+  }
+
+  await Promise.all(
+    sourceIds.map(async ({ sourceId, sourceType, idx }) => {
+      const bucket =
+        sourceType === 'moodle_file'
+          ? 'moodle-materials'
+          : sourceType === 'course_material'
+            ? 'course-materials'
+            : null;
+      const path =
+        sourceType === 'moodle_file'
+          ? moodlePaths[sourceId]
+          : sourceType === 'course_material'
+            ? materialPaths[sourceId]
+            : null;
+      if (!bucket || !path) return;
+      const client = bucket === 'moodle-materials' ? admin : supabase;
+      const { data } = await client.storage
+        .from(bucket)
+        .createSignedUrl(path, 3600);
+      sources[idx].signedUrl = data?.signedUrl ?? null;
+    }),
+  );
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const contents: Array<{ role: string; parts: any[] }> = [];

--- a/src/lib/actions/ai-context.ts
+++ b/src/lib/actions/ai-context.ts
@@ -309,12 +309,44 @@ export async function searchContext(
   params: SearchParams,
 ): Promise<SearchResult[]> {
   const userId = await getAuthUserId();
+  const supabase = await createClient();
   const queryEmbedding = await embedQuery(params.query);
+
+  // Resolve Typenote course -> canonical moodle_courses.id (if synced).
+  // RLS restricts user_course_syncs to the caller, so no user_id filter
+  // needed here.
+  let moodleCourseId: string | null = null;
+  let importedMoodleFileIds: string[] | null = null;
+  if (params.courseId) {
+    const { data: sync } = await supabase
+      .from('user_course_syncs')
+      .select('moodle_course_id')
+      .eq('course_id', params.courseId)
+      .maybeSingle();
+    moodleCourseId =
+      (sync as { moodle_course_id: string | null } | null)
+        ?.moodle_course_id ?? null;
+
+    if (moodleCourseId) {
+      // Fetch the user's notebook — the set of moodle files they have
+      // chosen to include. user_file_imports SELECT policy restricts
+      // to the caller already.
+      const { data: imports } = await supabase
+        .from('user_file_imports')
+        .select('moodle_file_id')
+        .eq('status', 'imported');
+      importedMoodleFileIds = (
+        (imports as { moodle_file_id: string }[] | null) ?? []
+      ).map((i) => i.moodle_file_id);
+    }
+  }
 
   const matches: MatchResult[] = await matchEmbeddings({
     queryEmbedding,
     userId,
     courseId: params.courseId,
+    moodleCourseId,
+    importedMoodleFileIds,
     weekId: params.weekId ?? null,
     matchCount: params.maxResults ?? 8,
   });

--- a/src/lib/actions/ai-context.ts
+++ b/src/lib/actions/ai-context.ts
@@ -131,7 +131,7 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
 
       const { data: fileRow, error: fileErr } = await admin
         .from('moodle_files')
-        .select('storage_path, file_name, mime_type')
+        .select('storage_path, file_name, mime_type, section_id')
         .eq('id', source.fileId)
         .single();
 
@@ -144,6 +144,25 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
         };
       }
 
+      // Look up canonical moodle_courses.id via the section. This is the file's
+      // upstream home and stays stable across users — using it on the embedding
+      // row makes the same file findable for everyone who imports it.
+      const { data: sectionRow, error: sectionErr } = await admin
+        .from('moodle_sections')
+        .select('course_id')
+        .eq('id', fileRow.section_id)
+        .single();
+
+      if (sectionErr || !sectionRow?.course_id) {
+        return {
+          success: false,
+          segmentsIndexed: 0,
+          skipped: false,
+          error: 'Moodle section not found for file',
+        };
+      }
+
+      courseId = sectionRow.course_id;
       sourceName = fileRow.file_name;
       mimeType = fileRow.mime_type ?? 'application/octet-stream';
       storageBucket = 'moodle-materials';

--- a/src/lib/actions/ai-context.ts
+++ b/src/lib/actions/ai-context.ts
@@ -320,20 +320,27 @@ export async function searchContext(
   if (params.courseId) {
     const { data: sync } = await supabase
       .from('user_course_syncs')
-      .select('moodle_course_id')
+      .select('id, moodle_course_id')
       .eq('course_id', params.courseId)
       .maybeSingle();
-    moodleCourseId =
-      (sync as { moodle_course_id: string | null } | null)
-        ?.moodle_course_id ?? null;
+    const syncRow = sync as {
+      id: string;
+      moodle_course_id: string | null;
+    } | null;
+    moodleCourseId = syncRow?.moodle_course_id ?? null;
+    const syncId = syncRow?.id ?? null;
 
-    if (moodleCourseId) {
-      // Fetch the user's notebook — the set of moodle files they have
-      // chosen to include. user_file_imports SELECT policy restricts
-      // to the caller already.
+    if (moodleCourseId && syncId) {
+      // Fetch the user's notebook for THIS course — files they imported
+      // into the current sync, not every file they ever imported across
+      // every course. The SQL function also re-filters by
+      // ce.course_id = match_moodle_course_id, but scoping here keeps
+      // the allowlist tight and avoids dragging unrelated file ids
+      // across the wire.
       const { data: imports } = await supabase
         .from('user_file_imports')
         .select('moodle_file_id')
+        .eq('sync_id', syncId)
         .eq('status', 'imported');
       importedMoodleFileIds = (
         (imports as { moodle_file_id: string }[] | null) ?? []

--- a/src/lib/actions/course-weeks-materials.integration.test.ts
+++ b/src/lib/actions/course-weeks-materials.integration.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Integration tests for `course-weeks.ts` and `course-materials.ts` schema
+ * behavior — the parts the server actions rely on but that no other test
+ * exercises directly.
+ *
+ * Risk surfaces:
+ *
+ *   - UNIQUE(course_id, week_number) — prevents two "Week 1" rows in the same
+ *     course. createCourseWeek computes `max + 1` to avoid this, but the
+ *     constraint is the actual guarantee — pinning it ensures any future
+ *     auto-numbering bug fails loudly instead of silently.
+ *
+ *   - course_weeks.course_id CASCADE — deleting a course removes its weeks.
+ *   - course_materials.week_id CASCADE — deleting a week removes its materials.
+ *
+ *   - documents.week_id ON DELETE SET NULL — deleting a week must NOT delete
+ *     the documents in it; they keep their course_id. Contrast with
+ *     documents.course_id CASCADE — week-deletion is a re-organization,
+ *     course-deletion is destructive.
+ *
+ *   - chk_week_requires_course — week_id cannot be set without course_id.
+ *
+ *   - course_materials.category CHECK ('material' | 'homework').
+ *
+ *   - RLS USING on UPDATE/DELETE for both tables.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  TEST_USER_ID,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+const COURSE_ID = '7b000000-0000-0000-0000-000000000001';
+const WEEK_1_ID = '7b000000-0000-0000-0000-000000000002';
+const WEEK_2_ID = '7b000000-0000-0000-0000-000000000003';
+const MATERIAL_ID = '7b000000-0000-0000-0000-000000000010';
+const DOC_IN_WEEK_ID = '7b000000-0000-0000-0000-000000000020';
+const USER_B_COURSE_ID = '7b000000-0000-0000-0000-0000000000b0';
+const USER_B_WEEK_ID = '7b000000-0000-0000-0000-0000000000b1';
+const USER_B_MATERIAL_ID = '7b000000-0000-0000-0000-0000000000b2';
+
+const allTestIds = [
+  COURSE_ID,
+  WEEK_1_ID,
+  WEEK_2_ID,
+  MATERIAL_ID,
+  DOC_IN_WEEK_ID,
+  USER_B_COURSE_ID,
+  USER_B_WEEK_ID,
+  USER_B_MATERIAL_ID,
+];
+
+async function cleanupAll(): Promise<void> {
+  await admin.from('course_materials').delete().in('id', allTestIds);
+  await admin.from('course_weeks').delete().in('id', allTestIds);
+  await admin.from('documents').delete().in('id', allTestIds);
+  await admin.from('courses').delete().in('id', allTestIds);
+}
+
+async function seedCourse(courseId = COURSE_ID, userId = TEST_USER_ID) {
+  await admin.from('courses').insert({
+    id: courseId,
+    user_id: userId,
+    name: 'Test Course',
+    color: '#000000',
+    position: 0,
+  });
+}
+
+describe('course_weeks — schema behavior', () => {
+  beforeAll(cleanupAll);
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it('createCourseWeek: round-trips course_id/week_number/topic', async () => {
+    await seedCourse();
+
+    const { error } = await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+      topic: 'Introduction',
+    });
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('*')
+      .eq('id', WEEK_1_ID)
+      .single();
+    expect(data).toMatchObject({
+      course_id: COURSE_ID,
+      week_number: 1,
+      topic: 'Introduction',
+    });
+  });
+
+  it('UNIQUE(course_id, week_number) rejects a duplicate Week 1', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('course_weeks').insert({
+      id: WEEK_2_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    expect(error).not.toBeNull();
+    // Supabase surfaces the constraint name in error.message
+    expect(error!.message).toMatch(/duplicate|unique/i);
+  });
+
+  it('deleting a course CASCADES to its weeks (FK course_weeks.course_id ON DELETE CASCADE)', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    await admin.from('courses').delete().eq('id', COURSE_ID);
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('id')
+      .eq('id', WEEK_1_ID);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('deleting a week sets documents.week_id NULL but keeps course_id (re-organization, not destructive)', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+    await admin.from('documents').insert({
+      id: DOC_IN_WEEK_ID,
+      user_id: TEST_USER_ID,
+      course_id: COURSE_ID,
+      week_id: WEEK_1_ID,
+      title: 'Doc in week',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    await admin.from('course_weeks').delete().eq('id', WEEK_1_ID);
+
+    const { data } = await admin
+      .from('documents')
+      .select('id, week_id, course_id')
+      .eq('id', DOC_IN_WEEK_ID)
+      .single();
+    // Doc survives — its week_id is null, course_id still set.
+    expect(data).not.toBeNull();
+    expect(data!.week_id).toBeNull();
+    expect(data!.course_id).toBe(COURSE_ID);
+  });
+
+  it('chk_week_requires_course rejects a doc with week_id but no course_id', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('documents').insert({
+      id: DOC_IN_WEEK_ID,
+      user_id: TEST_USER_ID,
+      course_id: null,
+      week_id: WEEK_1_ID,
+      title: 'Should fail',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/chk_week_requires_course/i);
+  });
+});
+
+describe('course_materials — schema behavior', () => {
+  beforeAll(cleanupAll);
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it('createCourseMaterial: round-trips required fields', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_1_ID,
+      user_id: TEST_USER_ID,
+      category: 'material',
+      storage_path: `${TEST_USER_ID}/lec01.pdf`,
+      file_name: 'lec01.pdf',
+      label: 'Lecture 1',
+      file_size: 4096,
+      mime_type: 'application/pdf',
+    });
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('course_materials')
+      .select('*')
+      .eq('id', MATERIAL_ID)
+      .single();
+    expect(data).toMatchObject({
+      week_id: WEEK_1_ID,
+      category: 'material',
+      file_name: 'lec01.pdf',
+      label: 'Lecture 1',
+    });
+  });
+
+  it("category CHECK constraint rejects values other than 'material' | 'homework'", async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+
+    const { error } = await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_1_ID,
+      user_id: TEST_USER_ID,
+      category: 'lecture-notes', // not allowed
+      storage_path: `${TEST_USER_ID}/bad.pdf`,
+      file_name: 'bad.pdf',
+      file_size: 1,
+      mime_type: 'application/pdf',
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/check|category/i);
+  });
+
+  it('deleting a week CASCADES to its materials (FK course_materials.week_id ON DELETE CASCADE)', async () => {
+    await seedCourse();
+    await admin.from('course_weeks').insert({
+      id: WEEK_1_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+    });
+    await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_1_ID,
+      user_id: TEST_USER_ID,
+      category: 'material',
+      storage_path: `${TEST_USER_ID}/x.pdf`,
+      file_name: 'x.pdf',
+      file_size: 1,
+      mime_type: 'application/pdf',
+    });
+
+    await admin.from('course_weeks').delete().eq('id', WEEK_1_ID);
+
+    const { data } = await admin
+      .from('course_materials')
+      .select('id')
+      .eq('id', MATERIAL_ID);
+    expect(data ?? []).toHaveLength(0);
+  });
+});
+
+describe('course_weeks + course_materials — RLS write enforcement', () => {
+  let clientA: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+
+    await admin.from('course_materials').delete().eq('id', USER_B_MATERIAL_ID);
+    await admin.from('course_weeks').delete().eq('id', USER_B_WEEK_ID);
+    await admin.from('courses').delete().eq('id', USER_B_COURSE_ID);
+
+    await admin.from('courses').insert({
+      id: USER_B_COURSE_ID,
+      user_id: TEST_USER_B.id,
+      name: "B's course",
+      color: '#0000FF',
+      position: 0,
+    });
+    await admin.from('course_weeks').insert({
+      id: USER_B_WEEK_ID,
+      course_id: USER_B_COURSE_ID,
+      user_id: TEST_USER_B.id,
+      week_number: 1,
+      topic: "B's week",
+    });
+    await admin.from('course_materials').insert({
+      id: USER_B_MATERIAL_ID,
+      week_id: USER_B_WEEK_ID,
+      user_id: TEST_USER_B.id,
+      category: 'homework',
+      storage_path: `${TEST_USER_B.id}/private.pdf`,
+      file_name: 'private.pdf',
+      file_size: 1,
+      mime_type: 'application/pdf',
+    });
+  });
+
+  afterAll(async () => {
+    await admin.from('course_materials').delete().eq('id', USER_B_MATERIAL_ID);
+    await admin.from('course_weeks').delete().eq('id', USER_B_WEEK_ID);
+    await admin.from('courses').delete().eq('id', USER_B_COURSE_ID);
+  });
+
+  it("User A's UPDATE on User B's course_week affects 0 rows", async () => {
+    await clientA
+      .from('course_weeks')
+      .update({ topic: 'hacked-by-a' })
+      .eq('id', USER_B_WEEK_ID);
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('topic')
+      .eq('id', USER_B_WEEK_ID)
+      .single();
+    expect(data!.topic).toBe("B's week");
+  });
+
+  it("User A's DELETE on User B's course_week affects 0 rows", async () => {
+    await clientA.from('course_weeks').delete().eq('id', USER_B_WEEK_ID);
+
+    const { data } = await admin
+      .from('course_weeks')
+      .select('id')
+      .eq('id', USER_B_WEEK_ID);
+    expect(data ?? []).toHaveLength(1);
+  });
+
+  it("User A's DELETE on User B's course_material affects 0 rows", async () => {
+    await clientA
+      .from('course_materials')
+      .delete()
+      .eq('id', USER_B_MATERIAL_ID);
+
+    const { data } = await admin
+      .from('course_materials')
+      .select('id')
+      .eq('id', USER_B_MATERIAL_ID);
+    expect(data ?? []).toHaveLength(1);
+  });
+});

--- a/src/lib/actions/courses.integration.test.ts
+++ b/src/lib/actions/courses.integration.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Integration tests for the schema behavior `courses.ts` server actions rely on.
+ *
+ * Key risk surfaces (NOT covered by existing tests):
+ *
+ *   - `courses.folder_id` references `folders(id) ON DELETE SET NULL`.
+ *     Deleting a folder must NOT delete courses inside it; they move to root.
+ *
+ *   - `documents.course_id` references `courses(id) ON DELETE CASCADE`.
+ *     This is the OPPOSITE of `documents.folder_id` (SET NULL). Deleting a
+ *     course deletes every document inside it — by design — because a course
+ *     deletion is destructive, not a re-organization. This test pins that
+ *     contract so it can't silently change.
+ *
+ *   - 3-level cascade: deleting a course must also delete its course_weeks
+ *     and (transitively) course_materials.
+ *
+ *   - `documents_folder_or_course` CHECK constraint prevents a row from being
+ *     in both a folder and a course simultaneously.
+ *
+ *   - RLS USING clause on UPDATE/DELETE — cross-user writes must affect 0
+ *     rows. The existing `rls-isolation` test only covers SELECT.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  TEST_USER_ID,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+const COURSE_ID = '7c000000-0000-0000-0000-000000000001';
+const WEEK_ID = '7c000000-0000-0000-0000-000000000002';
+const MATERIAL_ID = '7c000000-0000-0000-0000-000000000003';
+const DOC_IN_COURSE_ID = '7c000000-0000-0000-0000-000000000010';
+const FOLDER_ID = '7c000000-0000-0000-0000-000000000020';
+const USER_B_COURSE_ID = '7c000000-0000-0000-0000-0000000000b1';
+
+const allTestIds = [
+  COURSE_ID,
+  WEEK_ID,
+  MATERIAL_ID,
+  DOC_IN_COURSE_ID,
+  FOLDER_ID,
+  USER_B_COURSE_ID,
+];
+
+async function cleanupAll(): Promise<void> {
+  // Leaves before roots: materials -> weeks -> docs -> courses -> folders.
+  // Even though FKs cascade, deleting leaves first keeps cleanup idempotent
+  // across partial-failure reruns.
+  await admin.from('course_materials').delete().in('id', allTestIds);
+  await admin.from('course_weeks').delete().in('id', allTestIds);
+  await admin.from('documents').delete().in('id', allTestIds);
+  await admin.from('courses').delete().in('id', allTestIds);
+  await admin.from('folders').delete().in('id', allTestIds);
+}
+
+describe('courses — schema behavior backing courses.ts server actions', () => {
+  beforeAll(cleanupAll);
+  afterAll(cleanupAll);
+  afterEach(cleanupAll);
+
+  it('createCourse: round-trips name/color/folder_id', async () => {
+    const { error } = await admin.from('courses').insert({
+      id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      name: 'CS101',
+      color: '#3B82F6',
+      folder_id: null,
+      position: 0,
+    });
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('courses')
+      .select('*')
+      .eq('id', COURSE_ID)
+      .single();
+    expect(data).toMatchObject({
+      name: 'CS101',
+      color: '#3B82F6',
+      folder_id: null,
+      user_id: TEST_USER_ID,
+    });
+  });
+
+  it('updateCourse: updated_at trigger fires when name/color change', async () => {
+    await admin.from('courses').insert({
+      id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      name: 'Old',
+      color: '#000000',
+      position: 0,
+    });
+
+    const { data: before } = await admin
+      .from('courses')
+      .select('updated_at')
+      .eq('id', COURSE_ID)
+      .single();
+    const originalUpdatedAt = before!.updated_at as string;
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    await admin
+      .from('courses')
+      .update({ name: 'New', color: '#FFFFFF' })
+      .eq('id', COURSE_ID);
+
+    const { data: after } = await admin
+      .from('courses')
+      .select('name, color, updated_at')
+      .eq('id', COURSE_ID)
+      .single();
+    expect(after!.name).toBe('New');
+    expect(after!.color).toBe('#FFFFFF');
+    expect(new Date(after!.updated_at as string).getTime()).toBeGreaterThan(
+      new Date(originalUpdatedAt).getTime(),
+    );
+  });
+
+  it('deleting a course CASCADES to its weeks and materials (3-level cascade)', async () => {
+    await admin.from('courses').insert({
+      id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      name: 'Doomed',
+      color: '#000000',
+      position: 0,
+    });
+    await admin.from('course_weeks').insert({
+      id: WEEK_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      week_number: 1,
+      topic: 'Intro',
+    });
+    await admin.from('course_materials').insert({
+      id: MATERIAL_ID,
+      week_id: WEEK_ID,
+      user_id: TEST_USER_ID,
+      category: 'material',
+      storage_path: `${TEST_USER_ID}/test.pdf`,
+      file_name: 'test.pdf',
+      file_size: 1024,
+      mime_type: 'application/pdf',
+    });
+
+    await admin.from('courses').delete().eq('id', COURSE_ID);
+
+    const { data: weeks } = await admin
+      .from('course_weeks')
+      .select('id')
+      .eq('id', WEEK_ID);
+    const { data: materials } = await admin
+      .from('course_materials')
+      .select('id')
+      .eq('id', MATERIAL_ID);
+    expect(weeks ?? []).toHaveLength(0);
+    expect(materials ?? []).toHaveLength(0);
+  });
+
+  it('deleting a course CASCADES to its documents (course_id ON DELETE CASCADE — destructive by design)', async () => {
+    await admin.from('courses').insert({
+      id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      name: 'Doomed Course',
+      color: '#000000',
+      position: 0,
+    });
+    await admin.from('documents').insert({
+      id: DOC_IN_COURSE_ID,
+      user_id: TEST_USER_ID,
+      course_id: COURSE_ID,
+      title: 'Doc in course',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    await admin.from('courses').delete().eq('id', COURSE_ID);
+
+    const { data } = await admin
+      .from('documents')
+      .select('id')
+      .eq('id', DOC_IN_COURSE_ID);
+    // CASCADE: doc is gone. Contrast with deleting a *folder*, which
+    // sets folder_id NULL instead.
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('deleting a folder leaves the course intact with folder_id = null (ON DELETE SET NULL)', async () => {
+    await admin.from('folders').insert({
+      id: FOLDER_ID,
+      user_id: TEST_USER_ID,
+      name: 'Container',
+      color: '#000000',
+      position: 0,
+    });
+    await admin.from('courses').insert({
+      id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      folder_id: FOLDER_ID,
+      name: 'CS101',
+      color: '#000000',
+      position: 0,
+    });
+
+    await admin.from('folders').delete().eq('id', FOLDER_ID);
+
+    const { data } = await admin
+      .from('courses')
+      .select('id, folder_id')
+      .eq('id', COURSE_ID)
+      .single();
+    expect(data).not.toBeNull();
+    expect(data!.folder_id).toBeNull();
+  });
+
+  it('documents_folder_or_course CHECK constraint rejects a doc claiming both', async () => {
+    await admin.from('folders').insert({
+      id: FOLDER_ID,
+      user_id: TEST_USER_ID,
+      name: 'F',
+      color: '#000000',
+      position: 0,
+    });
+    await admin.from('courses').insert({
+      id: COURSE_ID,
+      user_id: TEST_USER_ID,
+      name: 'C',
+      color: '#000000',
+      position: 0,
+    });
+
+    const { error } = await admin.from('documents').insert({
+      id: DOC_IN_COURSE_ID,
+      user_id: TEST_USER_ID,
+      folder_id: FOLDER_ID,
+      course_id: COURSE_ID,
+      title: 'Should fail',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toMatch(/documents_folder_or_course/i);
+  });
+});
+
+describe('courses — RLS update/delete enforcement', () => {
+  let clientA: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    await admin.from('courses').delete().eq('id', USER_B_COURSE_ID);
+    await admin.from('courses').insert({
+      id: USER_B_COURSE_ID,
+      user_id: TEST_USER_B.id,
+      name: "B's private course",
+      color: '#0000FF',
+      position: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await admin.from('courses').delete().eq('id', USER_B_COURSE_ID);
+  });
+
+  it("User A's UPDATE on User B's course affects 0 rows", async () => {
+    await clientA
+      .from('courses')
+      .update({ name: 'hacked-by-a' })
+      .eq('id', USER_B_COURSE_ID);
+
+    const { data } = await admin
+      .from('courses')
+      .select('name')
+      .eq('id', USER_B_COURSE_ID)
+      .single();
+    expect(data!.name).toBe("B's private course");
+  });
+
+  it("User A's DELETE on User B's course affects 0 rows", async () => {
+    await clientA.from('courses').delete().eq('id', USER_B_COURSE_ID);
+
+    const { data } = await admin
+      .from('courses')
+      .select('id')
+      .eq('id', USER_B_COURSE_ID);
+    expect(data ?? []).toHaveLength(1);
+  });
+});

--- a/src/lib/actions/folders.integration.test.ts
+++ b/src/lib/actions/folders.integration.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Integration tests for folder behavior the `folders.ts` server actions rely on.
+ *
+ * The server actions themselves are thin wrappers over Supabase CRUD — the
+ * interesting and risky behavior lives in the schema:
+ *
+ *   - `folders.parent_id` references `folders(id) ON DELETE CASCADE`. Deleting
+ *     a parent folder must remove the subtree.
+ *   - `documents.folder_id` references `folders(id) ON DELETE SET NULL`.
+ *     Deleting a folder must NOT delete the documents in it; it must leave them
+ *     in "root" (folder_id = null).
+ *   - RLS update/delete by a non-owner must affect zero rows. The
+ *     `rls-isolation` integration test only verifies SELECT — it does not
+ *     verify the WITH-CHECK USING clause on UPDATE/DELETE.
+ *   - The `updated_at` trigger must fire on UPDATE.
+ *
+ * Tests run against the real local Supabase via admin (service_role) and
+ * anon-key user clients, mirroring `documents.integration.test.ts` and
+ * `rls-isolation.integration.test.ts`.
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  TEST_USER_A,
+  TEST_USER_B,
+  TEST_USER_ID,
+  createAdminClient,
+  createUserClient,
+} from '@/test/supabase-client';
+
+const admin = createAdminClient();
+
+// High-range UUIDs so they don't collide with seeded folders or other tests.
+const ROOT_ID = '7d000000-0000-0000-0000-000000000001';
+const CHILD_ID = '7d000000-0000-0000-0000-000000000002';
+const GRANDCHILD_ID = '7d000000-0000-0000-0000-000000000003';
+const DOC_IN_FOLDER_ID = '7d000000-0000-0000-0000-000000000010';
+const USER_B_FOLDER_ID = '7d000000-0000-0000-0000-0000000000b1';
+
+const allTestIds = [
+  ROOT_ID,
+  CHILD_ID,
+  GRANDCHILD_ID,
+  DOC_IN_FOLDER_ID,
+  USER_B_FOLDER_ID,
+];
+
+async function cleanupAll(): Promise<void> {
+  // Documents reference folders ON DELETE SET NULL — they survive folder
+  // deletion, so delete docs explicitly.
+  await admin.from('documents').delete().in('id', allTestIds);
+  await admin.from('folders').delete().in('id', allTestIds);
+}
+
+describe('folders — schema behavior backing folders.ts server actions', () => {
+  beforeAll(async () => {
+    await cleanupAll();
+  });
+
+  afterAll(async () => {
+    await cleanupAll();
+  });
+
+  afterEach(async () => {
+    await cleanupAll();
+  });
+
+  it('createFolder: round-trip insert succeeds and round-trips name/color/parent_id', async () => {
+    const { error } = await admin.from('folders').insert({
+      id: ROOT_ID,
+      user_id: TEST_USER_ID,
+      name: 'Calculus',
+      color: '#FF0000',
+      parent_id: null,
+      position: 0,
+    });
+    expect(error).toBeNull();
+
+    const { data } = await admin
+      .from('folders')
+      .select('*')
+      .eq('id', ROOT_ID)
+      .single();
+    expect(data).toMatchObject({
+      name: 'Calculus',
+      color: '#FF0000',
+      parent_id: null,
+      user_id: TEST_USER_ID,
+    });
+  });
+
+  it('updateFolder: updated_at trigger fires when name/color change', async () => {
+    await admin.from('folders').insert({
+      id: ROOT_ID,
+      user_id: TEST_USER_ID,
+      name: 'Old name',
+      color: '#000000',
+      position: 0,
+    });
+
+    const { data: before } = await admin
+      .from('folders')
+      .select('updated_at')
+      .eq('id', ROOT_ID)
+      .single();
+    const originalUpdatedAt = before!.updated_at as string;
+
+    // Sleep so the trigger writes a strictly-later timestamp. Postgres
+    // `now()` has microsecond precision, but two updates in the same
+    // statement-time can tie — a small delay is the simplest way to ensure
+    // the trigger fired AND committed a new value.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const { error } = await admin
+      .from('folders')
+      .update({ name: 'New name', color: '#00FF00' })
+      .eq('id', ROOT_ID);
+    expect(error).toBeNull();
+
+    const { data: after } = await admin
+      .from('folders')
+      .select('name, color, updated_at')
+      .eq('id', ROOT_ID)
+      .single();
+    expect(after!.name).toBe('New name');
+    expect(after!.color).toBe('#00FF00');
+    expect(new Date(after!.updated_at as string).getTime()).toBeGreaterThan(
+      new Date(originalUpdatedAt).getTime(),
+    );
+  });
+
+  it('deleteFolder: removes the folder row', async () => {
+    await admin.from('folders').insert({
+      id: ROOT_ID,
+      user_id: TEST_USER_ID,
+      name: 'Doomed',
+      color: '#000000',
+      position: 0,
+    });
+
+    await admin.from('folders').delete().eq('id', ROOT_ID);
+
+    const { data } = await admin.from('folders').select('id').eq('id', ROOT_ID);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('deleting a parent folder cascades to its descendants (parent_id ON DELETE CASCADE)', async () => {
+    // root -> child -> grandchild
+    await admin.from('folders').insert([
+      {
+        id: ROOT_ID,
+        user_id: TEST_USER_ID,
+        name: 'Root',
+        color: '#000000',
+        parent_id: null,
+        position: 0,
+      },
+      {
+        id: CHILD_ID,
+        user_id: TEST_USER_ID,
+        name: 'Child',
+        color: '#000000',
+        parent_id: ROOT_ID,
+        position: 0,
+      },
+      {
+        id: GRANDCHILD_ID,
+        user_id: TEST_USER_ID,
+        name: 'Grandchild',
+        color: '#000000',
+        parent_id: CHILD_ID,
+        position: 0,
+      },
+    ]);
+
+    await admin.from('folders').delete().eq('id', ROOT_ID);
+
+    const { data } = await admin
+      .from('folders')
+      .select('id')
+      .in('id', [ROOT_ID, CHILD_ID, GRANDCHILD_ID]);
+    expect(data ?? []).toHaveLength(0);
+  });
+
+  it('deleting a folder leaves its documents intact with folder_id = null (ON DELETE SET NULL)', async () => {
+    await admin.from('folders').insert({
+      id: ROOT_ID,
+      user_id: TEST_USER_ID,
+      name: 'Folder with docs',
+      color: '#000000',
+      position: 0,
+    });
+
+    await admin.from('documents').insert({
+      id: DOC_IN_FOLDER_ID,
+      user_id: TEST_USER_ID,
+      folder_id: ROOT_ID,
+      title: 'Doc that survives folder deletion',
+      subject: 'other',
+      canvas_type: 'blank',
+      position: 0,
+    });
+
+    await admin.from('folders').delete().eq('id', ROOT_ID);
+
+    const { data: doc } = await admin
+      .from('documents')
+      .select('id, folder_id')
+      .eq('id', DOC_IN_FOLDER_ID)
+      .single();
+    // Document MUST still exist…
+    expect(doc).not.toBeNull();
+    // …and have been moved to root (folder_id NULL).
+    expect(doc!.folder_id).toBeNull();
+  });
+});
+
+describe('folders — RLS update/delete enforcement', () => {
+  let clientA: SupabaseClient;
+
+  beforeAll(async () => {
+    clientA = await createUserClient(TEST_USER_A);
+    await admin.from('folders').delete().eq('id', USER_B_FOLDER_ID);
+
+    await admin.from('folders').insert({
+      id: USER_B_FOLDER_ID,
+      user_id: TEST_USER_B.id,
+      name: "B's private folder",
+      color: '#0000FF',
+      position: 0,
+    });
+  });
+
+  afterAll(async () => {
+    await admin.from('folders').delete().eq('id', USER_B_FOLDER_ID);
+  });
+
+  it("User A's UPDATE on User B's folder affects zero rows (RLS USING clause)", async () => {
+    await clientA
+      .from('folders')
+      .update({ name: 'hacked-by-a' })
+      .eq('id', USER_B_FOLDER_ID);
+
+    const { data } = await admin
+      .from('folders')
+      .select('name')
+      .eq('id', USER_B_FOLDER_ID)
+      .single();
+    expect(data!.name).toBe("B's private folder");
+  });
+
+  it("User A's DELETE on User B's folder affects zero rows (RLS USING clause)", async () => {
+    await clientA.from('folders').delete().eq('id', USER_B_FOLDER_ID);
+
+    const { data } = await admin
+      .from('folders')
+      .select('id')
+      .eq('id', USER_B_FOLDER_ID);
+    expect(data ?? []).toHaveLength(1);
+  });
+});

--- a/src/lib/actions/moodle-sync.ts
+++ b/src/lib/actions/moodle-sync.ts
@@ -317,3 +317,33 @@ export async function recordFileImports(
     importedCount: fileIds.length,
   };
 }
+
+/**
+ * Remove a Moodle file from the current user's notebook.
+ * Hard-deletes the user_file_imports row. The file remains in the
+ * shared registry and embeddings (other users may still reference it).
+ */
+export async function removeMoodleFileFromNotebook(
+  moodleFileId: string,
+  courseId: string,
+) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Unauthorized');
+
+  // RLS already restricts user_file_imports.delete to auth.uid() =
+  // user_id; the explicit .eq is belt-and-suspenders.
+  const { error } = await supabase
+    .from('user_file_imports')
+    .delete()
+    .eq('moodle_file_id', moodleFileId)
+    .eq('user_id', user.id);
+
+  if (error) throw new Error(error.message);
+
+  // Codebase convention: literal-path revalidation (see
+  // src/lib/actions/documents.ts:152).
+  revalidatePath('/dashboard/courses/' + courseId);
+}

--- a/src/lib/queries/__tests__/embeddings.integration.test.ts
+++ b/src/lib/queries/__tests__/embeddings.integration.test.ts
@@ -1,7 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createAdminClient, TEST_USER_ID } from '@/test/supabase-client';
-import { matchEmbeddings } from '../embeddings';
 
 const supabase = createAdminClient();
 
@@ -178,21 +177,6 @@ describe('content_embeddings table (v2 — 1536 dims, page segments)', () => {
   });
 });
 
-describe('matchEmbeddings new signature', () => {
-  it('accepts moodleCourseId and importedMoodleFileIds without throwing', async () => {
-    // Smoke test the new params are wired through the RPC; functional
-    // behavior is covered in subsequent tasks.
-    const result = await matchEmbeddings({
-      queryEmbedding: Array.from({ length: 1536 }, () => 0),
-      userId: TEST_USER_ID,
-      courseId: COURSE_ID,
-      moodleCourseId: null,
-      importedMoodleFileIds: null,
-    });
-    expect(Array.isArray(result)).toBe(true);
-  });
-});
-
 describe('per-user moodle_file access', () => {
   // These ids must match rows seeded in supabase/seed.sql. If they
   // don't exist yet, the inserts below will fail with FK errors and
@@ -212,23 +196,28 @@ describe('per-user moodle_file access', () => {
       .delete()
       .eq('source_id', MOODLE_FILE);
 
-    await supabase.from('content_embeddings').insert([
-      {
-        source_type: 'moodle_file',
-        source_id: MOODLE_FILE,
-        segment_index: 0,
-        page_start: null,
-        page_end: null,
-        segment_text: 'shared file content',
-        embedding: JSON.stringify(makeVector(1)),
-        user_id: null,
-        course_id: MOODLE_COURSE, // canonical, NOT a Typenote course id
-        week_id: null,
-        source_name: 'shared.pdf',
-        mime_type: 'application/pdf',
-        content_hash: 'test-hash-shared',
-      },
-    ]);
+    const { error: seedError } = await supabase
+      .from('content_embeddings')
+      .insert([
+        {
+          source_type: 'moodle_file',
+          source_id: MOODLE_FILE,
+          segment_index: 0,
+          page_start: null,
+          page_end: null,
+          segment_text: 'shared file content',
+          embedding: JSON.stringify(makeVector(1)),
+          user_id: null,
+          course_id: MOODLE_COURSE, // canonical, NOT a Typenote course id
+          week_id: null,
+          source_name: 'shared.pdf',
+          mime_type: 'application/pdf',
+          content_hash: 'test-hash-shared',
+        },
+      ]);
+    if (seedError) {
+      throw new Error(`Failed to seed test row: ${seedError.message}`);
+    }
   });
 
   afterAll(async () => {

--- a/src/lib/queries/__tests__/embeddings.integration.test.ts
+++ b/src/lib/queries/__tests__/embeddings.integration.test.ts
@@ -192,3 +192,96 @@ describe('matchEmbeddings new signature', () => {
     expect(Array.isArray(result)).toBe(true);
   });
 });
+
+describe('per-user moodle_file access', () => {
+  // These ids must match rows seeded in supabase/seed.sql. If they
+  // don't exist yet, the inserts below will fail with FK errors and
+  // a human should update the seed.
+  const USER_A = TEST_USER_ID;
+  const USER_B = 'b0000000-0000-0000-0000-000000000002';
+  const TYPENOTE_COURSE_A = COURSE_ID; // from seed
+  const TYPENOTE_COURSE_B = '30000000-0000-0000-0000-000000000002';
+  const MOODLE_COURSE = 'c0000000-0000-0000-0000-000000000001';
+  const MOODLE_FILE = '70000000-0000-0000-0000-000000000099';
+
+  beforeAll(async () => {
+    // Idempotent: clear any leftover state then insert one canonical
+    // embedding row keyed by the canonical moodle_courses.id.
+    await supabase
+      .from('content_embeddings')
+      .delete()
+      .eq('source_id', MOODLE_FILE);
+
+    await supabase.from('content_embeddings').insert([
+      {
+        source_type: 'moodle_file',
+        source_id: MOODLE_FILE,
+        segment_index: 0,
+        page_start: null,
+        page_end: null,
+        segment_text: 'shared file content',
+        embedding: JSON.stringify(makeVector(1)),
+        user_id: null,
+        course_id: MOODLE_COURSE, // canonical, NOT a Typenote course id
+        week_id: null,
+        source_name: 'shared.pdf',
+        mime_type: 'application/pdf',
+        content_hash: 'test-hash-shared',
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await supabase
+      .from('content_embeddings')
+      .delete()
+      .eq('source_id', MOODLE_FILE);
+  });
+
+  it('returns the row when the imported file is in the whitelist', async () => {
+    const { data, error } = await supabase.rpc('match_embeddings', {
+      query_embedding: JSON.stringify(makeVector(1)),
+      match_user_id: USER_A,
+      match_course_id: TYPENOTE_COURSE_A,
+      match_moodle_course_id: MOODLE_COURSE,
+      match_imported_moodle_file_ids: [MOODLE_FILE],
+      match_count: 8,
+      similarity_threshold: 0,
+    });
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect((data as { source_id: string }[])[0].source_id).toBe(MOODLE_FILE);
+  });
+
+  it('returns nothing when the imported list is empty', async () => {
+    const { data } = await supabase.rpc('match_embeddings', {
+      query_embedding: JSON.stringify(makeVector(1)),
+      match_user_id: USER_B,
+      match_course_id: TYPENOTE_COURSE_B,
+      match_moodle_course_id: MOODLE_COURSE,
+      match_imported_moodle_file_ids: [],
+      match_count: 8,
+      similarity_threshold: 0,
+    });
+    expect(data).toEqual([]);
+  });
+
+  it('returns nothing when the course is not Moodle-synced (no moodleCourseId)', async () => {
+    const { data } = await supabase.rpc('match_embeddings', {
+      query_embedding: JSON.stringify(makeVector(1)),
+      match_user_id: USER_A,
+      match_course_id: TYPENOTE_COURSE_A,
+      match_moodle_course_id: null,
+      match_imported_moodle_file_ids: null,
+      match_count: 8,
+      similarity_threshold: 0,
+    });
+    // course_material rows might match, but our seeded moodle_file row
+    // must NOT (the moodle branch doesn't fire without moodle_course_id).
+    expect(
+      ((data as { source_id: string }[] | null) ?? []).some(
+        (r) => r.source_id === MOODLE_FILE,
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/lib/queries/__tests__/embeddings.integration.test.ts
+++ b/src/lib/queries/__tests__/embeddings.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { createAdminClient, TEST_USER_ID } from '@/test/supabase-client';
+import { matchEmbeddings } from '../embeddings';
 
 const supabase = createAdminClient();
 
@@ -174,5 +175,20 @@ describe('content_embeddings table (v2 — 1536 dims, page segments)', () => {
       .eq('source_id', tempId);
 
     expect(data).toHaveLength(0);
+  });
+});
+
+describe('matchEmbeddings new signature', () => {
+  it('accepts moodleCourseId and importedMoodleFileIds without throwing', async () => {
+    // Smoke test the new params are wired through the RPC; functional
+    // behavior is covered in subsequent tasks.
+    const result = await matchEmbeddings({
+      queryEmbedding: Array.from({ length: 1536 }, () => 0),
+      userId: TEST_USER_ID,
+      courseId: COURSE_ID,
+      moodleCourseId: null,
+      importedMoodleFileIds: null,
+    });
+    expect(Array.isArray(result)).toBe(true);
   });
 });

--- a/src/lib/queries/embeddings.ts
+++ b/src/lib/queries/embeddings.ts
@@ -92,6 +92,8 @@ export async function matchEmbeddings(params: {
   queryEmbedding: number[];
   userId: string;
   courseId?: string | null;
+  moodleCourseId?: string | null;
+  importedMoodleFileIds?: string[] | null;
   weekId?: string | null;
   matchCount?: number;
   similarityThreshold?: number;
@@ -101,6 +103,8 @@ export async function matchEmbeddings(params: {
     query_embedding: JSON.stringify(params.queryEmbedding),
     match_user_id: params.userId,
     match_course_id: params.courseId ?? null,
+    match_moodle_course_id: params.moodleCourseId ?? null,
+    match_imported_moodle_file_ids: params.importedMoodleFileIds ?? null,
     match_week_id: params.weekId ?? null,
     match_count: params.matchCount ?? 8,
     similarity_threshold: params.similarityThreshold ?? 0.3,

--- a/supabase/migrations/20260522123000_per_user_material_access.sql
+++ b/supabase/migrations/20260522123000_per_user_material_access.sql
@@ -1,0 +1,92 @@
+-- Per-user material access in AI chat
+--
+-- Background: moodle_files is a shared registry (one row per file even
+-- when multiple users sync the same Moodle course). Embeddings used to
+-- be tied to the FIRST indexer's Typenote course_id, so only one user
+-- could ever find the file via RAG. This migration:
+--
+--   A. Repoints moodle_file embedding rows from <typenote course_id>
+--      to the canonical moodle_courses.id (reached via
+--      moodle_files.section_id -> moodle_sections.course_id).
+--
+--   B. Replaces match_embeddings with a version that handles two
+--      source-type branches and accepts an imported-file whitelist for
+--      per-user access enforcement.
+
+-- ---------------------------------------------------------------------------
+-- Step A: Backfill embedding course_id for moodle_file rows.
+-- ---------------------------------------------------------------------------
+update public.content_embeddings ce
+set course_id = ms.course_id
+from public.moodle_files mf
+join public.moodle_sections ms on ms.id = mf.section_id
+where ce.source_type = 'moodle_file'
+  and ce.source_id = mf.id
+  and ce.course_id is distinct from ms.course_id;
+
+-- ---------------------------------------------------------------------------
+-- Step B: Replace match_embeddings RPC.
+--
+-- 00014 registered the function with bare `vector` (not extensions.vector),
+-- so we drop using the exact same form to avoid leaving the old function
+-- alongside the new one.
+--
+-- LANGUAGE sql STABLE matches the original 00012 declaration (00014
+-- accidentally regressed to plpgsql). STABLE lets the planner cache
+-- function results within a single query, which matters because RAG
+-- hits this RPC on every chat turn.
+-- ---------------------------------------------------------------------------
+drop function if exists public.match_embeddings(
+  vector, uuid, uuid, uuid, integer, double precision
+);
+
+create or replace function public.match_embeddings(
+  query_embedding extensions.vector(1536),
+  match_user_id uuid,
+  match_course_id uuid default null,
+  match_moodle_course_id uuid default null,
+  match_imported_moodle_file_ids uuid[] default null,
+  match_week_id uuid default null,
+  match_count int default 8,
+  similarity_threshold float default 0.3
+)
+returns table (
+  id bigint,
+  source_type text,
+  source_id uuid,
+  source_name text,
+  segment_text text,
+  page_start integer,
+  page_end integer,
+  course_id uuid,
+  week_id uuid,
+  mime_type text,
+  similarity float
+)
+language sql stable
+as $$
+  select
+    ce.id, ce.source_type, ce.source_id, ce.source_name, ce.segment_text,
+    ce.page_start, ce.page_end, ce.course_id, ce.week_id, ce.mime_type,
+    1 - (ce.embedding <=> query_embedding) as similarity
+  from public.content_embeddings ce
+  where (ce.user_id = match_user_id or ce.user_id is null)
+    and (
+      -- course_material: keyed by Typenote course_id, uploader owns the row
+      (ce.source_type = 'course_material'
+        and match_course_id is not null
+        and ce.course_id = match_course_id)
+      or
+      -- moodle_file: keyed by moodle_courses.id (canonical); access is
+      -- whitelisted by the user's imported file set
+      (ce.source_type = 'moodle_file'
+        and match_moodle_course_id is not null
+        and ce.course_id = match_moodle_course_id
+        and (match_imported_moodle_file_ids is null
+             or ce.source_id = any(match_imported_moodle_file_ids)))
+    )
+    and (match_week_id is null or ce.week_id = match_week_id)
+    and 1 - (ce.embedding <=> query_embedding) > similarity_threshold
+  order by ce.embedding <=> query_embedding
+  limit match_count;
+$$;

--- a/supabase/migrations/20260522123000_per_user_material_access.sql
+++ b/supabase/migrations/20260522123000_per_user_material_access.sql
@@ -5,16 +5,32 @@
 -- be tied to the FIRST indexer's Typenote course_id, so only one user
 -- could ever find the file via RAG. This migration:
 --
---   A. Repoints moodle_file embedding rows from <typenote course_id>
+--   A. Drops the FK on content_embeddings.course_id (now a polymorphic
+--      reference: courses.id for course_material, moodle_courses.id for
+--      moodle_file).
+--
+--   B. Repoints moodle_file embedding rows from <typenote course_id>
 --      to the canonical moodle_courses.id (reached via
 --      moodle_files.section_id -> moodle_sections.course_id).
 --
---   B. Replaces match_embeddings with a version that handles two
+--   C. Replaces match_embeddings with a version that handles two
 --      source-type branches and accepts an imported-file whitelist for
 --      per-user access enforcement.
 
 -- ---------------------------------------------------------------------------
--- Step A: Backfill embedding course_id for moodle_file rows.
+-- Step A: Relax the course_id foreign key.
+--
+-- 00012 declared `course_id uuid references public.courses(id)`. With per-user
+-- access we now also store moodle_courses.id in this column for moodle_file
+-- rows, so the single-target FK no longer fits. Drop it; integrity is handled
+-- application-side (deletes cascade from the source registries via
+-- deleteEmbeddingsBySource and explicit cleanup paths).
+-- ---------------------------------------------------------------------------
+alter table public.content_embeddings
+  drop constraint if exists content_embeddings_course_id_fkey;
+
+-- ---------------------------------------------------------------------------
+-- Step B: Backfill embedding course_id for moodle_file rows.
 -- ---------------------------------------------------------------------------
 update public.content_embeddings ce
 set course_id = ms.course_id
@@ -25,7 +41,7 @@ where ce.source_type = 'moodle_file'
   and ce.course_id is distinct from ms.course_id;
 
 -- ---------------------------------------------------------------------------
--- Step B: Replace match_embeddings RPC.
+-- Step C: Replace match_embeddings RPC.
 --
 -- 00014 registered the function with bare `vector` (not extensions.vector),
 -- so we drop using the exact same form to avoid leaving the old function


### PR DESCRIPTION
## Summary

Promotes dev's content to main. This is dev's unique commits (post-divergence) rebased linearly onto current main. The direct dev → main PR (#188) was CONFLICTING because the two branches have diverged bidirectionally over time; this PR resolves that by replaying dev's commits onto main's tip so rebase-merge will work.

## Headline change

**AI chat per-user material access** (originally PR #187 / closed #184). Each user now sees the materials they imported via Moodle in AI chat, not just whoever synced the course first.

- Migration: drop FK on \`content_embeddings.course_id\` (now polymorphic), backfill moodle_file rows to canonical \`moodle_courses.id\`, replace \`match_embeddings\` RPC with per-source-type branches + per-user file whitelist.
- Trash button on each Moodle file row (remove from notebook).
- Clickable source citations in chat (when stored in Supabase Storage).

## Accumulated dev work also included

- Storage RLS integration tests
- Courses + folders integration test coverage
- Version-history RPC tests
- API auth / input validation tests
- /api/ai/search validation tests
- Markdown response XSS unit tests

## Test plan

- [ ] CI passes (lint, format, unit, integration, build, E2E)
- [ ] Vercel auto-deploys main on merge
- [ ] Manual verify two-user Moodle scenario in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)