### PR TITLE
fix(moodle): accept extension version >= minimum instead of exact match

### DIFF
--- a/extension/QUICKSTART.md
+++ b/extension/QUICKSTART.md
@@ -100,4 +100,4 @@ These exercise the failure paths. Run them before bumping to a new release.
   The manifest probably wasn't rebuilt after a change. Run `(cd extension && npm run build)` and reload the extension at `chrome://extensions`.
 
 - **"Update Extension" card.**
-  The loaded extension's manifest `version` doesn't match `EXPECTED_EXTENSION_VERSION` in `src/hooks/use-moodle-extension.ts`. Rebuild the extension or update the constant in lockstep.
+  The loaded extension's manifest `version` is _older_ than `MINIMUM_EXTENSION_VERSION` in `src/hooks/use-moodle-extension.ts`. Rebuild/reload the extension at or above that version (a newer version is accepted — the check is a minimum, not an exact match).

--- a/src/components/dashboard/moodle-connection-setup.test.tsx
+++ b/src/components/dashboard/moodle-connection-setup.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 
 vi.mock('@/hooks/use-moodle-extension', () => ({
   useMoodleExtension: vi.fn(),
-  EXPECTED_EXTENSION_VERSION: '0.2.0',
+  MINIMUM_EXTENSION_VERSION: '0.2.0',
 }));
 
 vi.mock('@/lib/actions/moodle-sync', () => ({

--- a/src/components/dashboard/moodle-sync-prompt.test.tsx
+++ b/src/components/dashboard/moodle-sync-prompt.test.tsx
@@ -4,7 +4,7 @@ import type { ExtensionState } from '@/hooks/use-moodle-extension';
 
 vi.mock('@/hooks/use-moodle-extension', () => ({
   useMoodleExtension: vi.fn(),
-  EXPECTED_EXTENSION_VERSION: '0.2.0',
+  MINIMUM_EXTENSION_VERSION: '0.2.0',
 }));
 
 import { useMoodleExtension } from '@/hooks/use-moodle-extension';

--- a/src/components/dashboard/moodle-sync-prompt.tsx
+++ b/src/components/dashboard/moodle-sync-prompt.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/card';
 import {
   useMoodleExtension,
-  EXPECTED_EXTENSION_VERSION,
+  MINIMUM_EXTENSION_VERSION,
 } from '@/hooks/use-moodle-extension';
 import { MoodleCardSkeleton } from './moodle-card-skeleton';
 import { MoodleConnectionSetup } from './moodle-connection-setup';
@@ -65,8 +65,8 @@ export function MoodleSyncPrompt({
           <CardTitle className="text-base">Moodle Integration</CardTitle>
           <CardDescription>
             Update the Typenote extension to continue syncing. Installed
-            version: <strong>{state.installedVersion}</strong>. Required:{' '}
-            <strong>{EXPECTED_EXTENSION_VERSION}</strong>.
+            version: <strong>{state.installedVersion}</strong>. Minimum
+            required: <strong>{MINIMUM_EXTENSION_VERSION}</strong> or newer.
           </CardDescription>
         </CardHeader>
         <CardContent>

--- a/src/hooks/use-moodle-extension.test.ts
+++ b/src/hooks/use-moodle-extension.test.ts
@@ -141,7 +141,7 @@ describe('useMoodleExtension', () => {
     expect(result.current.isInstalled).toBe(true);
   });
 
-  it('exposes state.status="version-mismatch" when ping returns a different version', async () => {
+  it('exposes state.status="version-mismatch" when the installed version is below the minimum', async () => {
     mockSendMessage.mockImplementation(
       (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
         callback({ success: true, data: { version: '0.1.0' } });
@@ -158,6 +158,25 @@ describe('useMoodleExtension', () => {
       installedVersion: '0.1.0',
     });
     expect(result.current.isInstalled).toBe(false);
+  });
+
+  it('treats a version NEWER than the minimum as installed (no mismatch)', async () => {
+    mockSendMessage.mockImplementation(
+      (_id: string, _msg: unknown, callback: (...args: unknown[]) => void) => {
+        callback({ success: true, data: { version: '0.3.0' } });
+      },
+    );
+
+    const { result } = renderHook(() => useMoodleExtension());
+    await waitFor(() =>
+      expect(result.current.state.status).not.toBe('checking'),
+    );
+
+    expect(result.current.state).toEqual({
+      status: 'installed',
+      version: '0.3.0',
+    });
+    expect(result.current.isInstalled).toBe(true);
   });
 
   it('falls back to "not-installed" when the PING response is malformed', async () => {

--- a/src/hooks/use-moodle-extension.ts
+++ b/src/hooks/use-moodle-extension.ts
@@ -1,9 +1,14 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
+import { isAtLeastVersion } from '@/lib/version';
 
 const EXTENSION_ID = process.env.NEXT_PUBLIC_EXTENSION_ID ?? '';
-export const EXPECTED_EXTENSION_VERSION = '0.2.0';
+// Lowest extension version the web app supports. The installed extension may
+// be this version OR NEWER — we no longer require an exact match, so a Web
+// Store auto-update that bumps the extension ahead of a web deploy (or vice
+// versa) doesn't block syncing during the rollout window.
+export const MINIMUM_EXTENSION_VERSION = '0.2.0';
 const PING_TIMEOUT_MS = 2_000;
 
 export type ExtensionState =
@@ -78,7 +83,7 @@ export function useMoodleExtension() {
         setState({ status: 'not-installed' });
         return;
       }
-      if (version !== EXPECTED_EXTENSION_VERSION) {
+      if (!isAtLeastVersion(version, MINIMUM_EXTENSION_VERSION)) {
         setState({ status: 'version-mismatch', installedVersion: version });
         return;
       }

--- a/src/lib/version.test.ts
+++ b/src/lib/version.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { isAtLeastVersion } from './version';
+
+describe('isAtLeastVersion', () => {
+  it('is true when the versions are equal', () => {
+    expect(isAtLeastVersion('0.2.0', '0.2.0')).toBe(true);
+  });
+
+  it('is true for a higher patch / minor / major', () => {
+    expect(isAtLeastVersion('0.2.1', '0.2.0')).toBe(true);
+    expect(isAtLeastVersion('0.3.0', '0.2.0')).toBe(true);
+    expect(isAtLeastVersion('1.0.0', '0.2.0')).toBe(true);
+  });
+
+  it('is false for a lower patch / minor', () => {
+    expect(isAtLeastVersion('0.2.0', '0.2.1')).toBe(false);
+    expect(isAtLeastVersion('0.1.9', '0.2.0')).toBe(false);
+  });
+
+  it('treats missing trailing segments as zero', () => {
+    expect(isAtLeastVersion('0.2', '0.2.0')).toBe(true);
+    expect(isAtLeastVersion('0.2.0', '0.2')).toBe(true);
+    expect(isAtLeastVersion('1', '0.2.0')).toBe(true);
+  });
+
+  it('does not compare segments lexically (10 > 9)', () => {
+    expect(isAtLeastVersion('0.10.0', '0.9.0')).toBe(true);
+  });
+});

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,0 +1,28 @@
+/**
+ * Compare two dot-separated numeric version strings (e.g. "0.2.0").
+ *
+ * Returns true when `installed` is the same as or newer than `minimum`.
+ * Comparison is per-segment numeric (so "0.10.0" > "0.9.0", unlike a string
+ * compare). Missing trailing segments are treated as 0, so "0.2" === "0.2.0".
+ * Non-numeric segments are coerced to 0 defensively rather than throwing.
+ */
+export function isAtLeastVersion(installed: string, minimum: string): boolean {
+  const parse = (v: string): number[] =>
+    v.split('.').map((part) => {
+      const n = Number.parseInt(part, 10);
+      return Number.isFinite(n) ? n : 0;
+    });
+
+  const a = parse(installed);
+  const b = parse(minimum);
+  const len = Math.max(a.length, b.length);
+
+  for (let i = 0; i < len; i++) {
+    const ai = a[i] ?? 0;
+    const bi = b[i] ?? 0;
+    if (ai > bi) return true;
+    if (ai < bi) return false;
+  }
+
+  return true; // all segments equal
+}


### PR DESCRIPTION
## Why

The web app gated Moodle sync on an **exact** extension-version match (`version !== EXPECTED_EXTENSION_VERSION` → blocking "Update Extension" card). The Chrome Web Store auto-updates users **gradually over hours**, but a web deploy flips **instantly** — so every extension version bump opened a window where `installed-ext ≠ deployed-web` and sync was **blocked** for those users. That made each future extension update a fragile, tightly-coordinated release.

## What

Switch to a **minimum**-version check: the installed extension may be the minimum **or newer**. Future bumps only need `MINIMUM_EXTENSION_VERSION` raised when a genuine breaking change lands, and the rollout window no longer blocks anyone.

- New pure helper `src/lib/version.ts` → `isAtLeastVersion(installed, minimum)` — per-segment **numeric** compare (so `0.10.0 > 0.9.0`), tolerant of short/garbage segments.
- Rename `EXPECTED_EXTENSION_VERSION` → `MINIMUM_EXTENSION_VERSION`; mismatch card copy → "Minimum required: X **or newer**".
- `QUICKSTART.md` troubleshooting note updated to the new semantics.

## Tests (TDD)
- `src/lib/version.test.ts` — equal / higher / lower / short-segment / non-lexical cases.
- `use-moodle-extension.test.ts` — new "newer version is installed, not a mismatch" case; existing **below-minimum** case still reports `version-mismatch`.

## Verified locally
- ✅ Unit 892/892 · ✅ Lint 0 errors · ✅ Prettier (changed files)
- ⏳ Integration + E2E run in CI (no Docker/Supabase locally).

Follow-up to #190 (the Chrome Web Store privacy/build-docs blockers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)