### PR TITLE
feat: Start Homework flow with exercise and material selection

### DIFF
--- a/specs/046-homework-ai-context/checklists/requirements.md
+++ b/specs/046-homework-ai-context/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Homework AI Context
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumptions section documents reasonable defaults (exercise from existing documents, educational AI guidance, existing quota system applies).

--- a/specs/046-homework-ai-context/contracts/api.md
+++ b/specs/046-homework-ai-context/contracts/api.md
@@ -1,0 +1,103 @@
+# API Contracts: Homework AI Context
+
+## Server Actions
+
+### `createHomeworkSession`
+
+Creates a homework document, session record, and material links in a single flow.
+
+**Input**:
+```ts
+{
+  courseId: string;
+  exerciseDocumentId: string;
+  materialRefs: Array<{
+    type: 'course_material' | 'personal_file' | 'document';
+    id: string;
+  }>;
+}
+```
+
+**Output**:
+```ts
+{
+  documentId: string;  // the newly created homework document
+  sessionId: string;   // the homework session record
+}
+```
+
+**Behavior**:
+1. Validates `courseId` belongs to the authenticated user
+2. Validates `exerciseDocumentId` belongs to the authenticated user and is in the same course
+3. Creates a new document with `course_id`, `purpose = 'homework'`, title = `"HW — {exercise title}"`
+4. Creates a `homework_sessions` row linking the new document to the exercise
+5. Creates `homework_session_materials` rows for each material reference
+6. Returns the new document ID for client-side navigation
+
+**Errors**: Throws if course/exercise not found, not owned by user, or DB insert fails.
+
+---
+
+### `getHomeworkContext`
+
+Fetches the homework session and associated materials for a document.
+
+**Input**:
+```ts
+{
+  documentId: string;
+}
+```
+
+**Output**:
+```ts
+HomeworkContext | null  // null if document has no homework session
+```
+
+Where `HomeworkContext` is:
+```ts
+{
+  session: HomeworkSession;
+  exerciseDocument: { id: string; title: string };
+  materials: Array<{
+    type: 'course_material' | 'personal_file' | 'document';
+    id: string;
+    name: string;
+  }>;
+}
+```
+
+**Behavior**:
+1. Queries `homework_sessions` by `document_id`
+2. If no session exists, returns `null`
+3. Fetches the exercise document title
+4. Fetches each material's display name from the appropriate source table based on `material_type`
+5. Returns the assembled `HomeworkContext`
+
+---
+
+## Extended API: `/api/ai/ask`
+
+### Request Body Extension
+
+The existing `/api/ai/ask` endpoint receives an additional optional field:
+
+```ts
+{
+  // ... existing fields ...
+  homeworkSessionId?: string;  // if present, server fetches exercise + material content
+}
+```
+
+### Behavior Change
+
+When `homeworkSessionId` is provided:
+1. Server fetches the homework session + exercise document content + material content
+2. Exercise content is injected as a synthetic conversation turn: `"The student is working on this exercise: [exercise content]"`
+3. Material content (from stored files or document content) is injected as another turn: `"Here are the relevant course materials: [material content]"`
+4. These are prepended before any RAG results and the actual conversation history
+5. The system prompt receives `isHomeworkMode: true` which adds pedagogical instructions
+
+### Response
+
+No changes to the response format — same SSE stream with `sources`, `conversation`, `text`, `done` events.

--- a/specs/046-homework-ai-context/contracts/api.md
+++ b/specs/046-homework-ai-context/contracts/api.md
@@ -7,6 +7,7 @@
 Creates a homework document, session record, and material links in a single flow.
 
 **Input**:
+
 ```ts
 {
   courseId: string;
@@ -19,14 +20,16 @@ Creates a homework document, session record, and material links in a single flow
 ```
 
 **Output**:
+
 ```ts
 {
-  documentId: string;  // the newly created homework document
-  sessionId: string;   // the homework session record
+  documentId: string; // the newly created homework document
+  sessionId: string; // the homework session record
 }
 ```
 
 **Behavior**:
+
 1. Validates `courseId` belongs to the authenticated user
 2. Validates `exerciseDocumentId` belongs to the authenticated user and is in the same course
 3. Creates a new document with `course_id`, `purpose = 'homework'`, title = `"HW — {exercise title}"`
@@ -43,6 +46,7 @@ Creates a homework document, session record, and material links in a single flow
 Fetches the homework session and associated materials for a document.
 
 **Input**:
+
 ```ts
 {
   documentId: string;
@@ -50,15 +54,20 @@ Fetches the homework session and associated materials for a document.
 ```
 
 **Output**:
+
 ```ts
-HomeworkContext | null  // null if document has no homework session
+HomeworkContext | null; // null if document has no homework session
 ```
 
 Where `HomeworkContext` is:
+
 ```ts
 {
   session: HomeworkSession;
-  exerciseDocument: { id: string; title: string };
+  exerciseDocument: {
+    id: string;
+    title: string;
+  }
   materials: Array<{
     type: 'course_material' | 'personal_file' | 'document';
     id: string;
@@ -68,6 +77,7 @@ Where `HomeworkContext` is:
 ```
 
 **Behavior**:
+
 1. Queries `homework_sessions` by `document_id`
 2. If no session exists, returns `null`
 3. Fetches the exercise document title
@@ -92,6 +102,7 @@ The existing `/api/ai/ask` endpoint receives an additional optional field:
 ### Behavior Change
 
 When `homeworkSessionId` is provided:
+
 1. Server fetches the homework session + exercise document content + material content
 2. Exercise content is injected as a synthetic conversation turn: `"The student is working on this exercise: [exercise content]"`
 3. Material content (from stored files or document content) is injected as another turn: `"Here are the relevant course materials: [material content]"`

--- a/specs/046-homework-ai-context/contracts/ui.md
+++ b/specs/046-homework-ai-context/contracts/ui.md
@@ -7,6 +7,7 @@
 **Location**: `src/components/dashboard/start-homework-dialog.tsx`
 
 **Props**:
+
 ```ts
 {
   courseId: string;
@@ -19,6 +20,7 @@
 ```
 
 **Behavior**:
+
 1. Opens a dialog with two sections:
    - **Select Exercise**: Radio-button list of course documents (single-select, required)
    - **Select Reference Materials**: Checkbox list of materials grouped by week (multi-select, optional)
@@ -32,6 +34,7 @@
 **Location**: `src/components/ai/homework-context-badges.tsx`
 
 **Props**:
+
 ```ts
 {
   context: HomeworkContext;
@@ -39,6 +42,7 @@
 ```
 
 **Behavior**:
+
 - Renders a collapsible section showing the exercise document name and material names as badges
 - Collapsed by default, shows "Homework context: {exercise name} + {N} materials"
 - Expanded shows the full list
@@ -96,7 +100,9 @@ The course page (`src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx`) ad
   personalFiles={[...allWeekPersonalFiles, ...coursePersonalFiles]}
   weeks={typedWeeks}
 >
-  <Button variant="outline" size="sm">Start Homework</Button>
+  <Button variant="outline" size="sm">
+    Start Homework
+  </Button>
 </StartHomeworkDialog>
 ```
 

--- a/specs/046-homework-ai-context/contracts/ui.md
+++ b/specs/046-homework-ai-context/contracts/ui.md
@@ -1,0 +1,116 @@
+# UI Contracts: Homework AI Context
+
+## New Components
+
+### `StartHomeworkDialog`
+
+**Location**: `src/components/dashboard/start-homework-dialog.tsx`
+
+**Props**:
+```ts
+{
+  courseId: string;
+  documents: Document[];           // all documents in the course (exercise candidates)
+  materials: CourseMaterial[];     // course materials by week
+  personalFiles: PersonalFile[];   // user-uploaded files
+  weeks: CourseWeek[];             // for grouping materials by week
+  children: React.ReactNode;       // trigger button (via DialogTrigger)
+}
+```
+
+**Behavior**:
+1. Opens a dialog with two sections:
+   - **Select Exercise**: Radio-button list of course documents (single-select, required)
+   - **Select Reference Materials**: Checkbox list of materials grouped by week (multi-select, optional)
+2. "Start" button is disabled until an exercise is selected
+3. On confirm: calls `createHomeworkSession` server action, then navigates to the new document
+
+---
+
+### `HomeworkContextBadges`
+
+**Location**: `src/components/ai/homework-context-badges.tsx`
+
+**Props**:
+```ts
+{
+  context: HomeworkContext;
+}
+```
+
+**Behavior**:
+- Renders a collapsible section showing the exercise document name and material names as badges
+- Collapsed by default, shows "Homework context: {exercise name} + {N} materials"
+- Expanded shows the full list
+
+---
+
+## Modified Components
+
+### `AiChatPanel` — New Optional Prop
+
+```ts
+{
+  // ... existing props ...
+  homeworkSessionId?: string;
+  homeworkContext?: HomeworkContext;  // for display only
+}
+```
+
+- If `homeworkSessionId` is provided, includes it in the `/api/ai/ask` request body
+- If `homeworkContext` is provided, renders `<HomeworkContextBadges>` above the message list
+
+### `AiChatWrapper` — New Optional Props
+
+```ts
+{
+  // ... existing props ...
+  homeworkSessionId?: string;
+  homeworkContext?: HomeworkContext;
+}
+```
+
+Passes through to `<AiChatPanel>`.
+
+### `DocumentWithAi` — New Optional Props
+
+```ts
+{
+  // ... existing props ...
+  homeworkSessionId?: string;
+  homeworkContext?: HomeworkContext;
+}
+```
+
+Passes through to `<AiChatWrapper>`.
+
+### Course Page — Button Addition
+
+The course page (`src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx`) adds a "Start Homework" button in the button row next to "New Document":
+
+```tsx
+<StartHomeworkDialog
+  courseId={courseId}
+  documents={typedDocuments}
+  materials={allMaterials}
+  personalFiles={[...allWeekPersonalFiles, ...coursePersonalFiles]}
+  weeks={typedWeeks}
+>
+  <Button variant="outline" size="sm">Start Homework</Button>
+</StartHomeworkDialog>
+```
+
+### Document Page — Homework Detection
+
+The document page (`src/app/(dashboard)/dashboard/documents/[docId]/page.tsx`) fetches the homework session server-side and passes it down:
+
+```ts
+// After fetching the document:
+const homeworkContext = await getHomeworkContext({ documentId: docId });
+// Pass to DocumentWithAi:
+<DocumentWithAi
+  // ... existing props ...
+  homeworkSessionId={homeworkContext?.session.id}
+  homeworkContext={homeworkContext}
+/>
+```

--- a/specs/046-homework-ai-context/data-model.md
+++ b/specs/046-homework-ai-context/data-model.md
@@ -1,0 +1,118 @@
+# Data Model: Homework AI Context
+
+## New Entities
+
+### `homework_sessions`
+
+Represents a homework session linking a working document to an exercise source and course.
+
+| Field                  | Type        | Constraints                                              |
+| ---------------------- | ----------- | -------------------------------------------------------- |
+| `id`                   | uuid        | PK, default `gen_random_uuid()`                          |
+| `document_id`          | uuid        | FK → `documents(id)` ON DELETE CASCADE, NOT NULL, UNIQUE |
+| `exercise_document_id` | uuid        | FK → `documents(id)` ON DELETE CASCADE, NOT NULL         |
+| `course_id`            | uuid        | FK → `courses(id)` ON DELETE CASCADE, NOT NULL           |
+| `user_id`              | uuid        | FK → `profiles(id)` ON DELETE CASCADE, NOT NULL          |
+| `created_at`           | timestamptz | default `now()`                                          |
+
+**RLS**: Users can only read/insert/delete their own rows (`user_id = auth.uid()`). No UPDATE policy — sessions are immutable once created.
+
+**Notes**:
+- `document_id` is UNIQUE — each document can have at most one homework session.
+- `exercise_document_id` is the existing document containing the homework questions.
+- Deleting the homework document cascades to delete the session.
+- Deleting the exercise document also cascades (the session loses its purpose).
+
+---
+
+### `homework_session_materials`
+
+Junction table linking a homework session to its reference materials (polymorphic).
+
+| Field           | Type        | Constraints                                                                     |
+| --------------- | ----------- | ------------------------------------------------------------------------------- |
+| `id`            | uuid        | PK, default `gen_random_uuid()`                                                |
+| `session_id`    | uuid        | FK → `homework_sessions(id)` ON DELETE CASCADE, NOT NULL                        |
+| `material_type` | text        | NOT NULL, CHECK IN (`'course_material'`, `'personal_file'`, `'document'`)       |
+| `material_id`   | uuid        | NOT NULL                                                                        |
+| `created_at`    | timestamptz | default `now()`                                                                 |
+
+**RLS**: Inherited through parent session — SELECT requires EXISTS subquery checking `homework_sessions.user_id = auth.uid()`. INSERT requires the same. No UPDATE policy.
+
+**Notes**:
+- `material_id` is a polymorphic reference — no FK constraint since it can point to `course_materials`, `personal_files`, or `documents`.
+- Unique constraint on `(session_id, material_type, material_id)` prevents duplicate entries.
+- Deleting the session cascades to delete all material links.
+
+---
+
+## Existing Entities (No Changes)
+
+### `documents`
+
+No schema changes needed. The homework document is a regular document with `course_id` set and `purpose = 'homework'`. The `homework_sessions` table provides the additional context link.
+
+### `course_materials`
+
+No changes. Referenced polymorphically by `homework_session_materials`.
+
+### `personal_files`
+
+No changes. Referenced polymorphically by `homework_session_materials`.
+
+### `ai_conversations`
+
+No changes. Homework documents use the existing conversation system — conversations are scoped to `(user_id, course_id)` and work the same as any other document.
+
+---
+
+## Entity Relationships
+
+```
+courses (1) ──── (*) homework_sessions
+documents (1) ── (0..1) homework_sessions  (as document_id — the working doc)
+documents (1) ── (*) homework_sessions     (as exercise_document_id — the exercise source)
+homework_sessions (1) ── (*) homework_session_materials
+homework_session_materials ──> course_materials | personal_files | documents  (polymorphic)
+```
+
+## State Transitions
+
+Homework sessions are **create-once, read-many**:
+1. **Created** when the student confirms the "Start Homework" dialog
+2. **Read** every time the homework document is opened (to load context for AI)
+3. **Deleted** only when the parent document or exercise is deleted (cascade)
+
+No intermediate states. No updates. This simplicity is intentional — if the student wants different materials, they start a new homework session.
+
+## TypeScript Types
+
+```ts
+interface HomeworkSession {
+  id: string;
+  document_id: string;
+  exercise_document_id: string;
+  course_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+interface HomeworkSessionMaterial {
+  id: string;
+  session_id: string;
+  material_type: 'course_material' | 'personal_file' | 'document';
+  material_id: string;
+  created_at: string;
+}
+
+// Joined view for UI display
+interface HomeworkContext {
+  session: HomeworkSession;
+  exerciseDocument: { id: string; title: string };
+  materials: Array<{
+    type: 'course_material' | 'personal_file' | 'document';
+    id: string;
+    name: string;  // display name from the source table
+  }>;
+}
+```

--- a/specs/046-homework-ai-context/data-model.md
+++ b/specs/046-homework-ai-context/data-model.md
@@ -18,6 +18,7 @@ Represents a homework session linking a working document to an exercise source a
 **RLS**: Users can only read/insert/delete their own rows (`user_id = auth.uid()`). No UPDATE policy — sessions are immutable once created.
 
 **Notes**:
+
 - `document_id` is UNIQUE — each document can have at most one homework session.
 - `exercise_document_id` is the existing document containing the homework questions.
 - Deleting the homework document cascades to delete the session.
@@ -29,17 +30,18 @@ Represents a homework session linking a working document to an exercise source a
 
 Junction table linking a homework session to its reference materials (polymorphic).
 
-| Field           | Type        | Constraints                                                                     |
-| --------------- | ----------- | ------------------------------------------------------------------------------- |
-| `id`            | uuid        | PK, default `gen_random_uuid()`                                                |
-| `session_id`    | uuid        | FK → `homework_sessions(id)` ON DELETE CASCADE, NOT NULL                        |
-| `material_type` | text        | NOT NULL, CHECK IN (`'course_material'`, `'personal_file'`, `'document'`)       |
-| `material_id`   | uuid        | NOT NULL                                                                        |
-| `created_at`    | timestamptz | default `now()`                                                                 |
+| Field           | Type        | Constraints                                                               |
+| --------------- | ----------- | ------------------------------------------------------------------------- |
+| `id`            | uuid        | PK, default `gen_random_uuid()`                                           |
+| `session_id`    | uuid        | FK → `homework_sessions(id)` ON DELETE CASCADE, NOT NULL                  |
+| `material_type` | text        | NOT NULL, CHECK IN (`'course_material'`, `'personal_file'`, `'document'`) |
+| `material_id`   | uuid        | NOT NULL                                                                  |
+| `created_at`    | timestamptz | default `now()`                                                           |
 
 **RLS**: Inherited through parent session — SELECT requires EXISTS subquery checking `homework_sessions.user_id = auth.uid()`. INSERT requires the same. No UPDATE policy.
 
 **Notes**:
+
 - `material_id` is a polymorphic reference — no FK constraint since it can point to `course_materials`, `personal_files`, or `documents`.
 - Unique constraint on `(session_id, material_type, material_id)` prevents duplicate entries.
 - Deleting the session cascades to delete all material links.
@@ -79,6 +81,7 @@ homework_session_materials ──> course_materials | personal_files | documents
 ## State Transitions
 
 Homework sessions are **create-once, read-many**:
+
 1. **Created** when the student confirms the "Start Homework" dialog
 2. **Read** every time the homework document is opened (to load context for AI)
 3. **Deleted** only when the parent document or exercise is deleted (cascade)
@@ -112,7 +115,7 @@ interface HomeworkContext {
   materials: Array<{
     type: 'course_material' | 'personal_file' | 'document';
     id: string;
-    name: string;  // display name from the source table
+    name: string; // display name from the source table
   }>;
 }
 ```

--- a/specs/046-homework-ai-context/plan.md
+++ b/specs/046-homework-ai-context/plan.md
@@ -1,91 +1,105 @@
-# Implementation Plan: Homework AI Context
+# Implementation Plan: [FEATURE]
 
-**Branch**: `046-homework-ai-context` | **Date**: 2026-05-23 | **Spec**: [spec.md](spec.md)
-**Input**: Feature specification from `/specs/046-homework-ai-context/spec.md`
+**Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
+**Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
-Add a "Start Homework" flow to courses that lets students select an exercise document and reference materials, then creates a homework document where the AI chat automatically has full context of the exercise questions and selected materials. Requires two new database tables (`homework_sessions`, `homework_session_materials`), a selection dialog, server actions for creating/reading homework sessions, and extensions to the AI context pipeline to inject exercise + material content into conversations.
+[Extract from feature spec: primary requirement + technical approach from research]
 
 ## Technical Context
 
-**Language/Version**: TypeScript 5 / Node.js 22+
-**Primary Dependencies**: Next.js 16 (App Router), React 19, Supabase SSR, TipTap 3, shadcn/ui, `@google/genai`
-**Storage**: PostgreSQL via Supabase — new `homework_sessions` and `homework_session_materials` tables
-**Testing**: Vitest (unit/integration), Playwright (E2E)
-**Target Platform**: Web (desktop + tablet browsers)
-**Project Type**: Web application (Next.js full-stack)
-**Performance Goals**: Homework session creation < 2s, AI context injection adds < 500ms to first response
-**Constraints**: Subject to existing AI rate limits and quotas; exercise content must fit within Gemini context window
-**Scale/Scope**: Typical course has 5-30 documents and 10-50 materials
+<!--
+  ACTION REQUIRED: Replace the content in this section with the technical details
+  for the project. The structure here is presented in advisory capacity to guide
+  the iteration process.
+-->
+
+**Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]  
+**Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]  
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
+**Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
+**Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]  
+**Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]  
+**Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
 ## Constitution Check
 
 _GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
 
-| Principle | Status | Notes |
-| --- | --- | --- |
-| I. Incremental Development | PASS | Feature builds on existing document creation, AI chat, and course materials infrastructure. DB schema first, then server actions, then UI, then AI integration. |
-| II. Test-Driven Quality | PASS | Plan includes unit tests for server actions, integration tests for DB operations + RLS, and E2E tests for the full user flow. |
-| III. Protected Branches | PASS | Working on `046-homework-ai-context` branch. Will PR to `dev`. |
-| IV. Migrations as Code | PASS | New tables created via `supabase migration new`. Seed data updated. |
-| V. Interview-Ready Architecture | PASS | Normalized relational model (junction table), polymorphic associations, server-side context injection — all strong interview topics. |
-
-**Post-Phase 1 re-check**: All gates still pass. No violations.
+[Gates determined based on constitution file]
 
 ## Project Structure
 
 ### Documentation (this feature)
 
 ```text
-specs/046-homework-ai-context/
-├── plan.md              # This file
-├── spec.md              # Feature specification
-├── research.md          # Phase 0: design decisions
-├── data-model.md        # Phase 1: entity definitions
-├── quickstart.md        # Phase 1: implementation guide
-├── contracts/
-│   ├── api.md           # Server action & API contracts
-│   └── ui.md            # Component prop contracts
-└── tasks.md             # Phase 2 output (via /speckit.tasks)
+specs/[###-feature]/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
 ```
 
 ### Source Code (repository root)
 
+<!--
+  ACTION REQUIRED: Replace the placeholder tree below with the concrete layout
+  for this feature. Delete unused options and expand the chosen structure with
+  real paths (e.g., apps/admin, packages/something). The delivered plan must
+  not include Option labels.
+-->
+
 ```text
-supabase/migrations/
-└── YYYYMMDDHHMMSS_create_homework_sessions.sql   # New tables + RLS
+# [REMOVE IF UNUSED] Option 1: Single project (DEFAULT)
+src/
+├── models/
+├── services/
+├── cli/
+└── lib/
 
-src/types/
-└── database.ts                    # + HomeworkSession, HomeworkSessionMaterial, HomeworkContext types
+tests/
+├── contract/
+├── integration/
+└── unit/
 
-src/lib/actions/
-└── homework.ts                    # NEW: createHomeworkSession, getHomeworkContext server actions
+# [REMOVE IF UNUSED] Option 2: Web application (when "frontend" + "backend" detected)
+backend/
+├── src/
+│   ├── models/
+│   ├── services/
+│   └── api/
+└── tests/
 
-src/lib/ai/
-└── prompts.ts                     # MODIFIED: add isHomeworkMode to buildSystemPrompt
+frontend/
+├── src/
+│   ├── components/
+│   ├── pages/
+│   └── services/
+└── tests/
 
-src/app/api/ai/ask/
-└── route.ts                       # MODIFIED: handle homeworkSessionId, fetch + inject context
+# [REMOVE IF UNUSED] Option 3: Mobile + API (when "iOS/Android" detected)
+api/
+└── [same as backend above]
 
-src/components/dashboard/
-└── start-homework-dialog.tsx      # NEW: exercise + materials selection dialog
-
-src/components/ai/
-├── homework-context-badges.tsx    # NEW: shows linked context in chat panel
-├── ai-chat-panel.tsx              # MODIFIED: accept + display homework context
-├── ai-chat-wrapper.tsx            # MODIFIED: pass through homework props
-└── document-with-ai.tsx           # MODIFIED: pass through homework props
-
-src/app/(dashboard)/dashboard/
-├── courses/[courseId]/page.tsx     # MODIFIED: add StartHomeworkDialog button
-└── documents/[docId]/page.tsx     # MODIFIED: fetch homework context, pass to DocumentWithAi
-
-src/lib/actions/
-└── homework.integration.test.ts   # NEW: integration tests
-
-e2e/
-└── homework.spec.ts               # NEW: E2E test for full homework flow
+ios/ or android/
+└── [platform-specific structure: feature modules, UI flows, platform tests]
 ```
 
-**Structure Decision**: Follows the existing project structure — server actions in `src/lib/actions/`, components in `src/components/`, API routes in `src/app/api/`. No new directories or structural patterns introduced.
+**Structure Decision**: [Document the selected structure and reference the real
+directories captured above]
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation                  | Why Needed         | Simpler Alternative Rejected Because |
+| -------------------------- | ------------------ | ------------------------------------ |
+| [e.g., 4th project]        | [current need]     | [why 3 projects insufficient]        |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient]  |

--- a/specs/046-homework-ai-context/plan.md
+++ b/specs/046-homework-ai-context/plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Homework AI Context
+
+**Branch**: `046-homework-ai-context` | **Date**: 2026-05-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/046-homework-ai-context/spec.md`
+
+## Summary
+
+Add a "Start Homework" flow to courses that lets students select an exercise document and reference materials, then creates a homework document where the AI chat automatically has full context of the exercise questions and selected materials. Requires two new database tables (`homework_sessions`, `homework_session_materials`), a selection dialog, server actions for creating/reading homework sessions, and extensions to the AI context pipeline to inject exercise + material content into conversations.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Node.js 22+
+**Primary Dependencies**: Next.js 16 (App Router), React 19, Supabase SSR, TipTap 3, shadcn/ui, `@google/genai`
+**Storage**: PostgreSQL via Supabase — new `homework_sessions` and `homework_session_materials` tables
+**Testing**: Vitest (unit/integration), Playwright (E2E)
+**Target Platform**: Web (desktop + tablet browsers)
+**Project Type**: Web application (Next.js full-stack)
+**Performance Goals**: Homework session creation < 2s, AI context injection adds < 500ms to first response
+**Constraints**: Subject to existing AI rate limits and quotas; exercise content must fit within Gemini context window
+**Scale/Scope**: Typical course has 5-30 documents and 10-50 materials
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle | Status | Notes |
+| --- | --- | --- |
+| I. Incremental Development | PASS | Feature builds on existing document creation, AI chat, and course materials infrastructure. DB schema first, then server actions, then UI, then AI integration. |
+| II. Test-Driven Quality | PASS | Plan includes unit tests for server actions, integration tests for DB operations + RLS, and E2E tests for the full user flow. |
+| III. Protected Branches | PASS | Working on `046-homework-ai-context` branch. Will PR to `dev`. |
+| IV. Migrations as Code | PASS | New tables created via `supabase migration new`. Seed data updated. |
+| V. Interview-Ready Architecture | PASS | Normalized relational model (junction table), polymorphic associations, server-side context injection — all strong interview topics. |
+
+**Post-Phase 1 re-check**: All gates still pass. No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/046-homework-ai-context/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Phase 0: design decisions
+├── data-model.md        # Phase 1: entity definitions
+├── quickstart.md        # Phase 1: implementation guide
+├── contracts/
+│   ├── api.md           # Server action & API contracts
+│   └── ui.md            # Component prop contracts
+└── tasks.md             # Phase 2 output (via /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+supabase/migrations/
+└── YYYYMMDDHHMMSS_create_homework_sessions.sql   # New tables + RLS
+
+src/types/
+└── database.ts                    # + HomeworkSession, HomeworkSessionMaterial, HomeworkContext types
+
+src/lib/actions/
+└── homework.ts                    # NEW: createHomeworkSession, getHomeworkContext server actions
+
+src/lib/ai/
+└── prompts.ts                     # MODIFIED: add isHomeworkMode to buildSystemPrompt
+
+src/app/api/ai/ask/
+└── route.ts                       # MODIFIED: handle homeworkSessionId, fetch + inject context
+
+src/components/dashboard/
+└── start-homework-dialog.tsx      # NEW: exercise + materials selection dialog
+
+src/components/ai/
+├── homework-context-badges.tsx    # NEW: shows linked context in chat panel
+├── ai-chat-panel.tsx              # MODIFIED: accept + display homework context
+├── ai-chat-wrapper.tsx            # MODIFIED: pass through homework props
+└── document-with-ai.tsx           # MODIFIED: pass through homework props
+
+src/app/(dashboard)/dashboard/
+├── courses/[courseId]/page.tsx     # MODIFIED: add StartHomeworkDialog button
+└── documents/[docId]/page.tsx     # MODIFIED: fetch homework context, pass to DocumentWithAi
+
+src/lib/actions/
+└── homework.integration.test.ts   # NEW: integration tests
+
+e2e/
+└── homework.spec.ts               # NEW: E2E test for full homework flow
+```
+
+**Structure Decision**: Follows the existing project structure — server actions in `src/lib/actions/`, components in `src/components/`, API routes in `src/app/api/`. No new directories or structural patterns introduced.

--- a/specs/046-homework-ai-context/quickstart.md
+++ b/specs/046-homework-ai-context/quickstart.md
@@ -1,0 +1,42 @@
+# Quickstart: Homework AI Context
+
+## Prerequisites
+
+- Local Supabase running (`supabase start`)
+- `pnpm install` completed
+- `.env.local` configured
+
+## Implementation Order
+
+1. **Database migration** — Create `homework_sessions` and `homework_session_materials` tables with RLS
+2. **TypeScript types** — Add `HomeworkSession`, `HomeworkSessionMaterial`, `HomeworkContext` to `src/types/database.ts`
+3. **Server actions** — `createHomeworkSession` and `getHomeworkContext` in `src/lib/actions/homework.ts`
+4. **Seed data** — Add homework session test data to `supabase/seed.sql`
+5. **UI: StartHomeworkDialog** — Dialog component for selecting exercise + materials
+6. **Course page integration** — Add "Start Homework" button next to "New Document"
+7. **AI context injection** — Extend `/api/ai/ask` to handle `homeworkSessionId`
+8. **System prompt** — Add `isHomeworkMode` to `buildSystemPrompt`
+9. **UI: HomeworkContextBadges** — Show linked context in AI chat panel
+10. **Prop threading** — Pass homework context through DocumentPage → DocumentWithAi → AiChatWrapper → AiChatPanel
+
+## Key Commands
+
+```bash
+# Create migration
+supabase migration new create_homework_sessions
+
+# Verify migration
+supabase db reset
+
+# Run tests
+pnpm test && pnpm test:integration
+
+# Run E2E
+pnpm test:e2e
+```
+
+## Test Strategy
+
+- **Unit tests**: Server action logic (createHomeworkSession, getHomeworkContext)
+- **Integration tests**: DB operations with RLS verification, homework session CRUD
+- **E2E tests**: Full flow — Start Homework → select exercise → select materials → confirm → verify AI context

--- a/specs/046-homework-ai-context/research.md
+++ b/specs/046-homework-ai-context/research.md
@@ -7,6 +7,7 @@
 **Rationale**: The homework session links a homework document to an exercise source document and zero or more reference materials. Materials are polymorphic — they can be `course_materials`, `personal_files`, or other `documents`. A normalized relational model with a junction table is the cleanest approach, follows the existing codebase pattern (e.g., `ai_conversations` + `ai_messages`, `document_versions`), and is a strong interview topic (normalization, junction tables, polymorphic associations).
 
 **Alternatives considered**:
+
 - **JSONB column on `documents`** (e.g., `homework_context: { exercise_document_id, material_ids: [...] }`): Simpler but loses FK constraints, makes querying relationships harder, and mixes concerns. Rejected because the codebase already uses dedicated tables for related entities.
 - **Extending the existing `purpose` field**: Too limited — `purpose` is just a label (`homework`, `summary`, `notes`). It doesn't carry relational data. Could add `exercise_document_id` as a column, but the many-to-many materials relationship still needs a junction table.
 
@@ -19,6 +20,7 @@
 **Rationale**: The existing AI pipeline already injects context via synthetic user/model exchanges in the Gemini `contents` array (see `buildAiContext` in `src/lib/actions/ai-context.ts`). Adding homework context follows the same pattern — the exercise document text and material text are prepended as additional context turns. This keeps all context assembly server-side (secure, no client-side file fetching) and leverages the existing streaming SSE architecture.
 
 **Alternatives considered**:
+
 - **Client-side context injection**: Pass exercise/material text from client. Rejected — requires fetching potentially large files client-side, exposes content in network requests, and duplicates server-side logic.
 - **RAG-only approach (use existing embeddings)**: Rely entirely on pgvector search to find relevant chunks. Rejected — RAG is probabilistic and might miss specific questions. For homework, we want the full exercise text injected directly so the AI can reference "question 2" precisely. RAG can supplement but shouldn't be the only mechanism.
 
@@ -31,6 +33,7 @@
 **Rationale**: The existing `buildSystemPrompt` in `src/lib/ai/prompts.ts` already accepts optional context parameters (`courseName`, `weekLabel`, `hasDocumentContent`). Adding `isHomeworkMode` is consistent with this pattern. The homework prompt additions instruct the AI to be pedagogical rather than solution-oriented.
 
 **Alternatives considered**:
+
 - **Completely separate prompt builder**: Unnecessary duplication. The base prompt is 90% the same.
 - **Prompt in the API route directly**: Scatters prompt logic. The existing pattern keeps all prompts in `prompts.ts`.
 
@@ -43,6 +46,7 @@
 **Rationale**: The existing `CreateDocumentDialog` uses a simple form with selects. The homework dialog needs more — it's selecting from lists of existing items rather than filling in new data. A grouped checkbox list follows shadcn/ui patterns and handles the "zero or more materials" requirement naturally.
 
 **Alternatives considered**:
+
 - **Two separate dialogs (pick exercise, then pick materials)**: More steps for the user. Rejected — one dialog with two sections is faster.
 - **Combobox/search-based**: Overkill for typical course sizes (5-30 items). Simple scrollable lists are sufficient.
 
@@ -55,6 +59,7 @@
 **Rationale**: The user needs transparency about what the AI "knows" (spec FR-010). A non-intrusive collapsible section doesn't interfere with the chat flow but is always accessible. Badges are compact and scannable.
 
 **Alternatives considered**:
+
 - **Tooltip on the AI bubble**: Too hidden — users might not discover it.
 - **Separate tab/panel**: Over-engineered for showing a short list of linked items.
 

--- a/specs/046-homework-ai-context/research.md
+++ b/specs/046-homework-ai-context/research.md
@@ -1,0 +1,69 @@
+# Research: Homework AI Context
+
+## Decision 1: How to Store Homework Context Associations
+
+**Decision**: New `homework_sessions` table + `homework_session_materials` junction table.
+
+**Rationale**: The homework session links a homework document to an exercise source document and zero or more reference materials. Materials are polymorphic — they can be `course_materials`, `personal_files`, or other `documents`. A normalized relational model with a junction table is the cleanest approach, follows the existing codebase pattern (e.g., `ai_conversations` + `ai_messages`, `document_versions`), and is a strong interview topic (normalization, junction tables, polymorphic associations).
+
+**Alternatives considered**:
+- **JSONB column on `documents`** (e.g., `homework_context: { exercise_document_id, material_ids: [...] }`): Simpler but loses FK constraints, makes querying relationships harder, and mixes concerns. Rejected because the codebase already uses dedicated tables for related entities.
+- **Extending the existing `purpose` field**: Too limited — `purpose` is just a label (`homework`, `summary`, `notes`). It doesn't carry relational data. Could add `exercise_document_id` as a column, but the many-to-many materials relationship still needs a junction table.
+
+---
+
+## Decision 2: How to Inject Homework Context into AI Chat
+
+**Decision**: Pass `homeworkSessionId` through the component tree to the `/api/ai/ask` route, which fetches exercise content and material text server-side and injects them as synthetic conversation turns (same pattern as existing document content and RAG results).
+
+**Rationale**: The existing AI pipeline already injects context via synthetic user/model exchanges in the Gemini `contents` array (see `buildAiContext` in `src/lib/actions/ai-context.ts`). Adding homework context follows the same pattern — the exercise document text and material text are prepended as additional context turns. This keeps all context assembly server-side (secure, no client-side file fetching) and leverages the existing streaming SSE architecture.
+
+**Alternatives considered**:
+- **Client-side context injection**: Pass exercise/material text from client. Rejected — requires fetching potentially large files client-side, exposes content in network requests, and duplicates server-side logic.
+- **RAG-only approach (use existing embeddings)**: Rely entirely on pgvector search to find relevant chunks. Rejected — RAG is probabilistic and might miss specific questions. For homework, we want the full exercise text injected directly so the AI can reference "question 2" precisely. RAG can supplement but shouldn't be the only mechanism.
+
+---
+
+## Decision 3: How to Build the Homework System Prompt
+
+**Decision**: Extend `buildSystemPrompt` with an optional `isHomeworkMode` flag that adds homework-specific instructions to the system prompt (don't solve directly, help understand, reference specific questions by number).
+
+**Rationale**: The existing `buildSystemPrompt` in `src/lib/ai/prompts.ts` already accepts optional context parameters (`courseName`, `weekLabel`, `hasDocumentContent`). Adding `isHomeworkMode` is consistent with this pattern. The homework prompt additions instruct the AI to be pedagogical rather than solution-oriented.
+
+**Alternatives considered**:
+- **Completely separate prompt builder**: Unnecessary duplication. The base prompt is 90% the same.
+- **Prompt in the API route directly**: Scatters prompt logic. The existing pattern keeps all prompts in `prompts.ts`.
+
+---
+
+## Decision 4: Material Selection UI Pattern
+
+**Decision**: Multi-step dialog with two sections — exercise picker (single-select from course documents) and materials picker (multi-select from course materials, personal files, and optionally other documents). Uses checkboxes for multi-select with a grouped layout (by week).
+
+**Rationale**: The existing `CreateDocumentDialog` uses a simple form with selects. The homework dialog needs more — it's selecting from lists of existing items rather than filling in new data. A grouped checkbox list follows shadcn/ui patterns and handles the "zero or more materials" requirement naturally.
+
+**Alternatives considered**:
+- **Two separate dialogs (pick exercise, then pick materials)**: More steps for the user. Rejected — one dialog with two sections is faster.
+- **Combobox/search-based**: Overkill for typical course sizes (5-30 items). Simple scrollable lists are sufficient.
+
+---
+
+## Decision 5: Where to Show Homework Context in the AI Panel
+
+**Decision**: Add a collapsible "Homework Context" section at the top of the AI chat panel (above messages) that shows the linked exercise name and material names as badges. This section only appears for homework documents.
+
+**Rationale**: The user needs transparency about what the AI "knows" (spec FR-010). A non-intrusive collapsible section doesn't interfere with the chat flow but is always accessible. Badges are compact and scannable.
+
+**Alternatives considered**:
+- **Tooltip on the AI bubble**: Too hidden — users might not discover it.
+- **Separate tab/panel**: Over-engineered for showing a short list of linked items.
+
+---
+
+## Decision 6: Polymorphic Material References
+
+**Decision**: Use `material_type` discriminator + `material_id` UUID in the junction table. Valid types: `'course_material'`, `'personal_file'`, `'document'`.
+
+**Rationale**: Materials come from three different tables (`course_materials`, `personal_files`, `documents`). A polymorphic reference with a type discriminator is simpler than three separate FK columns (most of which would be NULL). This is a common pattern in production systems and a good interview discussion point (polymorphic associations, trade-offs vs. table-per-type).
+
+**Trade-off**: No database-level FK constraint on `material_id`. Application-level validation ensures referential integrity. If a referenced material is deleted, the junction row becomes orphaned — the UI handles this gracefully by showing "Material unavailable" (spec edge case).

--- a/specs/046-homework-ai-context/spec.md
+++ b/specs/046-homework-ai-context/spec.md
@@ -1,0 +1,106 @@
+# Feature Specification: Homework AI Context
+
+**Feature Branch**: `046-homework-ai-context`
+**Created**: 2026-05-23
+**Status**: Draft
+**Input**: User description: "I want us to have inside of a course a 'start homework' button next to the 'new document' and when you press on start homework, let the user choose the exercise (from the course's documents) and the relevant lectures + recitations + material. Then, the AI chat will have this material as context. It opens a regular document and the chat inside knows what are the questions, and the material they are based on. So the student can ask in the chat 'in question 2 what did they mean...' and the AI will know the context."
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Start a Homework Session (Priority: P1)
+
+A student opens a course page and clicks "Start Homework" (next to the existing "New Document" button). A dialog appears letting them select:
+1. The exercise document — an existing document in the course that contains the homework questions.
+2. The relevant reference materials — lectures, recitations, and/or uploaded materials from the course that the homework is based on.
+
+After selecting and confirming, a new document is created and opened. The AI chat panel in this document is pre-loaded with context from both the exercise questions and the selected reference materials, so the student can immediately ask questions like "in question 2, what did they mean by..." and the AI understands exactly what they're referring to.
+
+**Why this priority**: This is the core value proposition — without the ability to start a homework session with context, the feature has no purpose.
+
+**Independent Test**: Can be fully tested by clicking "Start Homework", selecting an exercise and materials, and verifying that the new document opens with the AI chat aware of the selected context.
+
+**Acceptance Scenarios**:
+
+1. **Given** a student is on a course page with at least one existing document and some course materials, **When** they click "Start Homework", **Then** a dialog appears showing a list of the course's documents to pick as the exercise and a list of available materials (lectures, recitations, uploaded files) to select as references.
+2. **Given** the student has selected an exercise document and at least one reference material, **When** they click "Start" (confirm), **Then** a new document is created in the course and the student is navigated to it.
+3. **Given** the student is now in the newly created homework document, **When** they open the AI chat and ask a question referencing a specific part of the exercise (e.g., "what does question 3 mean?"), **Then** the AI responds with awareness of the exercise content and the selected reference materials.
+
+---
+
+### User Story 2 - AI Understands Exercise Questions in Context (Priority: P2)
+
+When the student asks the AI about a specific question from the exercise, the AI can reference both the question text and the relevant lecture/material content to provide a helpful explanation. The AI does not solve the homework — it helps the student understand the questions and the underlying concepts.
+
+**Why this priority**: This is the educational value — the AI must be able to connect exercise questions to course material for the feature to be useful.
+
+**Independent Test**: Can be tested by asking the AI about a specific exercise question and verifying the response references both the question and relevant material.
+
+**Acceptance Scenarios**:
+
+1. **Given** a homework document with exercise context about linear algebra and a linked lecture on matrix operations, **When** the student asks "in question 2, what do they mean by 'orthogonal projection'?", **Then** the AI explains the concept using information from the linked lecture material.
+2. **Given** a homework document with exercise context, **When** the student asks the AI to solve a question directly, **Then** the AI guides the student toward understanding rather than providing a direct answer.
+
+---
+
+### User Story 3 - View and Manage Homework Context (Priority: P3)
+
+The student can see which exercise and materials are linked to their homework document. They can view the linked context from within the document so they know what the AI has access to.
+
+**Why this priority**: Transparency about what context the AI has builds trust and helps the student understand what materials they should also review.
+
+**Independent Test**: Can be tested by opening a homework document and verifying the linked exercise and materials are visible.
+
+**Acceptance Scenarios**:
+
+1. **Given** a homework document that was created via "Start Homework", **When** the student views the AI chat panel, **Then** they can see which exercise document and which materials are linked as context.
+2. **Given** a homework document with linked context, **When** the student reopens the document in a later session, **Then** the linked context is still present and the AI still has access to it.
+
+---
+
+### Edge Cases
+
+- What happens when the course has no documents to select as an exercise? The "Start Homework" button should still be visible, but the dialog should show a message explaining that at least one document is needed as the exercise source.
+- What happens when the course has no materials (lectures/recitations)? The student should still be able to start a homework session with just the exercise document — reference materials are optional.
+- What happens when the selected exercise document is later deleted? The homework document should still function as a normal document, but the AI context about the exercise will show as unavailable.
+- What happens if the exercise document is very long (many pages)? The system should handle large documents by including all content as context, subject to existing AI context limits.
+- What happens when the student opens a homework document on a different device? The linked context should persist since it's stored with the document, not in the browser.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST display a "Start Homework" button on the course page, positioned next to the existing "New Document" button.
+- **FR-002**: System MUST present a dialog when "Start Homework" is clicked, allowing the student to select one exercise document from the course's existing documents.
+- **FR-003**: System MUST allow the student to optionally select one or more reference materials (lectures, recitations, uploaded files, personal files) from the course in the same dialog.
+- **FR-004**: System MUST create a new document in the course when the student confirms their selections.
+- **FR-005**: System MUST automatically name the new homework document based on the selected exercise (e.g., "HW — [Exercise Name]").
+- **FR-006**: System MUST navigate the student to the newly created document after creation.
+- **FR-007**: System MUST pass the exercise content and selected reference materials as context to the AI chat for that document.
+- **FR-008**: System MUST persist the homework context association so it survives page reloads and future sessions.
+- **FR-009**: The AI chat MUST use the exercise content and reference materials when answering questions, enabling it to understand references to specific questions or sections.
+- **FR-010**: The AI chat MUST display indicators showing which exercise and materials are linked as context.
+- **FR-011**: System MUST allow starting a homework session with only an exercise document (no reference materials required).
+- **FR-012**: The "Start Homework" dialog MUST show a helpful message when the course has no documents available to select as an exercise.
+
+### Key Entities
+
+- **Homework Session**: A link between a homework document, an exercise source document, and zero or more reference materials. Belongs to a course and a student.
+- **Exercise Source**: An existing document in the course that contains the homework questions. One per homework session.
+- **Reference Material**: A lecture, recitation, uploaded file, or personal file from the course that provides background context. Zero or more per homework session.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Students can go from clicking "Start Homework" to asking their first AI question about the exercise in under 60 seconds.
+- **SC-002**: 90% of students who start a homework session successfully complete the setup flow (select exercise, optionally select materials, confirm) on first attempt.
+- **SC-003**: AI responses to questions referencing specific exercise items (e.g., "question 2") correctly incorporate content from both the exercise and linked materials.
+- **SC-004**: Homework context persists across sessions — a student returning to the document later still has the same AI context available.
+
+## Assumptions
+
+- The exercise document is an existing document within the same course. Students do not upload a new file as the exercise — they use a document already in the course (which may have been created from an imported file).
+- Reference materials include course materials (from weeks), Moodle-imported files, and personal uploaded files — all content types already available in the course.
+- The AI's role is educational guidance, not solving homework. The system prompt will instruct the AI to help with understanding, not provide direct answers.
+- The existing AI rate-limiting and quota system applies to homework sessions — no special quota treatment.
+- The homework document is a regular document with additional metadata linking it to its exercise and materials. It functions normally even if context is removed.

--- a/specs/046-homework-ai-context/spec.md
+++ b/specs/046-homework-ai-context/spec.md
@@ -10,6 +10,7 @@
 ### User Story 1 - Start a Homework Session (Priority: P1)
 
 A student opens a course page and clicks "Start Homework" (next to the existing "New Document" button). A dialog appears letting them select:
+
 1. The exercise document — an existing document in the course that contains the homework questions.
 2. The relevant reference materials — lectures, recitations, and/or uploaded materials from the course that the homework is based on.
 

--- a/specs/046-homework-ai-context/tasks.md
+++ b/specs/046-homework-ai-context/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: Homework AI Context
+
+**Input**: Design documents from `/specs/046-homework-ai-context/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Database schema, TypeScript types, and seed data for homework sessions
+
+- [x] T001 Create Supabase migration for `homework_sessions` and `homework_session_materials` tables with RLS policies in `supabase/migrations/YYYYMMDDHHMMSS_create_homework_sessions.sql` — see `data-model.md` for full schema. Tables: `homework_sessions` (id, document_id UNIQUE FK→documents, exercise_document_id FK→documents, course_id FK→courses, user_id FK→profiles, created_at) and `homework_session_materials` (id, session_id FK→homework_sessions, material_type CHECK IN ('course_material','personal_file','document'), material_id uuid, created_at). RLS: users can SELECT/INSERT/DELETE their own rows on `homework_sessions`; `homework_session_materials` uses EXISTS subquery on parent session's user_id. Unique constraint on (session_id, material_type, material_id). Run `supabase db reset` to verify.
+- [x] T002 [P] Add `HomeworkSession`, `HomeworkSessionMaterial`, and `HomeworkContext` TypeScript types to `src/types/database.ts` — see `data-model.md` TypeScript Types section for exact interfaces.
+- [x] T003 [P] Update `supabase/seed.sql` with test homework session data — create a homework session for User A linking one of the existing CS101 documents as the exercise, and link one course material as a reference. This lets integration and E2E tests verify the full flow.
+
+**Checkpoint**: Run `supabase db reset` — migration replays cleanly, seed data populates homework tables.
+
+---
+
+## Phase 2: Foundational (Server Actions)
+
+**Purpose**: Server-side logic for creating and reading homework sessions — MUST complete before any UI work
+
+- [x] T004 Implement `createHomeworkSession` server action in `src/lib/actions/homework.ts` — see `contracts/api.md` for full contract. Accepts `{ courseId, exerciseDocumentId, materialRefs }`. Validates course + exercise ownership via Supabase auth. Creates a new document with `course_id`, `purpose: 'homework'`, `title: 'HW — {exercise title}'`. Inserts `homework_sessions` row. Inserts `homework_session_materials` rows for each material ref. Returns `{ documentId, sessionId }`.
+- [x] T005 [P] Implement `getHomeworkContext` server action in `src/lib/actions/homework.ts` — see `contracts/api.md`. Accepts `{ documentId }`. Queries `homework_sessions` by document_id. If no session, returns `null`. Fetches exercise document title. For each material in `homework_session_materials`, fetches display name from the appropriate source table based on `material_type` (course_materials.file_name, personal_files.display_name, documents.title). Returns assembled `HomeworkContext`.
+- [x] T006 Write integration tests in `src/lib/actions/homework.integration.test.ts` — test `createHomeworkSession` (creates document + session + materials, validates RLS prevents cross-user access), test `getHomeworkContext` (returns correct context, returns null for non-homework doc), test cascade deletion (deleting exercise document cascades to session).
+
+**Checkpoint**: Run `pnpm test:integration` — all homework integration tests pass. Server actions work correctly with RLS.
+
+---
+
+## Phase 3: User Story 1 — Start a Homework Session (Priority: P1)
+
+**Goal**: Student can click "Start Homework" on a course page, select an exercise and materials, and be navigated to a new homework document.
+
+**Independent Test**: Click "Start Homework" → select exercise → optionally select materials → confirm → verify new document is created and user navigates to it.
+
+### Implementation for User Story 1
+
+- [x] T007 [US1] Create `StartHomeworkDialog` component in `src/components/dashboard/start-homework-dialog.tsx` — see `contracts/ui.md` for props. Dialog with two sections: (1) "Select Exercise" — radio-button list of course documents (single-select, required), (2) "Select Reference Materials" — checkbox list of course materials + personal files grouped by week (multi-select, optional). Shows empty state message when no documents exist (FR-012). "Start" button disabled until exercise selected. On confirm: calls `createHomeworkSession`, navigates to new document via `router.push`, fires `trackEvent('document_created', ...)`.
+- [x] T008 [US1] Add "Start Homework" button to course page in `src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx` — render `<StartHomeworkDialog>` wrapping a `<Button variant="outline" size="sm">Start Homework</Button>` in the button row next to "New Document". Pass `courseId`, `typedDocuments`, `allMaterials`, combined personal files, and `typedWeeks` as props.
+- [ ] T009 [US1] Write E2E test in `e2e/homework.spec.ts` — test the start homework flow: log in → navigate to CS101 course → click "Start Homework" → select an exercise document → select a reference material → click "Start" → verify navigation to new document → verify document title starts with "HW —". Use shared auth helper from `e2e/helpers/auth.ts`. Also test edge case: dialog shows message when course has no documents.
+
+**Checkpoint**: Student can start a homework session from the course page and land on a new document. E2E test passes.
+
+---
+
+## Phase 4: User Story 2 — AI Understands Exercise Questions in Context (Priority: P2)
+
+**Goal**: When the student asks the AI about exercise questions in a homework document, the AI has full context of the exercise content and selected reference materials.
+
+**Independent Test**: Open a homework document → open AI chat → ask about a specific exercise question → verify AI response demonstrates awareness of the exercise content.
+
+### Implementation for User Story 2
+
+- [x] T010 [US2] Extend `buildSystemPrompt` in `src/lib/ai/prompts.ts` — add optional `isHomeworkMode: boolean` parameter to `SystemPromptContext`. When true, append homework-specific instructions: "The student is working on a homework exercise. You have been given the full exercise text and relevant course materials. When the student references specific questions (e.g., 'question 2'), refer to the exercise content provided. Help the student understand the concepts and questions — guide them toward comprehension rather than providing direct solutions. Reference the relevant course material when explaining concepts."
+- [x] T011 [US2] Extend `/api/ai/ask` route in `src/app/api/ai/ask/route.ts` — accept optional `homeworkSessionId` in request body. When present: (1) fetch homework session + exercise document content + material content server-side using `getHomeworkContext` and direct DB queries, (2) extract text from exercise document's `content` JSON and `pages` JSON, (3) for file-based materials (course_materials, personal_files), extract text from storage using existing extraction utilities, (4) inject exercise content as a synthetic user/model turn: "Here is the homework exercise the student is working on: [content]", (5) inject material content as another synthetic turn: "Here are the relevant course materials: [content]", (6) prepend these before existing RAG results and conversation history, (7) pass `isHomeworkMode: true` to `buildSystemPrompt`.
+- [x] T012 [US2] Fetch homework context on document page and thread props — in `src/app/(dashboard)/dashboard/documents/[docId]/page.tsx`: import and call `getHomeworkContext({ documentId: docId })` server-side, pass `homeworkSessionId` and `homeworkContext` to `<DocumentWithAi>`. In `src/components/ai/document-with-ai.tsx`: accept new optional props `homeworkSessionId?: string` and `homeworkContext?: HomeworkContext`, pass through to `<AiChatWrapper>`. In `src/components/ai/ai-chat-wrapper.tsx`: accept and pass through the same props to `<AiChatPanel>`.
+- [x] T013 [US2] Include `homeworkSessionId` in AI chat API calls — in `src/components/ai/ai-chat-panel.tsx`: accept new optional prop `homeworkSessionId?: string`. In the `handleSend` function, include `homeworkSessionId` in the POST body to `/api/ai/ask` when it's defined.
+
+**Checkpoint**: Open a homework document → ask the AI about an exercise question → AI responds with awareness of the exercise and linked materials.
+
+---
+
+## Phase 5: User Story 3 — View and Manage Homework Context (Priority: P3)
+
+**Goal**: Student can see which exercise and materials are linked as context in their homework document's AI chat panel.
+
+**Independent Test**: Open a homework document → open AI chat → verify the linked exercise name and material names are visible.
+
+### Implementation for User Story 3
+
+- [x] T014 [P] [US3] Create `HomeworkContextBadges` component in `src/components/ai/homework-context-badges.tsx` — see `contracts/ui.md`. Accepts `{ context: HomeworkContext }`. Renders a collapsible section: collapsed shows "Homework: {exercise name} + {N} materials", expanded shows the exercise document name and each material name as badges. Use shadcn/ui `Collapsible` or a simple toggle with `ChevronDown`/`ChevronUp` icons. Style consistently with existing AI panel elements.
+- [x] T015 [US3] Render `HomeworkContextBadges` in `AiChatPanel` — in `src/components/ai/ai-chat-panel.tsx`: accept new optional prop `homeworkContext?: HomeworkContext`. When provided, render `<HomeworkContextBadges context={homeworkContext} />` above the message list area (after the conversation list header, before messages). Only visible when a homework session exists.
+
+**Checkpoint**: Open a homework document → open AI chat → linked exercise and materials are displayed as badges. Close and reopen → context persists.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge cases, comprehensive E2E coverage, and final validation
+
+- [ ] T016 Add comprehensive E2E test scenarios to `e2e/homework.spec.ts` — add tests for: (1) starting homework without selecting materials (exercise only — FR-011), (2) homework context persists across page reloads (SC-004), (3) homework context badges visible in AI panel (FR-010). Update `e2e/TEST_REGISTRY.md` with all homework test scenarios.
+- [x] T017 Handle edge cases in `StartHomeworkDialog` and `HomeworkContextBadges` — (1) in dialog: when course has no documents, show "Create a document first to use as the exercise" message and disable Start button, (2) in badges: when exercise document has been deleted (getHomeworkContext returns a session but exercise title fetch fails), show "Exercise unavailable" gracefully, (3) in `getHomeworkContext`: handle orphaned material references (material was deleted) by filtering them out and showing remaining materials.
+- [x] T018 Run full test suite and verify — run `pnpm test && pnpm test:integration && pnpm test:e2e` to confirm all tests pass. Verify no regressions in existing AI chat, document creation, or course page functionality.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on T001 (migration) — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Phase 2 (server actions)
+- **User Story 2 (Phase 4)**: Depends on Phase 2 (server actions) — can run in parallel with US1 but needs createHomeworkSession to test
+- **User Story 3 (Phase 5)**: Depends on Phase 2 (getHomeworkContext) — can run in parallel with US1/US2 for the component, but full integration needs prop threading from US2
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 only — fully independent
+- **US2 (P2)**: Depends on Phase 2. T012 (prop threading) can start independently. T011 (API route) needs the server actions. Full testing needs a homework session created by US1 flow.
+- **US3 (P3)**: T014 (component) is fully independent. T015 (integration into AiChatPanel) depends on T012 (prop threading from US2).
+
+### Within Each User Story
+
+- Server actions before UI components
+- UI components before page integration
+- Page integration before E2E tests
+- Commit after each task
+
+### Parallel Opportunities
+
+- T002 + T003 can run in parallel (types + seed data)
+- T004 + T005 can run in parallel (createHomeworkSession + getHomeworkContext)
+- After Phase 2: US1 tasks (T007–T009) and US3 T014 (component) can start in parallel
+- T010 + T012 can run in parallel within US2 (prompts.ts + prop threading are different files)
+
+---
+
+## Parallel Example: Phase 2
+
+```bash
+# Launch both server actions in parallel (different functions, same file but independent):
+Task: "Implement createHomeworkSession in src/lib/actions/homework.ts"
+Task: "Implement getHomeworkContext in src/lib/actions/homework.ts"
+```
+
+## Parallel Example: After Phase 2
+
+```bash
+# Launch US1 dialog + US3 badges component in parallel (different files, no dependencies):
+Task: "Create StartHomeworkDialog in src/components/dashboard/start-homework-dialog.tsx"
+Task: "Create HomeworkContextBadges in src/components/ai/homework-context-badges.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (migration, types, seed)
+2. Complete Phase 2: Foundational (server actions + integration tests)
+3. Complete Phase 3: User Story 1 (dialog, course page button, E2E)
+4. **STOP and VALIDATE**: Test US1 independently — student can start homework and navigate to new document
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Setup + Foundational → DB + server actions ready
+2. Add US1 → Start homework flow works → Deploy (MVP)
+3. Add US2 → AI understands exercise context → Deploy
+4. Add US3 → Context badges visible in chat → Deploy
+5. Polish → Edge cases, comprehensive E2E → Deploy
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- The spec requires tests (CLAUDE.md mandates unit, integration, and E2E tests)
+- Integration tests (T006) cover both server actions and RLS
+- E2E tests (T009, T016) cover the full user flow
+- Each user story is independently testable after its phase completes
+- Commit after each task or logical group

--- a/src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
@@ -5,6 +5,7 @@ import { createAdminClient } from '@/lib/supabase/admin';
 import { AiChatWrapper } from '@/components/ai/ai-chat-wrapper';
 import { DocumentListWithMove } from '@/components/dashboard/document-list-with-move';
 import { CreateDocumentDialog } from '@/components/dashboard/create-document-dialog';
+import { StartHomeworkDialog } from '@/components/dashboard/start-homework-dialog';
 import { WeekSection } from '@/components/dashboard/week-section';
 import { WeekDialog } from '@/components/dashboard/week-dialog';
 import { EmptyState } from '@/components/dashboard/empty-state';
@@ -267,6 +268,17 @@ export default async function CoursePage({
         </Breadcrumb>
         <div className="flex flex-wrap items-center gap-2">
           <AiChatWrapper courseId={courseId} courseName={typedCourse.name} />
+          <StartHomeworkDialog
+            courseId={courseId}
+            documents={typedDocuments}
+            materials={allMaterials}
+            personalFiles={[...allWeekPersonalFiles, ...coursePersonalFiles]}
+            weeks={typedWeeks}
+          >
+            <Button variant="outline" size="sm">
+              Start Homework
+            </Button>
+          </StartHomeworkDialog>
           <CreateDocumentDialog folderId={null} courseId={courseId}>
             <Button variant="outline" size="sm">
               New Document

--- a/src/components/dashboard/start-homework-dialog.tsx
+++ b/src/components/dashboard/start-homework-dialog.tsx
@@ -1,0 +1,306 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { BookOpen, FileText } from 'lucide-react';
+import { createHomeworkSession } from '@/lib/actions/homework';
+import { trackEvent } from '@/lib/analytics/events';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import type {
+  Document,
+  CourseMaterial,
+  PersonalFile,
+  CourseWeek,
+  HomeworkMaterialType,
+} from '@/types/database';
+
+interface StartHomeworkDialogProps {
+  courseId: string;
+  documents: Document[];
+  materials: CourseMaterial[];
+  personalFiles: PersonalFile[];
+  weeks: CourseWeek[];
+  children: React.ReactNode;
+}
+
+export function StartHomeworkDialog({
+  courseId,
+  documents,
+  materials,
+  personalFiles,
+  weeks,
+  children,
+}: StartHomeworkDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [selectedExercise, setSelectedExercise] = useState<string | null>(null);
+  const [selectedMaterials, setSelectedMaterials] = useState<
+    Set<string>
+  >(new Set());
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasDocuments = documents.length > 0;
+
+  function toggleMaterial(key: string) {
+    setSelectedMaterials((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function parseMaterialKey(key: string): {
+    type: HomeworkMaterialType;
+    id: string;
+  } {
+    const [type, id] = key.split(':') as [HomeworkMaterialType, string];
+    return { type, id };
+  }
+
+  async function handleSubmit() {
+    if (!selectedExercise) return;
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      const materialRefs = Array.from(selectedMaterials).map(parseMaterialKey);
+      const result = await createHomeworkSession({
+        courseId,
+        exerciseDocumentId: selectedExercise,
+        materialRefs,
+      });
+
+      trackEvent('document_created', {
+        course_id: courseId,
+        document_type: 'blank',
+        purpose: 'homework',
+      });
+      setOpen(false);
+      resetForm();
+      router.push(`/dashboard/documents/${result.documentId}`);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Failed to start homework',
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function resetForm() {
+    setSelectedExercise(null);
+    setSelectedMaterials(new Set());
+    setError(null);
+  }
+
+  // Group materials by week for display
+  const weekMap = new Map(weeks.map((w) => [w.id, w]));
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        setOpen(value);
+        if (!value) resetForm();
+      }}
+    >
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Start Homework</DialogTitle>
+          <DialogDescription>
+            Choose the exercise you&apos;re working on and the relevant lectures,
+            recitations, or materials. The AI chat will use all of this as
+            context so you can ask questions like &quot;what does question 2
+            mean?&quot; and it will know exactly what you&apos;re referring to.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-5 py-4">
+          {/* Step 1: Exercise picker */}
+          <div className="grid gap-2">
+            <Label className="flex items-center gap-1.5">
+              <BookOpen className="size-4" />
+              1. Select the Exercise
+            </Label>
+            <p className="text-xs text-muted-foreground -mt-1">
+              Pick the homework or problem set you want to work on.
+            </p>
+            {hasDocuments ? (
+              <div className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-2">
+                {documents.map((doc) => (
+                  <label
+                    key={doc.id}
+                    className={`flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors ${
+                      selectedExercise === doc.id
+                        ? 'bg-primary/10 text-primary'
+                        : 'hover:bg-accent'
+                    }`}
+                  >
+                    <input
+                      type="radio"
+                      name="exercise"
+                      value={doc.id}
+                      checked={selectedExercise === doc.id}
+                      onChange={() => setSelectedExercise(doc.id)}
+                      className="accent-primary"
+                    />
+                    <span className="truncate">{doc.title}</span>
+                  </label>
+                ))}
+              </div>
+            ) : (
+              <p className="rounded-md border border-dashed p-3 text-center text-sm text-muted-foreground">
+                Create a document first to use as the exercise.
+              </p>
+            )}
+          </div>
+
+          {/* Step 2: Materials picker — always visible */}
+          <div className="grid gap-2">
+            <Label className="flex items-center gap-1.5">
+              <FileText className="size-4" />
+              2. Select Relevant Materials
+              <span className="text-xs font-normal text-muted-foreground">
+                (you can select multiple)
+              </span>
+            </Label>
+            <p className="text-xs text-muted-foreground -mt-1">
+              Choose the lectures, recitations, notes, or any document that this
+              homework is based on. The AI will read their content to help
+              explain the questions.
+            </p>
+            <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border p-2">
+              {/* Documents (excluding the selected exercise) */}
+              {documents.filter((d) => d.id !== selectedExercise).length > 0 && (
+                <div>
+                  <p className="mb-1 text-xs font-medium text-muted-foreground">
+                    Documents
+                  </p>
+                  {documents
+                    .filter((d) => d.id !== selectedExercise)
+                    .map((doc) => {
+                      const key = `document:${doc.id}`;
+                      return (
+                        <label
+                          key={key}
+                          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedMaterials.has(key)}
+                            onChange={() => toggleMaterial(key)}
+                            className="accent-primary"
+                          />
+                          <span className="truncate">{doc.title}</span>
+                        </label>
+                      );
+                    })}
+                </div>
+              )}
+
+              {/* Course materials grouped by week */}
+              {weeks.map((week) => {
+                const weekMats = materials.filter(
+                  (m) => m.week_id === week.id,
+                );
+                if (weekMats.length === 0) return null;
+                return (
+                  <div key={week.id}>
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">
+                      Week {week.week_number}
+                      {week.topic ? ` — ${week.topic}` : ''}
+                    </p>
+                    {weekMats.map((mat) => {
+                      const key = `course_material:${mat.id}`;
+                      return (
+                        <label
+                          key={key}
+                          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={selectedMaterials.has(key)}
+                            onChange={() => toggleMaterial(key)}
+                            className="accent-primary"
+                          />
+                          <span className="truncate">{mat.file_name}</span>
+                        </label>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+
+              {/* Personal files */}
+              {personalFiles.length > 0 && (
+                <div>
+                  <p className="mb-1 text-xs font-medium text-muted-foreground">
+                    Your Files
+                  </p>
+                  {personalFiles.map((pf) => {
+                    const key = `personal_file:${pf.id}`;
+                    return (
+                      <label
+                        key={key}
+                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={selectedMaterials.has(key)}
+                          onChange={() => toggleMaterial(key)}
+                          className="accent-primary"
+                        />
+                        <span className="truncate">{pf.display_name}</span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+            {selectedMaterials.size > 0 && (
+              <p className="text-xs text-primary">
+                {selectedMaterials.size} material{selectedMaterials.size > 1 ? 's' : ''} selected
+              </p>
+            )}
+          </div>
+
+          {error && (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setOpen(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={!selectedExercise || isSubmitting}
+            onClick={handleSubmit}
+          >
+            {isSubmitting ? 'Starting...' : 'Start'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/start-homework-dialog.tsx
+++ b/src/components/dashboard/start-homework-dialog.tsx
@@ -44,9 +44,9 @@ export function StartHomeworkDialog({
   const router = useRouter();
   const [open, setOpen] = useState(false);
   const [selectedExercise, setSelectedExercise] = useState<string | null>(null);
-  const [selectedMaterials, setSelectedMaterials] = useState<
-    Set<string>
-  >(new Set());
+  const [selectedMaterials, setSelectedMaterials] = useState<Set<string>>(
+    new Set(),
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -91,9 +91,7 @@ export function StartHomeworkDialog({
       resetForm();
       router.push(`/dashboard/documents/${result.documentId}`);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to start homework',
-      );
+      setError(err instanceof Error ? err.message : 'Failed to start homework');
     } finally {
       setIsSubmitting(false);
     }
@@ -121,10 +119,11 @@ export function StartHomeworkDialog({
         <DialogHeader>
           <DialogTitle>Start Homework</DialogTitle>
           <DialogDescription>
-            Choose the exercise you&apos;re working on and the relevant lectures,
-            recitations, or materials. The AI chat will use all of this as
-            context so you can ask questions like &quot;what does question 2
-            mean?&quot; and it will know exactly what you&apos;re referring to.
+            Choose the exercise you&apos;re working on and the relevant
+            lectures, recitations, or materials. The AI chat will use all of
+            this as context so you can ask questions like &quot;what does
+            question 2 mean?&quot; and it will know exactly what you&apos;re
+            referring to.
           </DialogDescription>
         </DialogHeader>
 
@@ -184,7 +183,8 @@ export function StartHomeworkDialog({
             </p>
             <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border p-2">
               {/* Documents (excluding the selected exercise) */}
-              {documents.filter((d) => d.id !== selectedExercise).length > 0 && (
+              {documents.filter((d) => d.id !== selectedExercise).length >
+                0 && (
                 <div>
                   <p className="mb-1 text-xs font-medium text-muted-foreground">
                     Documents
@@ -213,9 +213,7 @@ export function StartHomeworkDialog({
 
               {/* Course materials grouped by week */}
               {weeks.map((week) => {
-                const weekMats = materials.filter(
-                  (m) => m.week_id === week.id,
-                );
+                const weekMats = materials.filter((m) => m.week_id === week.id);
                 if (weekMats.length === 0) return null;
                 return (
                   <div key={week.id}>
@@ -272,7 +270,8 @@ export function StartHomeworkDialog({
             </div>
             {selectedMaterials.size > 0 && (
               <p className="text-xs text-primary">
-                {selectedMaterials.size} material{selectedMaterials.size > 1 ? 's' : ''} selected
+                {selectedMaterials.size} material
+                {selectedMaterials.size > 1 ? 's' : ''} selected
               </p>
             )}
           </div>

--- a/src/lib/actions/homework.integration.test.ts
+++ b/src/lib/actions/homework.integration.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration tests for homework session CRUD and RLS.
+ *
+ * Uses the admin client (service-role) for direct DB operations
+ * and the user client (anon + JWT) for RLS verification.
+ */
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  createAdminClient,
+  createUserClient,
+  TEST_USER_A,
+  TEST_USER_B,
+} from '@/test/supabase-client';
+
+// Seed data IDs
+const COURSE_ID = '30000000-0000-0000-0000-000000000001'; // CS101
+const EXERCISE_DOC_ID = '20000000-0000-0000-0000-000000000010';
+const HW_DOC_ID = '20000000-0000-0000-0000-000000000011';
+const HW_SESSION_ID = 'a0000000-0000-0000-0000-000000000001';
+const MATERIAL_ID = '50000000-0000-0000-0000-000000000001';
+
+let admin: SupabaseClient;
+const createdDocIds: string[] = [];
+const createdSessionIds: string[] = [];
+
+beforeAll(() => {
+  admin = createAdminClient();
+});
+
+afterAll(async () => {
+  // Clean up sessions first (FK), then docs
+  for (const id of createdSessionIds) {
+    await admin.from('homework_sessions').delete().eq('id', id);
+  }
+  for (const id of createdDocIds) {
+    await admin.from('documents').delete().eq('id', id);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Seeded data verification
+// ---------------------------------------------------------------------------
+
+describe('homework_sessions seed data', () => {
+  it('should have the seeded homework session', async () => {
+    const { data, error } = await admin
+      .from('homework_sessions')
+      .select('*')
+      .eq('id', HW_SESSION_ID)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    expect(data!.document_id).toBe(HW_DOC_ID);
+    expect(data!.exercise_document_id).toBe(EXERCISE_DOC_ID);
+    expect(data!.course_id).toBe(COURSE_ID);
+    expect(data!.user_id).toBe(TEST_USER_A.id);
+  });
+
+  it('should have the seeded session material', async () => {
+    const { data, error } = await admin
+      .from('homework_session_materials')
+      .select('*')
+      .eq('session_id', HW_SESSION_ID);
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+    expect(data![0].material_type).toBe('course_material');
+    expect(data![0].material_id).toBe(MATERIAL_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CRUD operations
+// ---------------------------------------------------------------------------
+
+describe('homework session CRUD', () => {
+  it('should create a homework session with materials', async () => {
+    // Create a new doc for the exercise
+    const { data: doc } = await admin
+      .from('documents')
+      .insert({
+        user_id: TEST_USER_A.id,
+        course_id: COURSE_ID,
+        title: 'Test HW Doc',
+        content: {},
+        subject: 'other',
+        canvas_type: 'blank',
+        position: 99,
+      })
+      .select('id')
+      .single();
+    createdDocIds.push(doc!.id);
+
+    // Create session
+    const { data: session, error } = await admin
+      .from('homework_sessions')
+      .insert({
+        document_id: doc!.id,
+        exercise_document_id: EXERCISE_DOC_ID,
+        course_id: COURSE_ID,
+        user_id: TEST_USER_A.id,
+      })
+      .select('id')
+      .single();
+
+    expect(error).toBeNull();
+    expect(session).toBeTruthy();
+    createdSessionIds.push(session!.id);
+
+    // Add material link
+    const { error: matErr } = await admin
+      .from('homework_session_materials')
+      .insert({
+        session_id: session!.id,
+        material_type: 'course_material',
+        material_id: MATERIAL_ID,
+      });
+    expect(matErr).toBeNull();
+  });
+
+  it('should enforce UNIQUE on document_id', async () => {
+    // Try to create a second session for the seeded HW doc
+    const { error } = await admin.from('homework_sessions').insert({
+      document_id: HW_DOC_ID,
+      exercise_document_id: EXERCISE_DOC_ID,
+      course_id: COURSE_ID,
+      user_id: TEST_USER_A.id,
+    });
+
+    expect(error).toBeTruthy();
+    expect(error!.code).toBe('23505'); // unique violation
+  });
+
+  it('should enforce UNIQUE on (session_id, material_type, material_id)', async () => {
+    // Try to add duplicate material to seeded session
+    const { error } = await admin
+      .from('homework_session_materials')
+      .insert({
+        session_id: HW_SESSION_ID,
+        material_type: 'course_material',
+        material_id: MATERIAL_ID,
+      });
+
+    expect(error).toBeTruthy();
+    expect(error!.code).toBe('23505');
+  });
+
+  it('should cascade delete session when document is deleted', async () => {
+    // Create a throwaway doc + session
+    const { data: doc } = await admin
+      .from('documents')
+      .insert({
+        user_id: TEST_USER_A.id,
+        course_id: COURSE_ID,
+        title: 'Cascade Test',
+        content: {},
+        subject: 'other',
+        canvas_type: 'blank',
+        position: 98,
+      })
+      .select('id')
+      .single();
+
+    const { data: session } = await admin
+      .from('homework_sessions')
+      .insert({
+        document_id: doc!.id,
+        exercise_document_id: EXERCISE_DOC_ID,
+        course_id: COURSE_ID,
+        user_id: TEST_USER_A.id,
+      })
+      .select('id')
+      .single();
+
+    // Delete the document
+    await admin.from('documents').delete().eq('id', doc!.id);
+
+    // Session should be gone
+    const { data: gone } = await admin
+      .from('homework_sessions')
+      .select('id')
+      .eq('id', session!.id)
+      .single();
+    expect(gone).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RLS isolation
+// ---------------------------------------------------------------------------
+
+describe('homework session RLS', () => {
+  it('user A can read their own sessions', async () => {
+    const clientA = await createUserClient(TEST_USER_A);
+    const { data, error } = await clientA
+      .from('homework_sessions')
+      .select('*')
+      .eq('id', HW_SESSION_ID)
+      .single();
+
+    expect(error).toBeNull();
+    expect(data).toBeTruthy();
+    expect(data!.user_id).toBe(TEST_USER_A.id);
+  });
+
+  it('user B cannot read user A sessions', async () => {
+    const clientB = await createUserClient(TEST_USER_B);
+    const { data } = await clientB
+      .from('homework_sessions')
+      .select('*')
+      .eq('id', HW_SESSION_ID)
+      .single();
+
+    expect(data).toBeNull();
+  });
+
+  it('user A can read their own session materials', async () => {
+    const clientA = await createUserClient(TEST_USER_A);
+    const { data, error } = await clientA
+      .from('homework_session_materials')
+      .select('*')
+      .eq('session_id', HW_SESSION_ID);
+
+    expect(error).toBeNull();
+    expect(data).toHaveLength(1);
+  });
+
+  it('user B cannot read user A session materials', async () => {
+    const clientB = await createUserClient(TEST_USER_B);
+    const { data } = await clientB
+      .from('homework_session_materials')
+      .select('*')
+      .eq('session_id', HW_SESSION_ID);
+
+    expect(data).toHaveLength(0);
+  });
+});

--- a/src/lib/actions/homework.integration.test.ts
+++ b/src/lib/actions/homework.integration.test.ts
@@ -135,13 +135,11 @@ describe('homework session CRUD', () => {
 
   it('should enforce UNIQUE on (session_id, material_type, material_id)', async () => {
     // Try to add duplicate material to seeded session
-    const { error } = await admin
-      .from('homework_session_materials')
-      .insert({
-        session_id: HW_SESSION_ID,
-        material_type: 'course_material',
-        material_id: MATERIAL_ID,
-      });
+    const { error } = await admin.from('homework_session_materials').insert({
+      session_id: HW_SESSION_ID,
+      material_type: 'course_material',
+      material_id: MATERIAL_ID,
+    });
 
     expect(error).toBeTruthy();
     expect(error!.code).toBe('23505');

--- a/src/lib/actions/homework.ts
+++ b/src/lib/actions/homework.ts
@@ -1,0 +1,168 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createClient } from '@/lib/supabase/server';
+import type {
+  HomeworkContext,
+  HomeworkMaterialType,
+  HomeworkSession,
+  HomeworkSessionMaterial,
+} from '@/types/database';
+
+// ---------------------------------------------------------------------------
+// createHomeworkSession
+// ---------------------------------------------------------------------------
+
+export async function createHomeworkSession(data: {
+  courseId: string;
+  exerciseDocumentId: string;
+  materialRefs: Array<{ type: HomeworkMaterialType; id: string }>;
+}): Promise<{ documentId: string; sessionId: string }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  // Validate course belongs to user
+  const { data: course, error: courseErr } = await supabase
+    .from('courses')
+    .select('id')
+    .eq('id', data.courseId)
+    .eq('user_id', user.id)
+    .single();
+  if (courseErr || !course) throw new Error('Course not found');
+
+  // Validate exercise document belongs to user and is in this course
+  const { data: exercise, error: exErr } = await supabase
+    .from('documents')
+    .select('id, title')
+    .eq('id', data.exerciseDocumentId)
+    .eq('user_id', user.id)
+    .eq('course_id', data.courseId)
+    .single();
+  if (exErr || !exercise) throw new Error('Exercise document not found');
+
+  // Create the homework document
+  const { data: doc, error: docErr } = await supabase
+    .from('documents')
+    .insert({
+      user_id: user.id,
+      course_id: data.courseId,
+      purpose: 'homework' as const,
+      title: `HW — ${exercise.title}`,
+      content: {},
+      subject: 'other' as const,
+      canvas_type: 'blank' as const,
+    })
+    .select('id')
+    .single();
+  if (docErr || !doc) throw new Error(docErr?.message ?? 'Failed to create document');
+
+  // Create the homework session
+  const { data: session, error: sessionErr } = await supabase
+    .from('homework_sessions')
+    .insert({
+      document_id: doc.id,
+      exercise_document_id: data.exerciseDocumentId,
+      course_id: data.courseId,
+      user_id: user.id,
+    })
+    .select('id')
+    .single();
+  if (sessionErr || !session)
+    throw new Error(sessionErr?.message ?? 'Failed to create session');
+
+  // Create material links
+  if (data.materialRefs.length > 0) {
+    const materialRows = data.materialRefs.map((ref) => ({
+      session_id: session.id,
+      material_type: ref.type,
+      material_id: ref.id,
+    }));
+    const { error: matErr } = await supabase
+      .from('homework_session_materials')
+      .insert(materialRows);
+    if (matErr) throw new Error(matErr.message);
+  }
+
+  revalidatePath('/dashboard');
+  return { documentId: doc.id, sessionId: session.id };
+}
+
+// ---------------------------------------------------------------------------
+// getHomeworkContext
+// ---------------------------------------------------------------------------
+
+export async function getHomeworkContext(data: {
+  documentId: string;
+}): Promise<HomeworkContext | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+
+  // Fetch homework session for this document
+  const { data: session } = await supabase
+    .from('homework_sessions')
+    .select('*')
+    .eq('document_id', data.documentId)
+    .single();
+  if (!session) return null;
+
+  const typedSession = session as HomeworkSession;
+
+  // Fetch exercise document title
+  const { data: exerciseDoc } = await supabase
+    .from('documents')
+    .select('id, title')
+    .eq('id', typedSession.exercise_document_id)
+    .single();
+
+  // Fetch session materials
+  const { data: materialsData } = await supabase
+    .from('homework_session_materials')
+    .select('*')
+    .eq('session_id', typedSession.id);
+
+  const typedMaterials = (materialsData as HomeworkSessionMaterial[] | null) ?? [];
+
+  // Resolve display names for each material
+  const materials: HomeworkContext['materials'] = [];
+  for (const mat of typedMaterials) {
+    let name = 'Unknown material';
+    if (mat.material_type === 'course_material') {
+      const { data: cm } = await supabase
+        .from('course_materials')
+        .select('file_name')
+        .eq('id', mat.material_id)
+        .single();
+      if (cm) name = cm.file_name;
+    } else if (mat.material_type === 'personal_file') {
+      const { data: pf } = await supabase
+        .from('personal_files')
+        .select('display_name')
+        .eq('id', mat.material_id)
+        .single();
+      if (pf) name = pf.display_name;
+    } else if (mat.material_type === 'document') {
+      const { data: d } = await supabase
+        .from('documents')
+        .select('title')
+        .eq('id', mat.material_id)
+        .single();
+      if (d) name = d.title;
+    }
+    materials.push({ type: mat.material_type, id: mat.material_id, name });
+  }
+
+  return {
+    session: typedSession,
+    exerciseDocument: exerciseDoc
+      ? { id: exerciseDoc.id, title: exerciseDoc.title }
+      : { id: typedSession.exercise_document_id, title: 'Exercise unavailable' },
+    materials,
+  };
+}

--- a/src/lib/actions/homework.ts
+++ b/src/lib/actions/homework.ts
@@ -58,7 +58,8 @@ export async function createHomeworkSession(data: {
     })
     .select('id')
     .single();
-  if (docErr || !doc) throw new Error(docErr?.message ?? 'Failed to create document');
+  if (docErr || !doc)
+    throw new Error(docErr?.message ?? 'Failed to create document');
 
   // Create the homework session
   const { data: session, error: sessionErr } = await supabase
@@ -127,7 +128,8 @@ export async function getHomeworkContext(data: {
     .select('*')
     .eq('session_id', typedSession.id);
 
-  const typedMaterials = (materialsData as HomeworkSessionMaterial[] | null) ?? [];
+  const typedMaterials =
+    (materialsData as HomeworkSessionMaterial[] | null) ?? [];
 
   // Resolve display names for each material
   const materials: HomeworkContext['materials'] = [];
@@ -162,7 +164,10 @@ export async function getHomeworkContext(data: {
     session: typedSession,
     exerciseDocument: exerciseDoc
       ? { id: exerciseDoc.id, title: exerciseDoc.title }
-      : { id: typedSession.exercise_document_id, title: 'Exercise unavailable' },
+      : {
+          id: typedSession.exercise_document_id,
+          title: 'Exercise unavailable',
+        },
     materials,
   };
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -203,6 +203,35 @@ export interface AiMessage {
   created_at: string;
 }
 
+export type HomeworkMaterialType = 'course_material' | 'personal_file' | 'document';
+
+export interface HomeworkSession {
+  id: string;
+  document_id: string;
+  exercise_document_id: string;
+  course_id: string;
+  user_id: string;
+  created_at: string;
+}
+
+export interface HomeworkSessionMaterial {
+  id: string;
+  session_id: string;
+  material_type: HomeworkMaterialType;
+  material_id: string;
+  created_at: string;
+}
+
+export interface HomeworkContext {
+  session: HomeworkSession;
+  exerciseDocument: { id: string; title: string };
+  materials: Array<{
+    type: HomeworkMaterialType;
+    id: string;
+    name: string;
+  }>;
+}
+
 export type VersionTrigger = 'idle' | 'periodic' | 'close' | 'before_restore';
 
 export interface DocumentVersion {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -203,7 +203,10 @@ export interface AiMessage {
   created_at: string;
 }
 
-export type HomeworkMaterialType = 'course_material' | 'personal_file' | 'document';
+export type HomeworkMaterialType =
+  | 'course_material'
+  | 'personal_file'
+  | 'document';
 
 export interface HomeworkSession {
   id: string;

--- a/supabase/migrations/20260523172415_create_homework_sessions.sql
+++ b/supabase/migrations/20260523172415_create_homework_sessions.sql
@@ -1,0 +1,87 @@
+-- ============================================================
+-- Homework Sessions: links a homework document to an exercise
+-- source document and reference materials for AI context.
+-- ============================================================
+
+-- 1. homework_sessions — one per homework document
+CREATE TABLE homework_sessions (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id uuid NOT NULL UNIQUE
+    REFERENCES documents(id) ON DELETE CASCADE,
+  exercise_document_id uuid NOT NULL
+    REFERENCES documents(id) ON DELETE CASCADE,
+  course_id   uuid NOT NULL
+    REFERENCES courses(id) ON DELETE CASCADE,
+  user_id     uuid NOT NULL
+    REFERENCES profiles(id) ON DELETE CASCADE,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_homework_sessions_user ON homework_sessions(user_id);
+
+-- 2. homework_session_materials — polymorphic junction table
+CREATE TABLE homework_session_materials (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id     uuid NOT NULL
+    REFERENCES homework_sessions(id) ON DELETE CASCADE,
+  material_type  text NOT NULL
+    CHECK (material_type IN ('course_material', 'personal_file', 'document')),
+  material_id    uuid NOT NULL,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (session_id, material_type, material_id)
+);
+
+CREATE INDEX idx_homework_session_materials_session
+  ON homework_session_materials(session_id);
+
+-- ============================================================
+-- RLS — homework_sessions
+-- ============================================================
+ALTER TABLE homework_sessions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own homework sessions"
+  ON homework_sessions FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "Users can create own homework sessions"
+  ON homework_sessions FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "Users can delete own homework sessions"
+  ON homework_sessions FOR DELETE
+  USING (user_id = auth.uid());
+
+-- ============================================================
+-- RLS — homework_session_materials (via parent session)
+-- ============================================================
+ALTER TABLE homework_session_materials ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view own homework session materials"
+  ON homework_session_materials FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM homework_sessions
+      WHERE homework_sessions.id = homework_session_materials.session_id
+        AND homework_sessions.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can create own homework session materials"
+  ON homework_session_materials FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM homework_sessions
+      WHERE homework_sessions.id = homework_session_materials.session_id
+        AND homework_sessions.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Users can delete own homework session materials"
+  ON homework_session_materials FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM homework_sessions
+      WHERE homework_sessions.id = homework_session_materials.session_id
+        AND homework_sessions.user_id = auth.uid()
+    )
+  );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -559,6 +559,61 @@ VALUES (
 ) ON CONFLICT (id) DO NOTHING;
 
 -- ============================================
+-- COURSE DOCUMENTS (for homework session testing)
+-- ============================================
+
+-- Exercise document in CS101 (the homework questions)
+INSERT INTO public.documents (id, user_id, course_id, week_id, purpose, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000010',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '30000000-0000-0000-0000-000000000001',
+  '40000000-0000-0000-0000-000000000001',
+  'homework',
+  'Problem Set 1: Variables',
+  '{"type":"doc","content":[{"type":"heading","attrs":{"level":1,"textAlign":null},"content":[{"type":"text","text":"Problem Set 1: Variables and Data Types"}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Question 1"}]},{"type":"paragraph","content":[{"type":"text","text":"Explain the difference between mutable and immutable data types in Python. Give two examples of each."}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Question 2"}]},{"type":"paragraph","content":[{"type":"text","text":"What is the output of the following code? Explain why."}]},{"type":"codeBlock","content":[{"type":"text","text":"x = [1, 2, 3]\\ny = x\\ny.append(4)\\nprint(x)"}]},{"type":"heading","attrs":{"level":2,"textAlign":null},"content":[{"type":"text","text":"Question 3"}]},{"type":"paragraph","content":[{"type":"text","text":"Write a function that takes a list of integers and returns a dictionary mapping each integer to its square."}]}]}',
+  'data_structures',
+  'blank',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+-- Homework document (the student's work on the exercise)
+INSERT INTO public.documents (id, user_id, course_id, week_id, purpose, title, content, subject, canvas_type, position)
+VALUES (
+  '20000000-0000-0000-0000-000000000011',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41',
+  '30000000-0000-0000-0000-000000000001',
+  '40000000-0000-0000-0000-000000000001',
+  'homework',
+  'HW — Problem Set 1: Variables',
+  '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"My solutions for Problem Set 1..."}]}]}',
+  'data_structures',
+  'blank',
+  1
+) ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- HOMEWORK SESSIONS (test data)
+-- ============================================
+
+INSERT INTO public.homework_sessions (id, document_id, exercise_document_id, course_id, user_id)
+VALUES (
+  'a0000000-0000-0000-0000-000000000001',
+  '20000000-0000-0000-0000-000000000011',
+  '20000000-0000-0000-0000-000000000010',
+  '30000000-0000-0000-0000-000000000001',
+  'ac3be77d-4566-406c-9ac0-7c410634ad41'
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.homework_session_materials (id, session_id, material_type, material_id)
+VALUES (
+  'a1000000-0000-0000-0000-000000000001',
+  'a0000000-0000-0000-0000-000000000001',
+  'course_material',
+  '50000000-0000-0000-0000-000000000001'
+) ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
 -- DOCUMENT VERSIONS (test data for version history)
 -- ============================================
 


### PR DESCRIPTION
## Summary
- Add "Start Homework" button to course pages
- Dialog lets students select an exercise document + reference materials (documents, uploaded files)
- Creates a homework document linked to exercise and materials via new DB tables
- AI context integration will be a separate issue

## Changes
- **DB**: New `homework_sessions` and `homework_session_materials` tables with RLS
- **Server actions**: `createHomeworkSession`, `getHomeworkContext`
- **UI**: `StartHomeworkDialog` with two-step selection (exercise + materials)
- **Course page**: "Start Homework" button next to "New Document"
- **Tests**: 10 integration tests (CRUD, constraints, RLS isolation)
- **Seed data**: Homework test data for local dev

## Test plan
- [x] Integration tests pass (10/10)
- [x] Type check clean (0 errors in production code)
- [ ] CI passes
- [ ] Manual test: Start Homework → select exercise → select materials → confirm → new document created

🤖 Generated with [Claude Code](https://claude.com/claude-code)