### PR TITLE
feat: pick Start Homework exercise from any imported source

### DIFF
--- a/docs/superpowers/specs/2026-05-26-polymorphic-homework-exercise-design.md
+++ b/docs/superpowers/specs/2026-05-26-polymorphic-homework-exercise-design.md
@@ -48,7 +48,7 @@ type HomeworkExerciseType = HomeworkMaterialType;
   `type === 'document'`** (otherwise `null`). The legacy column is kept in sync
   for documents so any un-migrated reader and the unique/back-compat paths still
   work.
-- **Read** (both readers): compute an *effective* exercise ref with a fallback
+- **Read** (both readers): compute an _effective_ exercise ref with a fallback
   for pre-feature / seeded rows:
 
   ```ts

--- a/docs/superpowers/specs/2026-05-26-polymorphic-homework-exercise-design.md
+++ b/docs/superpowers/specs/2026-05-26-polymorphic-homework-exercise-design.md
@@ -1,0 +1,181 @@
+# Polymorphic Homework Exercise — Design
+
+**Date:** 2026-05-26
+**Branch:** `feat/polymorphic-homework-exercise` (off `dev`, after PR #199 merged)
+**Status:** design — awaiting user review before plan + implementation
+
+## Goal
+
+In the **Start Homework** dialog, let Step 1 ("Select the Exercise") pick the
+exercise from **any imported source** — typed documents, course materials,
+personal files, or Moodle files — not just typed `documents`. The created
+homework document remains the blank workspace where the student writes their
+solution.
+
+## Context — current state
+
+- **Dialog** (`src/components/dashboard/start-homework-dialog.tsx`): Step 1 lists
+  only `documents` (single-select radio, value = bare document id). Step 2
+  ("Materials") already lists all four sources as `${type}:${id}` checkboxes.
+- **Server action** `createHomeworkSession` (`src/lib/actions/homework.ts`):
+  takes `exerciseDocumentId: string`, validates it is a `documents` row owned by
+  the user in the course, and writes `homework_sessions.exercise_document_id`.
+- **Readers** assume the exercise is a document:
+  - `getHomeworkContext` (`homework.ts`) reads `exercise_document_id` → returns
+    `exerciseDocument: { id, title }` for the chip.
+  - `resolveHomeworkContext` (`src/lib/ai/homework-context.ts`) reads
+    `exercise_document_id`, extracts its text into Tier 1.
+- **Schema is already polymorphic-ready.** Migration
+  `20260524144454_add_moodle_file_to_homework_materials.sql` (shipped in #199)
+  made `exercise_document_id` **nullable** and added `exercise_type text` +
+  `exercise_id uuid`; `homework_session_materials.material_type` already includes
+  `moodle_file`. **No migration is needed** — this work is application-layer only.
+
+## Design
+
+Reuse the existing `HomeworkMaterialType` for the exercise:
+
+```ts
+// the exercise can be any of the same four sources Step 2 already supports
+type HomeworkExerciseType = HomeworkMaterialType;
+// 'course_material' | 'personal_file' | 'document' | 'moodle_file'
+```
+
+### Data model — write & read
+
+- **Write** (`createHomeworkSession`): always set `exercise_type = type` and
+  `exercise_id = id`. Additionally set `exercise_document_id = id` **only when
+  `type === 'document'`** (otherwise `null`). The legacy column is kept in sync
+  for documents so any un-migrated reader and the unique/back-compat paths still
+  work.
+- **Read** (both readers): compute an *effective* exercise ref with a fallback
+  for pre-feature / seeded rows:
+
+  ```ts
+  const exercise = session.exercise_type
+    ? { type: session.exercise_type, id: session.exercise_id }
+    : { type: 'document', id: session.exercise_document_id }; // legacy rows
+  ```
+
+  This keeps the **seeded** homework session (`supabase/seed.sql`, which only
+  sets `exercise_document_id`) and the existing homework E2E green without a
+  data backfill.
+
+### Change 1 — Dialog Step 1 (exercise picker)
+
+- Render the same four source groups Step 2 renders, but as **single-select
+  radios**, with `value = ${type}:${id}` (the same key format Step 2 uses for
+  checkboxes). `selectedExercise` becomes the selected key string (or `null`).
+- Step 2 already excludes the chosen document; **generalize** that exclusion to
+  skip whichever `${type}:${id}` equals `selectedExercise`, across all groups.
+- `handleSubmit` parses the key (reusing the existing `parseMaterialKey`) into
+  `{ type, id }` and passes it as `exercise`.
+- Moodle sections are already lazy-loaded on dialog open for Step 2; Step 1
+  reuses that same state — no extra fetch.
+
+### Change 2 — `createHomeworkSession`
+
+- Signature: `{ courseId, exercise: { type, id }, materialRefs }` (replaces
+  `exerciseDocumentId`).
+- Validate + resolve the exercise display name via a new helper
+  `resolveHomeworkSourceName(supabase, admin, type, id)` (below). The
+  user-scoped `supabase` client means RLS returns `null` for any row the user
+  can't access, so a `null` result doubles as the ownership check — throw
+  `Exercise not found`. This preserves today's per-user guarantee for documents
+  and extends it to the other source types.
+- Title: `HW — ${name}` (name from the helper, e.g. `HW — homework-1.pdf`).
+- Insert `exercise_type` / `exercise_id` (+ `exercise_document_id` for documents).
+
+### Change 3 — name resolver + `getHomeworkContext` + chip
+
+- Add `resolveHomeworkSourceName(supabase, admin, type, id)` →
+  `Promise<string | null>` (name only — no storage download):
+  - `document` → `documents.title`
+  - `course_material` → `course_materials.label ?? file_name`
+  - `personal_file` → `personal_files.display_name`
+  - `moodle_file` → `moodle_files.file_name` via the **admin** client (shared
+    registry; mirrors the existing material-name resolution in `getHomeworkContext`).
+- `getHomeworkContext`: compute the effective exercise (with fallback), resolve
+  its name via the helper, and return it in the existing
+  `exerciseDocument: { id, title }` shape (`title` = resolved name).
+  - **Minimal-churn choice:** keep the `HomeworkContext.exerciseDocument` field
+    name and the chip unchanged — `title` now holds the source name regardless of
+    type. A rename to `exercise` is deferred (see Non-goals).
+  - DRY: replace the inline material-name resolution in `getHomeworkContext`'s
+    loop with the same helper (low-risk cleanup, since we're editing this code).
+
+### Change 4 — `resolveHomeworkContext` (AI Tier 1)
+
+- Compute the effective exercise (with fallback), then branch:
+  - `type === 'document'` → query `documents(title, content, pages)`;
+    `exerciseName = title`, `exerciseText = cap(extractDocumentText(...))`
+    (today's behavior).
+  - **file types** → resolve **name only** (no storage download/extract);
+    `exerciseText = ''`.
+- **No change to `prompts.ts` or `ai-context.ts`.** The Tier-1 verbatim block is
+  already gated on `homework?.exerciseText` being non-empty
+  (`ai-context.ts:723`), and `buildSystemPrompt` only uses the exercise **name**.
+  So a file exercise (`exerciseText === ''`) is named in the system prompt with
+  **no verbatim dump**, and its content reaches the model through Tier-3 RAG
+  (imported files are embedded at import time). `homeworkContextUsed` stays
+  `true` because it is derived from `!!homework`, not from the injected text.
+
+## Why (the "why" for interviews)
+
+Notes and imported files use **different content pipelines**: a typed note lives
+as ProseMirror JSON and is **not** RAG-indexed, so the AI needs its text injected
+verbatim; an imported file is extracted, chunked, and **embedded at import**, so
+RAG already covers its content and re-injecting it verbatim would waste the token
+budget. Branching the exercise on type routes each source to the channel that
+already exists for it — and keeps the design consistent with the
+already-polymorphic `homework_session_materials`.
+
+## Validation / security
+
+`resolveHomeworkSourceName` enforces ownership by **construction**: it queries
+`document` / `personal_file` / `course_material` through the **user-scoped**
+`supabase` client, so RLS restricts results to rows the user may read and the
+helper returns `null` for anything else (a cross-user or cross-course id simply
+won't resolve). Only `moodle_file` is read through the **admin** client, because
+that registry is intentionally shared (same trust model as Step-2 Moodle pinning
+and the existing `getHomeworkContext`). `createHomeworkSession` treats `null` as
+`Exercise not found`. Step-2 `materialRefs` remain unvalidated, exactly as today
+(out of scope).
+
+## Edge cases
+
+- **Legacy / seeded rows** (`exercise_type` null): the read-side fallback treats
+  them as `document` via `exercise_document_id`. The seeded homework E2E (open
+  doc → chip shows "Problem Set 1: Variables") stays green with no backfill.
+- **Unresolvable name:** helper returns `null` → `createHomeworkSession` throws
+  `Exercise not found`; readers degrade to `"Exercise"` / `"Exercise unavailable"`.
+- **Exercise also pinned as a material:** prevented in the UI (Step 2 excludes the
+  chosen key). Backend doesn't enforce it; harmless duplication if it ever occurs.
+- **Deleting a file exercise:** `exercise_id` is a plain `uuid` (no FK), so unlike
+  the old `exercise_document_id` (`ON DELETE CASCADE`) deleting the source file
+  does **not** cascade-delete the homework document/session — the session just
+  resolves to "Exercise unavailable". This matches how
+  `homework_session_materials.material_id` already behaves. Accepted.
+
+## Testing
+
+- **Unit** (`src/lib/ai/__tests__/homework-context.test.ts`): with a file-type
+  exercise, `resolveHomeworkContext` returns the file name and `exerciseText === ''`
+  (mock clients, no download). Existing document-exercise test stays green via the
+  fallback path.
+- **Integration** (`*.integration.test.ts`, service-role client + seeded data):
+  `createHomeworkSession` with a file exercise writes `exercise_type`/`exercise_id`;
+  `getHomeworkContext` returns the file's name in `exerciseDocument.title`.
+- **E2E** (no Gemini key — mock `/api/ai/*` as the existing homework spec does):
+  start homework from the course page (client-side nav), pick an **imported file**
+  as the exercise, click Start, assert navigation to the new doc and that the chip
+  shows the file name. Update `e2e/TEST_REGISTRY.md`.
+
+## Non-goals (YAGNI)
+
+- No dialog or terminology redesign — keep the two-step layout and the "Materials"
+  wording.
+- No rename of `HomeworkContext.exerciseDocument` (deferred to avoid churn across
+  the type, chip, and tests).
+- No verbatim extraction of file exercises — RAG covers them (explicit user call).
+- No backfill migration of existing rows — the read-side fallback handles them.

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -201,10 +201,12 @@ context-menu entry point works end-to-end.
 ## Homework-focused AI context (Phase 2) (`e2e/homework-ai-context.spec.ts`) — IMPLEMENTED
 
 Covers the Phase 2 feature that wires the persisted Homework object into the AI tutor.
-The seed (`supabase/seed.sql`) contains a complete homework session: working document `20000000-…-0011` linked to exercise "Problem Set 1: Variables" with pinned course material `lecture-1-slides.pdf`. The test opens that document directly — it does **not** drive the course page's Start Homework dialog, which is flaky in CI (the same reason `ai-chat.spec.ts` skips in CI). The Gemini call is mocked via `page.route('**/api/ai/ask')`, so the test needs no `GOOGLE_GENERATIVE_AI_API_KEY` (the test CI job has none) and is fully deterministic; the real context-building logic is covered by unit + integration tests.
+The seed (`supabase/seed.sql`) contains a complete homework session: working document `20000000-…-0011` linked to exercise "Problem Set 1: Variables" with pinned course material `lecture-1-slides.pdf`. The first test opens that document directly; the latter two drive the course page's **Start Homework dialog** via client-side navigation (`goToSeededCourse`) — the document-exercise path and the imported-file-exercise path. The Gemini call is mocked via `page.route('**/api/ai/ask')`, so the tests need no `GOOGLE_GENERATIVE_AI_API_KEY` (the test CI job has none) and are fully deterministic; the real context-building logic is also covered by unit + integration tests.
 
 - [x] Open the seeded homework document → the homework context chip (`data-testid="homework-context"`) is visible and names the exercise ("Problem Set 1: Variables") and the pinned material (`lecture-1-slides.pdf`)
 - [x] Open the AI Tutor panel → send a question → the mocked assistant response renders in the chat (quota and conversation-history endpoints are also mocked so the chat opens clean)
+- [x] Start Homework from the course page via **client-side nav** (`goToSeededCourse`) → pick the document exercise "Problem Set 1: Variables" → Start → navigates to the new homework doc and the context chip is visible (regression guard for the heavy-props soft-nav bug fixed in #199)
+- [x] Start Homework picking an **imported file** as the exercise (course material "Lecture 1: Intro to Programming") → Start → the context chip names the file by `file_name` (`lecture-1-slides.pdf`), proving the polymorphic exercise picker: a file (not just a typed note) can be the exercise, with its content covered by RAG rather than verbatim extraction
 
 ---
 
@@ -273,7 +275,7 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 | Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`         | 8/8        |
 | Moodle Ext Gating     | Implemented | `e2e/moodle-touch-gating.spec.ts`        | 2/2        |
 | Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`             | 3/3        |
-| Homework AI Context   | Implemented | `e2e/homework-ai-context.spec.ts`        | 1/1        |
+| Homework AI Context   | Implemented | `e2e/homework-ai-context.spec.ts`        | 3/3        |
 | Version History       | Planned     | `e2e/version-history.spec.ts`            | 0/5        |
 | PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts`      | 8/8        |
 | **Total**             |             |                                          | **92/100** |

--- a/e2e/homework-ai-context.spec.ts
+++ b/e2e/homework-ai-context.spec.ts
@@ -143,4 +143,36 @@ test.describe('Homework-focused AI context', () => {
       'Problem Set 1: Variables',
     );
   });
+
+  // The exercise is polymorphic: it can be any imported source, not just a
+  // typed note. Here we pick a course material (an imported file) as the
+  // exercise. The chip names it by file_name, proving a file became the
+  // exercise (its content is covered by RAG, not extracted verbatim).
+  test('start homework with an imported file as the exercise', async ({
+    page,
+  }) => {
+    test.setTimeout(60_000);
+
+    await goToSeededCourse(page); // client-side navigation
+
+    await page.getByRole('button', { name: /start homework/i }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    // Step 1 lists imported sources as radios; pick the course material
+    // (shown by its label). Target the radio so we don't hit the Step-2
+    // checkbox with the same name.
+    await dialog
+      .getByRole('radio', { name: 'Lecture 1: Intro to Programming' })
+      .check();
+
+    await page.getByRole('button', { name: /^start$/i }).click();
+
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 15_000,
+    });
+    const chip = page.getByTestId('homework-context');
+    await expect(chip).toBeVisible({ timeout: 10_000 });
+    await expect(chip).toContainText('lecture-1-slides.pdf');
+  });
 });

--- a/src/components/dashboard/start-homework-dialog.tsx
+++ b/src/components/dashboard/start-homework-dialog.tsx
@@ -59,8 +59,6 @@ export function StartHomeworkDialog({
       .catch(() => setMoodleSections([]));
   }, [open, moodleLoaded, courseId]);
 
-  const hasDocuments = documents.length > 0;
-
   function toggleMaterial(key: string) {
     setSelectedMaterials((prev) => {
       const next = new Set(prev);
@@ -87,7 +85,7 @@ export function StartHomeworkDialog({
       const materialRefs = Array.from(selectedMaterials).map(parseMaterialKey);
       const result = await createHomeworkSession({
         courseId,
-        exerciseDocumentId: selectedExercise,
+        exercise: parseMaterialKey(selectedExercise),
         materialRefs,
       });
 
@@ -111,6 +109,47 @@ export function StartHomeworkDialog({
     setSelectedMaterials(new Set());
     setError(null);
   }
+
+  // All pickable sources, grouped for display. Step 1 (the exercise, single
+  // select) and Step 2 (pinned materials, multi-select) draw from the same
+  // list; keys are `${type}:${id}` and parsed by parseMaterialKey. Moodle
+  // files appear once they finish lazy-loading.
+  const sourceGroups = [
+    {
+      label: 'Documents',
+      items: documents.map((d) => ({ key: `document:${d.id}`, name: d.title })),
+    },
+    {
+      label: 'Course Materials',
+      items: materials.map((m) => ({
+        key: `course_material:${m.id}`,
+        name: m.label ?? m.file_name,
+      })),
+    },
+    {
+      label: 'Your Files',
+      items: personalFiles.map((f) => ({
+        key: `personal_file:${f.id}`,
+        name: f.display_name,
+      })),
+    },
+    {
+      label: 'Moodle Files',
+      items: moodleSections.flatMap((s) =>
+        s.files.map((f) => ({ key: `moodle_file:${f.id}`, name: f.file_name })),
+      ),
+    },
+  ].filter((g) => g.items.length > 0);
+
+  const hasSources = sourceGroups.length > 0;
+
+  // Step 2 lists every source except whichever one is chosen as the exercise.
+  const pinnableGroups = sourceGroups
+    .map((g) => ({
+      ...g,
+      items: g.items.filter((i) => i.key !== selectedExercise),
+    }))
+    .filter((g) => g.items.length > 0);
 
   return (
     <Dialog
@@ -143,32 +182,39 @@ export function StartHomeworkDialog({
             <p className="text-xs text-muted-foreground -mt-1">
               Pick the homework or problem set you want to work on.
             </p>
-            {hasDocuments ? (
-              <div className="max-h-40 space-y-1 overflow-y-auto rounded-md border p-2">
-                {documents.map((doc) => (
-                  <label
-                    key={doc.id}
-                    className={`flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors ${
-                      selectedExercise === doc.id
-                        ? 'bg-primary/10 text-primary'
-                        : 'hover:bg-accent'
-                    }`}
-                  >
-                    <input
-                      type="radio"
-                      name="exercise"
-                      value={doc.id}
-                      checked={selectedExercise === doc.id}
-                      onChange={() => setSelectedExercise(doc.id)}
-                      className="accent-primary"
-                    />
-                    <span className="truncate">{doc.title}</span>
-                  </label>
+            {hasSources ? (
+              <div className="max-h-44 space-y-2 overflow-y-auto rounded-md border p-2">
+                {sourceGroups.map((group) => (
+                  <div key={group.label}>
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">
+                      {group.label}
+                    </p>
+                    {group.items.map((item) => (
+                      <label
+                        key={item.key}
+                        className={`flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm transition-colors ${
+                          selectedExercise === item.key
+                            ? 'bg-primary/10 text-primary'
+                            : 'hover:bg-accent'
+                        }`}
+                      >
+                        <input
+                          type="radio"
+                          name="exercise"
+                          value={item.key}
+                          checked={selectedExercise === item.key}
+                          onChange={() => setSelectedExercise(item.key)}
+                          className="accent-primary"
+                        />
+                        <span className="truncate">{item.name}</span>
+                      </label>
+                    ))}
+                  </div>
                 ))}
               </div>
             ) : (
               <p className="rounded-md border border-dashed p-3 text-center text-sm text-muted-foreground">
-                Create a document first to use as the exercise.
+                Import a file or create a document first to use as the exercise.
               </p>
             )}
           </div>
@@ -192,115 +238,31 @@ export function StartHomeworkDialog({
               it what to focus on first.
             </p>
             <div className="max-h-48 space-y-2 overflow-y-auto rounded-md border p-2">
-              {/* Documents (excluding the selected exercise) */}
-              {documents.filter((d) => d.id !== selectedExercise).length >
-                0 && (
-                <div>
+              {pinnableGroups.map((group) => (
+                <div key={group.label}>
                   <p className="mb-1 text-xs font-medium text-muted-foreground">
-                    Documents
+                    {group.label}
                   </p>
-                  {documents
-                    .filter((d) => d.id !== selectedExercise)
-                    .map((doc) => {
-                      const key = `document:${doc.id}`;
-                      return (
-                        <label
-                          key={key}
-                          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedMaterials.has(key)}
-                            onChange={() => toggleMaterial(key)}
-                            className="accent-primary"
-                          />
-                          <span className="truncate">{doc.title}</span>
-                        </label>
-                      );
-                    })}
+                  {group.items.map((item) => (
+                    <label
+                      key={item.key}
+                      className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedMaterials.has(item.key)}
+                        onChange={() => toggleMaterial(item.key)}
+                        className="accent-primary"
+                      />
+                      <span className="truncate">{item.name}</span>
+                    </label>
+                  ))}
                 </div>
-              )}
-
-              {/* Course materials — flat list */}
-              {materials.length > 0 && (
-                <div>
-                  <p className="mb-1 text-xs font-medium text-muted-foreground">
-                    Course Materials
-                  </p>
-                  {materials.map((mat) => {
-                    const key = `course_material:${mat.id}`;
-                    return (
-                      <label
-                        key={key}
-                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selectedMaterials.has(key)}
-                          onChange={() => toggleMaterial(key)}
-                          className="accent-primary"
-                        />
-                        <span className="truncate">
-                          {mat.label ?? mat.file_name}
-                        </span>
-                      </label>
-                    );
-                  })}
-                </div>
-              )}
-
-              {/* Personal files */}
-              {personalFiles.length > 0 && (
-                <div>
-                  <p className="mb-1 text-xs font-medium text-muted-foreground">
-                    Your Files
-                  </p>
-                  {personalFiles.map((pf) => {
-                    const key = `personal_file:${pf.id}`;
-                    return (
-                      <label
-                        key={key}
-                        className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={selectedMaterials.has(key)}
-                          onChange={() => toggleMaterial(key)}
-                          className="accent-primary"
-                        />
-                        <span className="truncate">{pf.display_name}</span>
-                      </label>
-                    );
-                  })}
-                </div>
-              )}
-
-              {/* Moodle files (lazy-loaded) */}
-              {moodleSections.some((s) => s.files.length > 0) && (
-                <div>
-                  <p className="mb-1 text-xs font-medium text-muted-foreground">
-                    Moodle Files
-                  </p>
-                  {moodleSections.flatMap((s) =>
-                    s.files.map((f) => {
-                      const key = `moodle_file:${f.id}`;
-                      return (
-                        <label
-                          key={key}
-                          className="flex cursor-pointer items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent"
-                        >
-                          <input
-                            type="checkbox"
-                            checked={selectedMaterials.has(key)}
-                            onChange={() => toggleMaterial(key)}
-                            className="accent-primary"
-                          />
-                          <span className="truncate">{f.file_name}</span>
-                        </label>
-                      );
-                    }),
-                  )}
-                </div>
+              ))}
+              {pinnableGroups.length === 0 && (
+                <p className="px-2 py-1 text-xs text-muted-foreground">
+                  No other materials to pin.
+                </p>
               )}
             </div>
             {selectedMaterials.size > 0 && (

--- a/src/lib/actions/homework.ts
+++ b/src/lib/actions/homework.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
+import { resolveHomeworkSourceName } from '@/lib/ai/homework-context';
 import type {
   HomeworkContext,
   HomeworkMaterialType,
@@ -17,10 +18,11 @@ import type {
 
 export async function createHomeworkSession(data: {
   courseId: string;
-  exerciseDocumentId: string;
+  exercise: { type: HomeworkMaterialType; id: string };
   materialRefs: Array<{ type: HomeworkMaterialType; id: string }>;
 }): Promise<{ documentId: string; sessionId: string }> {
   const supabase = await createClient();
+  const admin = createAdminClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
@@ -35,15 +37,16 @@ export async function createHomeworkSession(data: {
     .single();
   if (courseErr || !course) throw new Error('Course not found');
 
-  // Validate exercise document belongs to user and is in this course
-  const { data: exercise, error: exErr } = await supabase
-    .from('documents')
-    .select('id, title')
-    .eq('id', data.exerciseDocumentId)
-    .eq('user_id', user.id)
-    .eq('course_id', data.courseId)
-    .single();
-  if (exErr || !exercise) throw new Error('Exercise document not found');
+  // Validate + name the exercise. The user-scoped client means RLS returns
+  // null for anything the user can't read, so a null name doubles as the
+  // access check (Moodle files are read via admin — shared registry).
+  const exerciseName = await resolveHomeworkSourceName(
+    supabase,
+    admin,
+    data.exercise.type,
+    data.exercise.id,
+  );
+  if (!exerciseName) throw new Error('Exercise not found');
 
   // Create the homework document
   const { data: doc, error: docErr } = await supabase
@@ -52,7 +55,7 @@ export async function createHomeworkSession(data: {
       user_id: user.id,
       course_id: data.courseId,
       purpose: 'homework' as const,
-      title: `HW — ${exercise.title}`,
+      title: `HW — ${exerciseName}`,
       content: {},
       subject: 'other' as const,
       canvas_type: 'blank' as const,
@@ -62,12 +65,16 @@ export async function createHomeworkSession(data: {
   if (docErr || !doc)
     throw new Error(docErr?.message ?? 'Failed to create document');
 
-  // Create the homework session
+  // Create the homework session. The exercise is polymorphic; keep the legacy
+  // exercise_document_id in sync for documents so old readers still resolve.
   const { data: session, error: sessionErr } = await supabase
     .from('homework_sessions')
     .insert({
       document_id: doc.id,
-      exercise_document_id: data.exerciseDocumentId,
+      exercise_type: data.exercise.type,
+      exercise_id: data.exercise.id,
+      exercise_document_id:
+        data.exercise.type === 'document' ? data.exercise.id : null,
       course_id: data.courseId,
       user_id: user.id,
     })
@@ -115,13 +122,27 @@ export async function getHomeworkContext(data: {
   if (!session) return null;
 
   const typedSession = session as HomeworkSession;
+  // Moodle reads need the admin client (shared registry); resolveHomeworkSourceName
+  // only uses it for moodle_file, so it's safe to pass for every type.
+  const admin = createAdminClient();
 
-  // Fetch exercise document title
-  const { data: exerciseDoc } = await supabase
-    .from('documents')
-    .select('id, title')
-    .eq('id', typedSession.exercise_document_id)
-    .single();
+  // Resolve the polymorphic exercise name, falling back to the legacy document
+  // FK for pre-feature / seeded rows.
+  const exerciseType = (typedSession.exercise_type ??
+    (typedSession.exercise_document_id
+      ? 'document'
+      : null)) as HomeworkMaterialType | null;
+  const exerciseId =
+    typedSession.exercise_id ?? typedSession.exercise_document_id;
+  const exerciseName =
+    exerciseType && exerciseId
+      ? await resolveHomeworkSourceName(
+          supabase,
+          admin,
+          exerciseType,
+          exerciseId,
+        )
+      : null;
 
   // Fetch session materials
   const { data: materialsData } = await supabase
@@ -132,53 +153,25 @@ export async function getHomeworkContext(data: {
   const typedMaterials =
     (materialsData as HomeworkSessionMaterial[] | null) ?? [];
 
-  // Resolve display names for each material
+  // Resolve display names for each material (same per-type resolver as above).
   const materials: HomeworkContext['materials'] = [];
   for (const mat of typedMaterials) {
-    let name = 'Unknown material';
-    if (mat.material_type === 'course_material') {
-      const { data: cm } = await supabase
-        .from('course_materials')
-        .select('file_name')
-        .eq('id', mat.material_id)
-        .single();
-      if (cm) name = cm.file_name;
-    } else if (mat.material_type === 'personal_file') {
-      const { data: pf } = await supabase
-        .from('personal_files')
-        .select('display_name')
-        .eq('id', mat.material_id)
-        .single();
-      if (pf) name = pf.display_name;
-    } else if (mat.material_type === 'document') {
-      const { data: d } = await supabase
-        .from('documents')
-        .select('title')
-        .eq('id', mat.material_id)
-        .single();
-      if (d) name = d.title;
-    } else if (mat.material_type === 'moodle_file') {
-      // Moodle files are shared (user_id null on embeddings); read via admin
-      // so RLS on the shared registry never hides the display name.
-      const admin = createAdminClient();
-      const { data: mf } = await admin
-        .from('moodle_files')
-        .select('file_name')
-        .eq('id', mat.material_id)
-        .single();
-      if (mf) name = mf.file_name;
-    }
+    const name =
+      (await resolveHomeworkSourceName(
+        supabase,
+        admin,
+        mat.material_type,
+        mat.material_id,
+      )) ?? 'Unknown material';
     materials.push({ type: mat.material_type, id: mat.material_id, name });
   }
 
   return {
     session: typedSession,
-    exerciseDocument: exerciseDoc
-      ? { id: exerciseDoc.id, title: exerciseDoc.title }
-      : {
-          id: typedSession.exercise_document_id ?? '',
-          title: 'Exercise unavailable',
-        },
+    exerciseDocument: {
+      id: exerciseId ?? '',
+      title: exerciseName ?? 'Exercise unavailable',
+    },
     materials,
   };
 }

--- a/src/lib/ai/__tests__/homework-context.test.ts
+++ b/src/lib/ai/__tests__/homework-context.test.ts
@@ -90,6 +90,59 @@ describe('resolveHomeworkContext', () => {
     expect(ctx?.pinned).toEqual([]);
   });
 
+  it('references a file exercise by name only — no text extraction (RAG covers it)', async () => {
+    const c = makeClient({
+      rows: {
+        homework_sessions: {
+          id: 's1',
+          exercise_document_id: null,
+          exercise_type: 'course_material',
+          exercise_id: 'cm1',
+        },
+        course_materials: {
+          file_name: 'homework-1.pdf',
+          storage_path: 'p/hw.pdf',
+          mime_type: 'application/pdf',
+        },
+      },
+      lists: { homework_session_materials: [] },
+    });
+    const ctx = await resolveHomeworkContext(c, c, 'hw1');
+    expect(ctx?.exerciseName).toBe('homework-1.pdf');
+    expect(ctx?.exerciseText).toBe(''); // file content reaches the model via RAG
+    expect(ctx?.pinned).toEqual([]);
+  });
+
+  it('falls back to exercise_document_id for legacy rows (no exercise_type)', async () => {
+    // A pre-feature / seeded row: only exercise_document_id is set.
+    const c = makeClient({
+      rows: {
+        homework_sessions: {
+          id: 's1',
+          exercise_document_id: 'ex1',
+          exercise_type: null,
+          exercise_id: null,
+        },
+        documents: {
+          title: 'Legacy PS',
+          content: {
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Legacy exercise body' }],
+              },
+            ],
+          },
+        },
+      },
+      lists: { homework_session_materials: [] },
+    });
+    const ctx = await resolveHomeworkContext(c, c, 'hw1');
+    expect(ctx?.exerciseName).toBe('Legacy PS');
+    expect(ctx?.exerciseText).toContain('Legacy exercise body');
+  });
+
   it('extracts a pinned course_material via download + pdf extractor', async () => {
     const c = makeClient({
       rows: {

--- a/src/lib/ai/homework-context.integration.test.ts
+++ b/src/lib/ai/homework-context.integration.test.ts
@@ -34,4 +34,44 @@ describe('resolveHomeworkContext (integration, seeded data)', () => {
     const pinned = ctx!.pinned.find((p) => p.name === 'lecture-1-slides.pdf');
     expect(pinned?.text).toBe('');
   });
+
+  it('references a file exercise (course_material) by name only — no extraction', async () => {
+    const admin = createAdminClient();
+    const SEED_USER = 'ac3be77d-4566-406c-9ac0-7c410634ad41';
+    const SEED_COURSE = '30000000-0000-0000-0000-000000000001';
+    const HW1_MATERIAL = '50000000-0000-0000-0000-000000000002'; // homework-1.pdf
+
+    // A homework doc whose exercise is an imported course material (not a
+    // typed note). Created here (not seeded) and cleaned up after the assert.
+    const docId = crypto.randomUUID();
+    await admin.from('documents').insert({
+      id: docId,
+      user_id: SEED_USER,
+      course_id: SEED_COURSE,
+      purpose: 'homework',
+      title: 'HW — homework-1.pdf',
+      content: {},
+      subject: 'other',
+      canvas_type: 'blank',
+    });
+    await admin.from('homework_sessions').insert({
+      document_id: docId,
+      course_id: SEED_COURSE,
+      user_id: SEED_USER,
+      exercise_type: 'course_material',
+      exercise_id: HW1_MATERIAL,
+      exercise_document_id: null,
+    });
+
+    try {
+      const ctx = await resolveHomeworkContext(admin, admin, docId);
+      expect(ctx).not.toBeNull();
+      expect(ctx!.exerciseName).toBe('homework-1.pdf');
+      // Content reaches the model via Tier-3 RAG, not as verbatim Tier-1 text.
+      expect(ctx!.exerciseText).toBe('');
+    } finally {
+      // documents ON DELETE CASCADE removes the homework_sessions row too.
+      await admin.from('documents').delete().eq('id', docId);
+    }
+  });
 });

--- a/src/lib/ai/homework-context.ts
+++ b/src/lib/ai/homework-context.ts
@@ -56,6 +56,87 @@ function extractFileText(buffer: Buffer, mimeType: string): Promise<string> {
   return Promise.resolve('');
 }
 
+interface FileSourceConfig {
+  table: string;
+  client: SupabaseClient;
+  bucket: string;
+  nameCol: string;
+}
+
+/**
+ * Storage/table config for the three file-backed homework source types.
+ * `document` is intentionally excluded — it is not file-backed (its text comes
+ * from ProseMirror JSON, not Storage).
+ */
+function fileSourceConfig(
+  type: HomeworkMaterialType,
+  supabase: SupabaseClient,
+  admin: SupabaseClient,
+): FileSourceConfig | null {
+  switch (type) {
+    case 'course_material':
+      return {
+        table: 'course_materials',
+        client: supabase,
+        bucket: 'course-materials',
+        nameCol: 'file_name',
+      };
+    case 'personal_file':
+      return {
+        table: 'personal_files',
+        client: supabase,
+        bucket: 'personal-files',
+        nameCol: 'display_name',
+      };
+    case 'moodle_file':
+      return {
+        table: 'moodle_files',
+        client: admin,
+        bucket: 'moodle-materials',
+        nameCol: 'file_name',
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Resolve the display name of any homework source (exercise or material) by
+ * type — WITHOUT downloading file content. User-owned tables are read through
+ * the user-scoped `supabase` client (RLS enforces access, so a denied/missing
+ * row returns null); the shared Moodle registry is read through `admin`.
+ * Never throws — returns null on any failure.
+ */
+export async function resolveHomeworkSourceName(
+  supabase: SupabaseClient,
+  admin: SupabaseClient,
+  type: HomeworkMaterialType,
+  id: string,
+): Promise<string | null> {
+  try {
+    if (type === 'document') {
+      const { data } = await supabase
+        .from('documents')
+        .select('title')
+        .eq('id', id)
+        .maybeSingle();
+      return (data?.title as string | undefined) || null;
+    }
+    const cfg = fileSourceConfig(type, supabase, admin);
+    if (!cfg) return null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = (await (cfg.client as any)
+      .from(cfg.table)
+      .select(cfg.nameCol)
+      .eq('id', id)
+      .maybeSingle()) as { data: Record<string, unknown> | null };
+    if (!data) return null;
+    return String(data[cfg.nameCol] ?? '') || null;
+  } catch {
+    return null;
+  }
+}
+
 /** Resolve one pinned material to { name, text }. Never throws — degrades to ''. */
 async function resolvePinnedMaterial(
   supabase: SupabaseClient,
@@ -77,30 +158,7 @@ async function resolvePinnedMaterial(
       };
     }
 
-    // File-backed types: { table, client, bucket, nameCol }
-    const cfg =
-      type === 'course_material'
-        ? {
-            table: 'course_materials',
-            client: supabase,
-            bucket: 'course-materials',
-            nameCol: 'file_name',
-          }
-        : type === 'personal_file'
-          ? {
-              table: 'personal_files',
-              client: supabase,
-              bucket: 'personal-files',
-              nameCol: 'display_name',
-            }
-          : type === 'moodle_file'
-            ? {
-                table: 'moodle_files',
-                client: admin,
-                bucket: 'moodle-materials',
-                nameCol: 'file_name',
-              }
-            : null;
+    const cfg = fileSourceConfig(type, supabase, admin);
     if (!cfg) return null;
 
     // Select all columns; cast via unknown to escape Supabase's strict generic
@@ -146,23 +204,45 @@ export async function resolveHomeworkContext(
 ): Promise<HomeworkAiContext | null> {
   const { data: session } = await supabase
     .from('homework_sessions')
-    .select('id, exercise_document_id')
+    .select('id, exercise_document_id, exercise_type, exercise_id')
     .eq('document_id', documentId)
     .maybeSingle();
   if (!session) return null;
 
-  // Tier 1 — exercise (today always a document)
+  // Tier 1 — exercise. The exercise is polymorphic: prefer the typed columns
+  // and fall back to the legacy document FK for pre-feature / seeded rows.
   let exerciseName = 'Exercise';
   let exerciseText = '';
-  if (session.exercise_document_id) {
-    const { data: ex } = await supabase
-      .from('documents')
-      .select('title, content, pages')
-      .eq('id', session.exercise_document_id)
-      .maybeSingle();
-    if (ex) {
-      exerciseName = ex.title ?? 'Exercise';
-      exerciseText = cap(extractDocumentText(ex), MAX_HOMEWORK_SOURCE_CHARS);
+  const exerciseType = (session.exercise_type ??
+    (session.exercise_document_id
+      ? 'document'
+      : null)) as HomeworkMaterialType | null;
+  const exerciseId = (session.exercise_id ?? session.exercise_document_id) as
+    | string
+    | null;
+
+  if (exerciseType && exerciseId) {
+    if (exerciseType === 'document') {
+      // Typed notes are NOT RAG-indexed → inject their text verbatim (Tier 1).
+      const { data: ex } = await supabase
+        .from('documents')
+        .select('title, content, pages')
+        .eq('id', exerciseId)
+        .maybeSingle();
+      if (ex) {
+        exerciseName = ex.title ?? 'Exercise';
+        exerciseText = cap(extractDocumentText(ex), MAX_HOMEWORK_SOURCE_CHARS);
+      }
+    } else {
+      // Imported files are already embedded → reference by name only; their
+      // content reaches the model through Tier-3 RAG (no verbatim dump).
+      const name = await resolveHomeworkSourceName(
+        supabase,
+        admin,
+        exerciseType,
+        exerciseId,
+      );
+      if (name) exerciseName = name;
     }
   }
 


### PR DESCRIPTION
## Summary

The Start Homework **exercise** was hard-wired to a typed document — Step 1 of the dialog only listed `documents`. Now the exercise can be **any imported source** (document, course material, personal file, or Moodle file), mirroring the Step-2 materials picker. The created homework document remains the blank workspace where the student writes their solution.

Application-layer only — the polymorphic schema (`exercise_type` / `exercise_id`, nullable `exercise_document_id`) already shipped in #199. **No migration.**

Design spec: `docs/superpowers/specs/2026-05-26-polymorphic-homework-exercise-design.md`.

## Changes

- **`start-homework-dialog.tsx`** — Step 1 lists all four sources as single-select radios; Step 2 excludes the chosen exercise. Both steps render from one shared grouped source list (removes prior duplication).
- **`createHomeworkSession`** — takes `exercise: { type, id }`; validates + names it via a shared `resolveHomeworkSourceName` (user-scoped client → RLS enforces access); writes the polymorphic columns (keeps legacy `exercise_document_id` in sync for documents).
- **`resolveHomeworkContext` / `getHomeworkContext`** — resolve the exercise by type, falling back to the legacy column for pre-feature/seeded rows. **Document exercise → verbatim text (Tier 1); imported file → name only** (its content is already embedded, so Tier-3 RAG covers it — no verbatim dump, no prompt change needed).

## Why the note/file split

Typed notes aren't RAG-indexed, so the AI needs their text injected. Imported files are extracted + embedded at import, so RAG already covers them. Branching the exercise on type routes each source to the channel that already exists for it.

## Test Plan

- [x] Unit (`homework-context.test.ts`): file exercise → name only, `exerciseText === ''`; legacy `exercise_document_id` fallback still extracts text. (889 unit pass)
- [x] Integration (`homework-context.integration.test.ts`): a course-material exercise resolves to its `file_name` with empty text. (4 pass)
- [x] E2E (`homework-ai-context.spec.ts`): start homework picking an **imported file** as the exercise → chip names the file. _(Validated logic + selectors locally via aria snapshot; the assertion needs the clean seeded DB, which only CI has — local DB is on the pre-flat-model schema.)_
- [x] Registry updated (`e2e/TEST_REGISTRY.md`).
- [ ] **CI green** (runs E2E on a fresh seeded DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)