### PR TITLE
ci: run Supabase migrations against prod before deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Apply pending database migrations to production BEFORE shipping code.
+      # The Vercel steps below only deploy application code; they do not touch
+      # Supabase. Without this step, the SQL in supabase/migrations/ never runs
+      # against prod, so deployed code can reference tables/columns/functions
+      # that don't exist (the exact gap that left prod on a months-old schema).
+      # Migrating first ("expand" before deploy) keeps the schema ahead of the
+      # code. `db push` is idempotent: it applies only migrations not yet
+      # recorded in the remote schema_migrations table, so re-runs are no-ops.
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Apply database migrations to production
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ] || [ -z "$SUPABASE_DB_PASSWORD" ]; then
+            echo "::error::SUPABASE_ACCESS_TOKEN and SUPABASE_DB_PASSWORD must be set as repository secrets for prod migrations to run."
+            exit 1
+          fi
+          # Project ref is public (it is the subdomain of NEXT_PUBLIC_SUPABASE_URL).
+          supabase link --project-ref ffjlffoznifduxfsjyuq
+          supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+
       # `vercel build` detects pnpm-lock.yaml and shells out to `pnpm install`.
       # Without pnpm on PATH it fails with `spawn pnpm ENOENT`.
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

The `deploy` job only ran `vercel build` + `vercel deploy` — it never applied the SQL in `supabase/migrations/` to the production database. Deployed code that referenced new tables/columns/functions crashed at runtime, and prod's schema silently fell **months behind** the code (last applied migration was from March; ~7 migrations including homework, document versions, the course-weeks flatten, context-files, and course-sharing had never run on prod).

This PR adds a Supabase CLI step that runs `supabase db push` **before** the build/deploy, so the schema is migrated ahead of the code on every push to `main` ("expand before deploy"). `db push` is idempotent — it applies only migrations not yet recorded in the remote `schema_migrations` table, so re-runs are no-ops.

Prod's schema was already brought current manually (out of band) ahead of this change, so the first run of this step will be a no-op.

## Required setup (repo secrets)

Two new repository secrets must be added for the step to run:
- `SUPABASE_ACCESS_TOKEN` — a Supabase access token (Account → Access Tokens; a dedicated CI token recommended)
- `SUPABASE_DB_PASSWORD` — the production database password (Supabase → Project Settings → Database)

The project ref (`ffjlffoznifduxfsjyuq`) is hardcoded; it is public (it's the subdomain of `NEXT_PUBLIC_SUPABASE_URL`).

## Test Plan
- [ ] CI (lint/format/unit/integration/build/E2E) passes on this PR
- [ ] After merge to `main`: the "Apply database migrations to production" step runs, links the project, and reports no pending migrations (no-op)
- [ ] Production dashboard, Moodle courses, and sharing load without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)