### PR TITLE
fix(moodle): fast parallel sync + working cancel; dashboard sidebar & AI language fixes

### DIFF
--- a/docs/superpowers/specs/2026-05-31-moodle-sync-speed-cancel-design.md
+++ b/docs/superpowers/specs/2026-05-31-moodle-sync-speed-cancel-design.md
@@ -1,0 +1,120 @@
+# Moodle sync: speed, parallelism, reliability, and working cancel
+
+Date: 2026-05-31
+Status: approved
+
+## Problem
+
+Two bugs shipped to `main`/`dev`:
+
+1. **Full-course sync takes hours.** For every file, the extension opened a fresh
+   popup browser window (`openScrapeWindow`), navigated it to the Moodle resource
+   page, scraped the DOM for the `pluginfile.php` link, then closed the window —
+   serially, one window per file. Window create/destroy + focus juggling per file
+   is the cost; the resolution _strategy_ was fine, the _mechanism_ was the
+   regression.
+2. **Pressing X / Cancel didn't stop downloads.** The download loop never checked
+   the cancel flag (only the permission-wait poll did), so closing the dialog let
+   every remaining file download to completion.
+
+History note: the pre-popup resolver (`0af40a1`) reused a single tab and only fell
+back to `?redirect=1` when scraping found nothing. Commit `7ea9ec2` swapped the
+reused tab for a per-file popup window — that is what made it slow. So the fix is
+to go lighter than even the original, not heavier.
+
+## How Moodle resources behave (drives the resolver)
+
+A Moodle "file resource" has an instructor-set display mode:
+
+| Display mode               | `GET view.php?id=…` (or `?redirect=1`) returns                   |
+| -------------------------- | ---------------------------------------------------------------- |
+| Automatic / Force download | 302 → the `pluginfile.php` file directly                         |
+| Open / In pop-up           | usually 302 → the file                                           |
+| Embed / In frame           | an HTML viewer page with the file in `<object>`/`<iframe>`/`<a>` |
+
+The download fetch already follows redirects and rejects `text/html`. So for the
+common force-download/open case, `?redirect=1` resolves with **zero extra
+requests** — the download fetch itself lands on the file.
+
+## Design
+
+### Tiered resolution (cheapest first)
+
+`resolveFileUrl(moodleUrl)`:
+
+1. Already a `pluginfile.php` URL (all folder children + link-sweep items — the
+   majority) → return as-is.
+2. `/mod/resource/view.php` (or `/mod/folder/view.php`) → return `url?redirect=1`.
+   No extra request; the download fetch follows it.
+3. Otherwise → return as-is.
+
+`handleDownloadAndUpload` (the download step):
+
+1. Fetch `downloadUrl` (`credentials: 'include'`, `redirect: 'follow'`).
+2. If the response is **HTML** (embed mode), parse the `pluginfile.php` link out
+   of _that same response body_ (no extra GET) via `pickPluginfileUrl`, then
+   re-fetch the real file.
+3. If still HTML / unparseable → **escalate once** to a single reused background
+   tab (`resolveViaTab`, serialized by a mutex so the ≤4 parallel workers share
+   one tab), DOM-scraping via the existing `scrapeFileUrl`.
+4. If that also fails → throw → the file is counted failed and shows up in the
+   existing **Retry failed** list. No silent wrong-file, no hang.
+
+### Correctness guards
+
+- **Smart-pick** (`pickPluginfileUrl`): among all `pluginfile.php` matches in the
+  HTML, prefer one with `forcedownload=1`; otherwise the first whose path is NOT
+  under `/user/icon/`, `/theme/`, or `/course/overviewfiles/` (avatars / logos /
+  course images that appear in the page header before the real content);
+  otherwise the first match. Decodes `&amp;`.
+- **Extension validation** (`extensionMatches`): after resolving, if the resolved
+  file's extension and the expected filename's extension are both known and
+  differ, reject — catches a wrong-URL slip regardless of how it resolved. The
+  existing "not text/html" check stays.
+
+### Parallel downloads + cancel (web app)
+
+- `runWithConcurrency(items, worker, { concurrency: 4, shouldCancel })` — bounded
+  worker pool, `shouldCancel` (reads `pollCancelRef.current`) checked before each
+  item. In-flight ≤4 finish, then the pool stops pulling. Cancel = "stop starting
+  new work", not "abort in-flight" (there is no abort channel to the extension);
+  communicated via "N downloaded before stopping".
+- Cancel button rendered during `syncing` / `scraping-content`.
+
+### Robustness fixes
+
+- `handleRetryFailed` wrapped in try/catch → on a pre-download throw it lands on
+  `error` instead of wedging on `syncing` with a no-op Cancel button.
+- `loadCourses` resets `pollCancelRef.current = false` (symmetry with
+  sync/preview/retry; future-proofs against a stale `true`).
+
+## Units & boundaries
+
+- `extension/src/lib/url-resolve.ts` — **pure**, no chrome/DOM globals at import:
+  `extractPluginfileUrl(html)`, `pickPluginfileUrl(html)`, `extensionMatches(resolvedUrl, expectedFileName)`,
+  `fileExtensionOf(urlOrName)`. Imported by the service worker; unit-tested under
+  the root jsdom vitest.
+- `src/lib/concurrency.ts` — pure `runWithConcurrency` (already exists, tested).
+- Service worker wires the tiers + the reused fallback tab + mutex.
+- Dialog wires parallelism + cancel + the two robustness fixes.
+
+## Testing
+
+- `extension/src/lib/url-resolve.test.ts`: avatar/theme/overviewfiles skipped;
+  `forcedownload` preferred; `&amp;` decoded; no-match/relative → null; extension
+  mismatch detected; matching/unknown extensions accepted.
+- `src/lib/concurrency.test.ts`: order, max-concurrency, cancel-mid-flight,
+  up-front cancel, empty, error isolation (already present).
+- `src/components/dashboard/moodle-sync-dialog.test.tsx`: new test — Cancel
+  mid-sync stops further downloads and shows the cancelled message.
+- CI: add `extension/src/**/*.test.ts` to `vitest.config.ts` `include` so the
+  existing `pnpm test` step runs the extension unit test (no new deps; pure
+  module needs no chrome mocks). Extension `tsc`/`esbuild` build unchanged.
+
+## Out of scope
+
+- Aborting in-flight downloads (no message channel to the extension; bounded to
+  ≤4 stragglers — acceptable).
+- E2E for real Moodle sync (needs a live Moodle session + packed extension; can't
+  run against seeded local Supabase).
+- Version bump already done: `0.2.0` → `0.2.1` (web app accepts `>=` minimum).

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -32,6 +32,7 @@ When adding or modifying a feature, update this registry and write the correspon
 - [x] Delete document with confirmation dialog
 - [x] Document appears in correct folder
 - [x] Move document to different folder/course
+- [x] Create document dialog has no subject selector (subject removed at creation)
 
 ---
 
@@ -273,6 +274,7 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 - [x] Contributor link: member joins, sees materials, uploads a file, owner sees it
 - [x] Viewer link: member cannot see upload controls
 - [x] Leave: member removes course from list; course persists for owner
+- [x] Shared course appears in the member's left sidebar tree (under "Shared with me"), not only the dashboard cards
 - [ ] Privacy: member's note in a shared course is invisible to the owner (covered by integration tests; E2E optional)
 - [ ] AI: member's chat cites an owner-uploaded file (needs Gemini key; covered by integration + manual)
 
@@ -319,7 +321,7 @@ and the per-`(source, page)` `p. N` citation in
 | Homework AI Context   | Removed     | (deleted)                                | —          |
 | Version History       | Planned     | `e2e/version-history.spec.ts`            | 0/5        |
 | PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts`      | 8/8        |
-| Course Sharing        | Implemented | `e2e/sharing.spec.ts`                    | 3/5        |
+| Course Sharing        | Implemented | `e2e/sharing.spec.ts`                    | 4/6        |
 | **Total**             |             |                                          | **97/107** |
 
 ---

--- a/e2e/documents.spec.ts
+++ b/e2e/documents.spec.ts
@@ -29,6 +29,27 @@ test.describe('Documents', () => {
     });
   });
 
+  test('create document dialog has no subject selector', async ({ page }) => {
+    await page.getByRole('button', { name: 'New Document' }).click();
+    await expect(page.getByText('Create New Document')).toBeVisible();
+
+    // Subject selection was removed from creation: the dialog should expose a
+    // title input and page-style choices, but no subject combobox/label.
+    await expect(page.getByLabel('Title')).toBeVisible();
+    await expect(page.getByRole('combobox')).toHaveCount(0);
+    await expect(page.getByText('Subject', { exact: true })).toHaveCount(0);
+
+    // It still creates a document end-to-end.
+    const docTitle = `No Subject ${Date.now()}`;
+    const titleInput = page.getByLabel('Title');
+    await titleInput.clear();
+    await titleInput.fill(docTitle);
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 10_000,
+    });
+  });
+
   test('open existing document navigates to editor', async ({ page }) => {
     // Click the first document card on the dashboard
     const firstDoc = page.locator('[data-testid="document-card"]').first();

--- a/e2e/extension-real.spec.ts
+++ b/e2e/extension-real.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, chromium, type BrowserContext } from '@playwright/test';
 import * as path from 'path';
 
 const EXTENSION_PATH = path.resolve(__dirname, '..', 'extension');
-const EXPECTED_VERSION = '0.2.0';
+const EXPECTED_VERSION = '0.2.1';
 const PINNED_EXTENSION_ID = 'beajdnpmcbgjfkhojoangknkeimimmfm';
 // CI's webServer serves on localhost:3000; locally override via PLAYWRIGHT_BASE_URL
 // to point at a deployed instance.
@@ -52,7 +52,7 @@ test.describe('Typenote Moodle Extension — real extension load', () => {
     }
   });
 
-  test('PING from an allowed origin returns version 0.2.0', async () => {
+  test('PING from an allowed origin returns version 0.2.1', async () => {
     const context = await launchWithExtension();
     try {
       const sw = await getServiceWorker(context);

--- a/e2e/sharing.spec.ts
+++ b/e2e/sharing.spec.ts
@@ -102,6 +102,46 @@ test.describe('Course sharing', () => {
     await memberCtx.close();
   });
 
+  test('shared course appears in the member sidebar tree, not only the dashboard cards', async ({
+    browser,
+  }) => {
+    test.setTimeout(90_000);
+    const ownerCtx = await browser.newContext();
+    const ownerPage = await ownerCtx.newPage();
+    await loginAs(ownerPage, OWNER.email, OWNER.password);
+    const courseName = `Sidebar Share E2E ${Date.now()}`;
+    await createCourse(ownerPage, courseName);
+    const url = await getShareUrl(ownerPage, 'viewer');
+
+    const memberCtx = await browser.newContext();
+    const memberPage = await memberCtx.newPage();
+    await loginAs(memberPage, MEMBER.email, MEMBER.password);
+    await memberPage.goto(url);
+    await expect(
+      memberPage.getByRole('heading', { name: courseName }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Back on the dashboard, the shared course must show in the LEFT sidebar
+    // tree (a separate component that previously listed owned courses only),
+    // under its own "Shared with me" group — not just on the dashboard cards.
+    await memberPage.goto('/dashboard');
+    const sidebar = memberPage.getByTestId('dashboard-sidebar');
+    await expect(sidebar.getByText('Shared with me')).toBeVisible({
+      timeout: 10_000,
+    });
+    const sidebarEntry = sidebar.getByRole('button', { name: courseName });
+    await expect(sidebarEntry).toBeVisible({ timeout: 10_000 });
+
+    // And it navigates to the shared course when clicked from the sidebar.
+    await sidebarEntry.click();
+    await expect(memberPage).toHaveURL(/\/dashboard\/courses\//, {
+      timeout: 10_000,
+    });
+
+    await ownerCtx.close();
+    await memberCtx.close();
+  });
+
   test('leave: member removes course from list; course persists for owner', async ({
     browser,
   }) => {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Typenote Moodle Sync",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Import course materials from Moodle into Typenote",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmAsETPFXkIxxNHGIsBGrtCXNqx3OSLT/BDLyd22QD6Es4IwKlMN3Png15xHpOB+RRaExNC0DtyW73/dnvSEJRJD8vTWV6JWijUeKRP2BGwk06kLTwz0u+RETLJRRvvnfgUh+WiaeX+hFZlfpFXo5zSJP6EhmZq4Asxhc0MIDyAD5JlLtgivQhy3CoFz8eyiAFcziwSKobnUVaEAm96ayjVStCyrayoz676estF5yNRSii/E5XCNdFGVbuiD70wjF3NH2KdxQm1JiGXUrZyefCtVO0cHov5akc+TWT1YIvBrcYaHuXFN/Uf4oJgzhkj9l5uEDPWdx3ajiv1WXbZirmQIDAQAB",
   "permissions": ["storage", "scripting", "cookies", "tabs", "activeTab"],

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -720,62 +720,48 @@ async function handleDownloadAndUpload(
 
     const downloadUrl = resolveFileUrl(moodleFileUrl);
 
-    // Fast path: if the registry already has this file AND its size matches
-    // what Moodle says NOW, we can register the import for this user
-    // without downloading bytes again. HEAD is one round-trip and pulls no
-    // body. Any failure (HEAD unsupported, network blip, server says
-    // "can't verify") falls through to the existing full-download flow.
+    // Claim-from-registry fast path: ask the server whether the shared
+    // registry already has this file's bytes. If so, it records the import for
+    // this user and we skip the Moodle download ENTIRELY — no HEAD, no bytes,
+    // no re-upload. This is what makes a second user's sync of an
+    // already-stored course near-instant.
+    //
+    // We deliberately don't probe Moodle with a HEAD first: embed-mode
+    // resources (view.php) return HTML on a HEAD, so the old size-match gate
+    // never fired for them and every file re-downloaded. The server owns the
+    // "do we already have it?" decision now. Any error here falls through to
+    // the full-download path below.
     try {
-      const headResp = await fetch(downloadUrl, {
-        method: 'HEAD',
-        credentials: 'include',
-        redirect: 'follow',
+      const fastResp = await fetch(`${baseOrigin}/api/moodle/import-existing`, {
+        method: 'POST',
+        headers: jsonHeaders,
+        body: JSON.stringify({
+          sectionId: metadata.sectionId,
+          moodleUrl: metadata.moodleUrl,
+        }),
       });
-      // Skip the size-match shortcut for embed-mode resources: a HEAD on the
-      // view page returns the HTML's length, not the file's, which would feed
-      // import-existing a bogus size.
-      const headType = headResp.headers.get('content-type') ?? '';
-      if (headResp.ok && !headType.includes('text/html')) {
-        const sizeHeader = headResp.headers.get('content-length');
-        const observedSize = sizeHeader ? Number(sizeHeader) : NaN;
-        if (Number.isFinite(observedSize) && observedSize > 0) {
-          const fastResp = await fetch(
-            `${baseOrigin}/api/moodle/import-existing`,
-            {
-              method: 'POST',
-              headers: jsonHeaders,
-              body: JSON.stringify({
-                sectionId: metadata.sectionId,
-                moodleUrl: metadata.moodleUrl,
-                observedSize,
-              }),
+      if (fastResp.ok) {
+        const fastJson = (await fastResp.json()) as {
+          imported?: boolean;
+          contentHash?: string;
+          fileSize?: number;
+          mimeType?: string;
+        };
+        if (fastJson.imported) {
+          return {
+            success: true,
+            data: {
+              contentHash: fastJson.contentHash ?? '',
+              fileSize: fastJson.fileSize ?? 0,
+              mimeType: fastJson.mimeType ?? '',
+              deduplicated: true,
             },
-          );
-          if (fastResp.ok) {
-            const fastJson = (await fastResp.json()) as {
-              imported?: boolean;
-              contentHash?: string;
-              fileSize?: number;
-              mimeType?: string;
-            };
-            if (fastJson.imported) {
-              return {
-                success: true,
-                data: {
-                  contentHash: fastJson.contentHash ?? '',
-                  fileSize: fastJson.fileSize ?? observedSize,
-                  mimeType: fastJson.mimeType ?? '',
-                  deduplicated: true,
-                },
-              };
-            }
-          }
+          };
         }
       }
     } catch {
-      // Any error in the fast-path probe — fall through to full download.
-      // We never want a HEAD failure to block an import that the slow path
-      // would otherwise complete.
+      // Registry probe failed (network blip, server error) — fall through to
+      // the full download so a transient failure never blocks an import.
     }
 
     let response = await fetch(downloadUrl, {

--- a/extension/src/background/service-worker.ts
+++ b/extension/src/background/service-worker.ts
@@ -18,8 +18,9 @@ import type {
   ScrapedCoursesData,
   ScrapedCourseContentData,
 } from '../types/messages';
+import { pickPluginfileUrl, extensionMatches } from '../lib/url-resolve';
 
-const EXTENSION_VERSION = '0.2.0';
+const EXTENSION_VERSION = '0.2.1';
 
 // ============================================
 // Pending permission stash
@@ -590,43 +591,112 @@ async function handleScrapeCourseContent(
 // ============================================
 
 /**
- * Resolves a Moodle activity URL to the actual pluginfile.php download URL.
- * For view.php URLs: navigates a tab to the page and extracts the real URL
- * from the DOM (pluginfile.php links in embeds/iframes/download links).
- * For pluginfile.php URLs: returns as-is.
+ * Maps a Moodle activity URL to the cheapest URL the download step can fetch.
+ *
+ * This does NO network I/O — that's the whole point of the speed fix. The old
+ * code opened a popup window per file (hours for a full course); even the
+ * pre-popup version navigated a tab per file. Instead:
+ *
+ *   - A `pluginfile.php` URL (all folder children + link-sweep items — the
+ *     majority of files) is already the file: return as-is.
+ *   - A `/mod/resource/view.php` URL gets `?redirect=1`. For "force download" /
+ *     "open" resources (the common case) Moodle 302s straight to the file, so
+ *     the download fetch follows it to the bytes with ZERO extra requests.
+ *   - Anything else is returned untouched.
+ *
+ * "Embed/in-frame" resources don't 302 — they return an HTML viewer page. That
+ * case is handled in handleDownloadAndUpload, which parses the pluginfile link
+ * out of the response it already fetched (no extra GET), and escalates to a
+ * single reused tab only if parsing fails. See resolveViaTab.
  */
-async function resolveFileUrl(moodleUrl: string): Promise<string> {
-  // Already a direct file URL
+function resolveFileUrl(moodleUrl: string): string {
   if (moodleUrl.includes('/pluginfile.php')) {
     return moodleUrl;
   }
-
-  // Navigate to the resource page and extract the real file URL
   if (
     moodleUrl.includes('/mod/resource/view.php') ||
     moodleUrl.includes('/mod/folder/view.php')
   ) {
-    const { tabId, windowId } = await openScrapeWindow(moodleUrl);
-    try {
-      try {
-        const realUrl = await executeScraperFunction<string>(
-          tabId,
-          'scrapeFileUrl',
-        );
-        if (realUrl) return realUrl;
-      } catch {
-        // scrapeFileUrl returned null — no pluginfile.php link found on page
-      }
-
-      // Fallback: try redirect=1 parameter
-      const sep = moodleUrl.includes('?') ? '&' : '?';
-      return `${moodleUrl}${sep}redirect=1`;
-    } finally {
-      await closeScrapeWindow(windowId);
-    }
+    const sep = moodleUrl.includes('?') ? '&' : '?';
+    return `${moodleUrl}${sep}redirect=1`;
   }
-
   return moodleUrl;
+}
+
+// ============================================
+// Fallback resolver: one reused background tab
+// ============================================
+// Last resort for resources whose pluginfile link we can't get from the page's
+// server HTML (e.g. JS-rendered viewers). We DOM-scrape via the content script,
+// but — unlike the old code — share ONE inactive tab across all files and
+// serialize navigations through a mutex, so this never becomes "a tab per file"
+// again. The tab is auto-closed shortly after the last fallback resolve.
+
+let fallbackTabId: number | null = null;
+let fallbackChain: Promise<unknown> = Promise.resolve();
+let fallbackCloseTimer: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Resolves a view.php URL to its pluginfile link by loading it in the shared
+ * fallback tab and running the DOM scraper. Returns null if it can't. Calls are
+ * serialized: the ≤4 download workers take turns on the single tab so their
+ * navigations can't clobber each other.
+ */
+async function resolveViaTab(moodleUrl: string): Promise<string | null> {
+  const run = fallbackChain.then(() => resolveViaTabInner(moodleUrl));
+  // Keep the mutex chain alive whether this resolve succeeds or throws.
+  fallbackChain = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
+
+async function resolveViaTabInner(moodleUrl: string): Promise<string | null> {
+  if (fallbackCloseTimer !== null) {
+    clearTimeout(fallbackCloseTimer);
+    fallbackCloseTimer = null;
+  }
+  try {
+    if (fallbackTabId === null) {
+      // Inactive tab: a resource view page has its pluginfile link in the
+      // initial HTML (no timer-driven hydration like the dashboard), so it
+      // doesn't need focus to render — and we don't steal the user's focus.
+      const tab = await chrome.tabs.create({ url: moodleUrl, active: false });
+      if (tab.id === undefined) return null;
+      fallbackTabId = tab.id;
+    } else {
+      await chrome.tabs.update(fallbackTabId, {
+        url: moodleUrl,
+        active: false,
+      });
+    }
+    await waitForTabLoad(fallbackTabId);
+    const realUrl = await executeScraperFunction<string>(
+      fallbackTabId,
+      'scrapeFileUrl',
+    );
+    return realUrl || null;
+  } catch {
+    return null;
+  } finally {
+    scheduleFallbackTabClose();
+  }
+}
+
+/** Close the shared fallback tab a few seconds after the last fallback use. */
+function scheduleFallbackTabClose(): void {
+  if (fallbackCloseTimer !== null) clearTimeout(fallbackCloseTimer);
+  fallbackCloseTimer = setTimeout(() => {
+    fallbackCloseTimer = null;
+    if (fallbackTabId !== null) {
+      const id = fallbackTabId;
+      fallbackTabId = null;
+      chrome.tabs.remove(id).catch(() => {
+        // Tab already gone — fine.
+      });
+    }
+  }, 5_000);
 }
 
 async function handleDownloadAndUpload(
@@ -648,7 +718,7 @@ async function handleDownloadAndUpload(
     };
     if (authToken) jsonHeaders['Authorization'] = `Bearer ${authToken}`;
 
-    const downloadUrl = await resolveFileUrl(moodleFileUrl);
+    const downloadUrl = resolveFileUrl(moodleFileUrl);
 
     // Fast path: if the registry already has this file AND its size matches
     // what Moodle says NOW, we can register the import for this user
@@ -661,7 +731,11 @@ async function handleDownloadAndUpload(
         credentials: 'include',
         redirect: 'follow',
       });
-      if (headResp.ok) {
+      // Skip the size-match shortcut for embed-mode resources: a HEAD on the
+      // view page returns the HTML's length, not the file's, which would feed
+      // import-existing a bogus size.
+      const headType = headResp.headers.get('content-type') ?? '';
+      if (headResp.ok && !headType.includes('text/html')) {
         const sizeHeader = headResp.headers.get('content-length');
         const observedSize = sizeHeader ? Number(sizeHeader) : NaN;
         if (Number.isFinite(observedSize) && observedSize > 0) {
@@ -704,7 +778,7 @@ async function handleDownloadAndUpload(
       // would otherwise complete.
     }
 
-    const response = await fetch(downloadUrl, {
+    let response = await fetch(downloadUrl, {
       credentials: 'include',
       redirect: 'follow',
     });
@@ -714,11 +788,51 @@ async function handleDownloadAndUpload(
       );
     }
 
-    const contentType = response.headers.get('content-type') ?? '';
+    let resolvedUrl = response.url || downloadUrl;
+    let contentType = response.headers.get('content-type') ?? '';
+
+    // Embed/in-frame resource: we got the HTML viewer page, not the file.
+    // Parse the real pluginfile link out of THIS response (no extra GET);
+    // pickPluginfileUrl skips avatar/theme/overview chrome and prefers a
+    // forcedownload link. If the page has no usable link (e.g. JS-rendered),
+    // escalate once to the shared fallback tab.
     if (contentType.includes('text/html')) {
+      const html = await response.text();
+      let real = pickPluginfileUrl(html);
+      if (!real) {
+        real = await resolveViaTab(moodleFileUrl);
+      }
+      if (!real) {
+        throw new Error(
+          `Could not find a downloadable file for ${moodleFileUrl.substring(0, 80)}`,
+        );
+      }
+      response = await fetch(real, {
+        credentials: 'include',
+        redirect: 'follow',
+      });
+      if (!response.ok) {
+        throw new Error(
+          `Download failed: ${response.status} ${response.statusText}`,
+        );
+      }
+      resolvedUrl = response.url || real;
+      contentType = response.headers.get('content-type') ?? '';
+      if (contentType.includes('text/html')) {
+        throw new Error(
+          `Got HTML instead of file — could not resolve download URL. ` +
+            `Resource: ${moodleFileUrl.substring(0, 80)}`,
+        );
+      }
+    }
+
+    // Wrong-file guard: if the resolved file's extension is known and differs
+    // from the expected filename's, we resolved to the wrong thing (e.g. an
+    // avatar PNG for a PDF). The "not HTML" check above can't catch that.
+    if (!extensionMatches(resolvedUrl, metadata.fileName)) {
       throw new Error(
-        `Got HTML instead of file — could not resolve download URL. ` +
-          `Resource: ${moodleFileUrl.substring(0, 80)}`,
+        `Resolved a different file type than expected for ${metadata.fileName} ` +
+          `(got ${resolvedUrl.substring(0, 80)}).`,
       );
     }
 

--- a/extension/src/lib/url-resolve.test.ts
+++ b/extension/src/lib/url-resolve.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractPluginfileUrl,
+  pickPluginfileUrl,
+  isNonContentPluginfile,
+  fileExtensionOf,
+  extensionMatches,
+} from './url-resolve';
+
+describe('extractPluginfileUrl', () => {
+  it('extracts a pluginfile URL from an <object> embed', () => {
+    const html = `<object data="https://moodle.runi.ac.il/pluginfile.php/12345/mod_resource/content/3/lecture%201.pdf?forcedownload=1" type="application/pdf"></object>`;
+    expect(extractPluginfileUrl(html)).toBe(
+      'https://moodle.runi.ac.il/pluginfile.php/12345/mod_resource/content/3/lecture%201.pdf?forcedownload=1',
+    );
+  });
+
+  it('decodes &amp; in the matched URL', () => {
+    const html = `<a href="https://m.x.ac.il/pluginfile.php/1/mod_resource/content/0/a.pdf?time=1&amp;forcedownload=1">x</a>`;
+    expect(extractPluginfileUrl(html)).toBe(
+      'https://m.x.ac.il/pluginfile.php/1/mod_resource/content/0/a.pdf?time=1&forcedownload=1',
+    );
+  });
+
+  it('returns null when there is no pluginfile link', () => {
+    const html = `<div>no file, just a <a href="https://host/course/view.php?id=1">course</a></div>`;
+    expect(extractPluginfileUrl(html)).toBeNull();
+  });
+
+  it('does not match relative pluginfile paths (requires scheme)', () => {
+    const html = `<a href="/pluginfile.php/1/mod_resource/content/0/a.pdf">x</a>`;
+    expect(extractPluginfileUrl(html)).toBeNull();
+  });
+});
+
+describe('pickPluginfileUrl', () => {
+  it('skips a leading avatar pluginfile and returns the real resource', () => {
+    // Avatar appears in the header BEFORE the resource — the bug we are guarding.
+    const html = `
+      <img src="https://m.ac.il/pluginfile.php/55/user/icon/boost/f1?rev=2">
+      <object data="https://m.ac.il/pluginfile.php/999/mod_resource/content/1/slides.pptx"></object>
+    `;
+    expect(pickPluginfileUrl(html)).toBe(
+      'https://m.ac.il/pluginfile.php/999/mod_resource/content/1/slides.pptx',
+    );
+  });
+
+  it('skips a theme-logo pluginfile and returns the real resource', () => {
+    const html = `
+      <img src="https://m.ac.il/pluginfile.php/1/theme/boost/logo/1/logo.png">
+      <a href="https://m.ac.il/pluginfile.php/42/mod_resource/content/0/notes.pdf">notes</a>
+    `;
+    expect(pickPluginfileUrl(html)).toBe(
+      'https://m.ac.il/pluginfile.php/42/mod_resource/content/0/notes.pdf',
+    );
+  });
+
+  it('prefers a forcedownload=1 link even if a non-content one comes first', () => {
+    const html = `
+      <img src="https://m.ac.il/pluginfile.php/55/user/icon/boost/f1">
+      <a href="https://m.ac.il/pluginfile.php/7/mod_resource/content/0/preview.pdf">preview</a>
+      <a href="https://m.ac.il/pluginfile.php/7/mod_resource/content/0/real.pdf?forcedownload=1">download</a>
+    `;
+    expect(pickPluginfileUrl(html)).toBe(
+      'https://m.ac.il/pluginfile.php/7/mod_resource/content/0/real.pdf?forcedownload=1',
+    );
+  });
+
+  it('falls back to the first match when every link is non-content', () => {
+    const html = `<img src="https://m.ac.il/pluginfile.php/55/user/icon/boost/f1.png">`;
+    expect(pickPluginfileUrl(html)).toBe(
+      'https://m.ac.il/pluginfile.php/55/user/icon/boost/f1.png',
+    );
+  });
+
+  it('returns null when there is no pluginfile link', () => {
+    expect(pickPluginfileUrl('<p>nothing here</p>')).toBeNull();
+  });
+
+  it('decodes &amp; on the chosen URL', () => {
+    const html = `<a href="https://m.ac.il/pluginfile.php/7/mod_resource/content/0/x.pdf?a=1&amp;forcedownload=1">d</a>`;
+    expect(pickPluginfileUrl(html)).toBe(
+      'https://m.ac.il/pluginfile.php/7/mod_resource/content/0/x.pdf?a=1&forcedownload=1',
+    );
+  });
+});
+
+describe('isNonContentPluginfile', () => {
+  it.each([
+    ['https://m/pluginfile.php/55/user/icon/boost/f1', true],
+    ['https://m/pluginfile.php/1/theme/boost/logo/1/logo.png', true],
+    ['https://m/pluginfile.php/3/course/overviewfiles/0/cover.jpg', true],
+    ['https://m/pluginfile.php/9/mod_resource/content/0/real.pdf', false],
+  ])('%s -> %s', (url, expected) => {
+    expect(isNonContentPluginfile(url)).toBe(expected);
+  });
+});
+
+describe('fileExtensionOf', () => {
+  it('reads extension from a URL with a query string', () => {
+    expect(
+      fileExtensionOf(
+        'https://m/pluginfile.php/1/x/y/lecture.pdf?forcedownload=1',
+      ),
+    ).toBe('pdf');
+  });
+
+  it('percent-decodes the segment before reading the extension', () => {
+    expect(fileExtensionOf('https://m/x/lecture%20one.PPTX')).toBe('pptx');
+  });
+
+  it('reads extension from a bare filename', () => {
+    expect(fileExtensionOf('notes.docx')).toBe('docx');
+  });
+
+  it('returns null for unknown/undeterminable extensions', () => {
+    expect(fileExtensionOf('https://m/x/file.xyz')).toBeNull();
+    expect(fileExtensionOf('https://m/x/noextension')).toBeNull();
+    expect(fileExtensionOf('')).toBeNull();
+  });
+});
+
+describe('extensionMatches', () => {
+  it('accepts when resolved extension equals expected', () => {
+    expect(
+      extensionMatches('https://m/pluginfile.php/1/x/real.pdf', 'real.pdf'),
+    ).toBe(true);
+  });
+
+  it('rejects an avatar PNG resolved for an expected PDF', () => {
+    expect(
+      extensionMatches(
+        'https://m/pluginfile.php/55/user/icon/boost/f1.png',
+        'lecture.pdf',
+      ),
+    ).toBe(false);
+  });
+
+  it('accepts (does not block) when either extension is unknown', () => {
+    // Resolved is a redirect=1 view URL with no file extension -> unknown -> allow.
+    expect(
+      extensionMatches(
+        'https://m/mod/resource/view.php?id=5&redirect=1',
+        'lecture.pdf',
+      ),
+    ).toBe(true);
+    // Expected name has no extension -> unknown -> allow.
+    expect(
+      extensionMatches('https://m/pluginfile.php/1/x/real.pdf', 'lecture'),
+    ).toBe(true);
+  });
+});

--- a/extension/src/lib/url-resolve.ts
+++ b/extension/src/lib/url-resolve.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure URL-resolution helpers for Moodle file downloads.
+ *
+ * These are deliberately free of `chrome.*` and DOM globals at import time so
+ * they can be unit-tested under the web app's jsdom vitest without mocking the
+ * extension environment. The service worker imports them; all the I/O (fetch,
+ * tabs) lives there.
+ */
+
+// File extensions Typenote can actually import. Mirrors ALLOWED_FILE_EXTENSIONS
+// in the content scraper — kept in sync deliberately (small, rarely changes).
+const KNOWN_EXTENSIONS = new Set([
+  'pdf',
+  'docx',
+  'doc',
+  'pptx',
+  'ppt',
+  // Non-content types we still want to RECOGNISE (so extensionMatches can flag
+  // an avatar PNG masquerading as a PDF) even though they're never imported.
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'svg',
+  'webp',
+  'zip',
+  'rar',
+  'mp4',
+  'mp3',
+  'xlsx',
+  'xls',
+]);
+
+// Path fragments that mark a pluginfile URL as chrome (avatar, theme logo,
+// course overview image) rather than the actual resource the user wants. These
+// commonly appear in a resource view page's header — BEFORE the real file in
+// source order — so a naive "first match" would grab them.
+const NON_CONTENT_PATH_FRAGMENTS = [
+  '/user/icon/',
+  '/theme/',
+  '/course/overviewfiles/',
+];
+
+/**
+ * Extracts the first `pluginfile.php` download URL from raw HTML. Returns null
+ * when none is present. Moodle HTML-escapes `&` as `&amp;` inside attribute
+ * values, so we decode that back to a usable URL. The service worker has no
+ * DOMParser, hence a regex scan of the markup.
+ *
+ * Prefer `pickPluginfileUrl` over this for resource pages — it avoids grabbing
+ * an avatar/logo that precedes the real file. This raw "first match" helper is
+ * exported mainly for testing and as the primitive `pickPluginfileUrl` builds on.
+ */
+export function extractPluginfileUrl(html: string): string | null {
+  const match = html.match(
+    /https?:\/\/[^\s"'<>\\]+\/pluginfile\.php\/[^\s"'<>\\]+/,
+  );
+  if (!match) return null;
+  return decodeAmp(match[0]);
+}
+
+/**
+ * Picks the best `pluginfile.php` URL from a resource view page's HTML.
+ *
+ * Priority:
+ *   1. A link carrying `forcedownload=1` — that's unambiguously the file Moodle
+ *      wants you to download.
+ *   2. The first link whose path is NOT avatar/theme/overview chrome.
+ *   3. The first link of any kind (last resort).
+ *
+ * Returns null when the HTML contains no pluginfile link at all. Decodes
+ * `&amp;` on the chosen URL.
+ */
+export function pickPluginfileUrl(html: string): string | null {
+  const matches = html.match(
+    /https?:\/\/[^\s"'<>\\]+\/pluginfile\.php\/[^\s"'<>\\]+/g,
+  );
+  if (!matches || matches.length === 0) return null;
+
+  const decoded = matches.map(decodeAmp);
+
+  const forced = decoded.find((u) => /[?&]forcedownload=1\b/.test(u));
+  if (forced) return forced;
+
+  const content = decoded.find((u) => !isNonContentPluginfile(u));
+  if (content) return content;
+
+  return decoded[0];
+}
+
+/**
+ * True when a pluginfile URL points at avatar/theme/course-overview chrome
+ * rather than an actual resource file.
+ */
+export function isNonContentPluginfile(url: string): boolean {
+  return NON_CONTENT_PATH_FRAGMENTS.some((frag) => url.includes(frag));
+}
+
+/**
+ * Returns the lowercased file extension implied by a URL or filename, or null
+ * if it can't be determined or isn't a recognised type. Strips query/hash and
+ * percent-decodes the last path segment first (Moodle encodes spaces etc.).
+ */
+export function fileExtensionOf(urlOrName: string): string | null {
+  if (!urlOrName) return null;
+  // Last path segment, without query/hash.
+  let segment = urlOrName.split(/[?#]/)[0];
+  segment = segment.substring(segment.lastIndexOf('/') + 1);
+  try {
+    segment = decodeURIComponent(segment);
+  } catch {
+    // Leave as-is if it isn't valid percent-encoding.
+  }
+  const dot = segment.lastIndexOf('.');
+  if (dot < 0 || dot === segment.length - 1) return null;
+  const ext = segment.slice(dot + 1).toLowerCase();
+  return KNOWN_EXTENSIONS.has(ext) ? ext : null;
+}
+
+/**
+ * Guards against resolving to the wrong file (e.g. an avatar PNG instead of the
+ * lecture PDF). Returns false ONLY when both extensions are known AND they
+ * differ. If either side's extension is unknown/undeterminable we return true
+ * (don't block) — we'd rather download a correctly-resolved oddball than reject
+ * a real file because we couldn't classify it.
+ */
+export function extensionMatches(
+  resolvedUrl: string,
+  expectedFileName: string,
+): boolean {
+  const got = fileExtensionOf(resolvedUrl);
+  const want = fileExtensionOf(expectedFileName);
+  if (got === null || want === null) return true;
+  return got === want;
+}
+
+function decodeAmp(url: string): string {
+  return url.replace(/&amp;/g, '&');
+}

--- a/src/app/api/moodle/import-existing/route.test.ts
+++ b/src/app/api/moodle/import-existing/route.test.ts
@@ -169,7 +169,9 @@ describe('POST /api/moodle/import-existing', () => {
     expect(data.reason).toBe('not_in_registry');
   });
 
-  it('refuses with size_unknown when registry has no file_size', async () => {
+  it('claims even when file_size is unknown, as long as bytes are stored', async () => {
+    // file_size is metadata; storage_path + content_hash prove we have the
+    // bytes. Claim-from-registry no longer gates on size.
     const admin = buildAdmin({
       file: {
         id: 'file-1',
@@ -184,11 +186,15 @@ describe('POST /api/moodle/import-existing', () => {
     const res = await POST(makeRequest(body) as never);
     const data = await res.json();
 
-    expect(data.imported).toBe(false);
-    expect(data.reason).toBe('size_unknown');
+    expect(data.imported).toBe(true);
+    expect(recordUserFileImport).toHaveBeenCalledWith('u1', 'file-1', 'mc-1');
   });
 
-  it('refuses with size_changed when observedSize disagrees with registry', async () => {
+  it('claims regardless of observedSize differing from the stored size', async () => {
+    // Deliberate tradeoff: we do NOT re-verify size against Moodle. A stored
+    // file (storage_path + content_hash) is claimed even when the HEAD-observed
+    // size differs, so a second user skips the download. A replaced file is
+    // picked up by a future change-detecting re-sync, not here.
     const admin = buildAdmin({
       file: {
         id: 'file-1',
@@ -203,8 +209,28 @@ describe('POST /api/moodle/import-existing', () => {
     const res = await POST(makeRequest(body) as never);
     const data = await res.json();
 
+    expect(data.imported).toBe(true);
+    expect(data.deduplicated).toBe(true);
+    expect(recordUserFileImport).toHaveBeenCalledWith('u1', 'file-1', 'mc-1');
+  });
+
+  it('does not claim a registry row that has no content hash (not materialized)', async () => {
+    const admin = buildAdmin({
+      file: {
+        id: 'file-1',
+        storage_path: 'm.org/c1/abc.pdf',
+        content_hash: null,
+        file_size: 100,
+        mime_type: 'application/pdf',
+      },
+    });
+    setupAuth(admin);
+
+    const res = await POST(makeRequest(body) as never);
+    const data = await res.json();
+
     expect(data.imported).toBe(false);
-    expect(data.reason).toBe('size_changed');
+    expect(data.reason).toBe('not_materialized');
     expect(recordUserFileImport).not.toHaveBeenCalled();
   });
 

--- a/src/app/api/moodle/import-existing/route.test.ts
+++ b/src/app/api/moodle/import-existing/route.test.ts
@@ -16,10 +16,19 @@ vi.mock('@/lib/actions/ai-context', () => ({
   indexContent: vi.fn().mockResolvedValue({ success: true, skipped: true }),
 }));
 
-// Default: no existing embedding, so a claim re-indexes. Tests that exercise
-// the skip-when-already-indexed path override this per-case.
+// Default: no existing embedding, so a claim schedules a background index.
+// Tests that exercise the skip-when-already-indexed path override this per-case.
 vi.mock('@/lib/queries/embeddings', () => ({
   getContentHash: vi.fn().mockResolvedValue(null),
+}));
+
+// Run scheduled background work synchronously so indexContent assertions hold.
+// One test overrides this with a capturing mock to prove the response does not
+// wait on indexing.
+vi.mock('@/lib/server/after-response', () => ({
+  scheduleAfterResponse: vi.fn((work: () => Promise<void>) => {
+    void work();
+  }),
 }));
 
 import { POST } from './route';
@@ -28,6 +37,7 @@ import { createAdminClient } from '@/lib/supabase/admin';
 import { recordUserFileImport } from '@/lib/actions/moodle-sync';
 import { indexContent } from '@/lib/actions/ai-context';
 import { getContentHash } from '@/lib/queries/embeddings';
+import { scheduleAfterResponse } from '@/lib/server/after-response';
 
 type FileRow = {
   id: string;
@@ -331,33 +341,22 @@ describe('POST /api/moodle/import-existing', () => {
     });
     setupAuth(admin);
 
-    let resolveIndex!: () => void;
-    const gate = new Promise<{ success: boolean; skipped: boolean }>(
-      (resolve) => {
-        resolveIndex = () => resolve({ success: true, skipped: false });
-      },
-    );
-    vi.mocked(indexContent).mockReturnValueOnce(gate as never);
-
-    const respPromise = POST(makeRequest(body) as never);
-
-    // Let microtasks run: indexContent should have been dispatched...
-    await new Promise((r) => setImmediate(r));
-    let settled = false;
-    void respPromise.then(() => {
-      settled = true;
+    // Capture the scheduled work instead of running it, to prove the response
+    // does NOT wait on indexing.
+    let scheduled: (() => Promise<void>) | null = null;
+    vi.mocked(scheduleAfterResponse).mockImplementationOnce((work) => {
+      scheduled = work;
     });
-    await new Promise((r) => setImmediate(r));
-    // ...but the response must NOT have resolved yet (proves we await).
-    expect(settled).toBe(false);
+    // indexContent would hang forever if (wrongly) awaited inline.
+    vi.mocked(indexContent).mockReturnValueOnce(new Promise(() => {}) as never);
 
-    resolveIndex();
-    const res = await respPromise;
+    const res = await POST(makeRequest(body) as never);
+
+    // Response returns immediately even though indexing hasn't run.
     expect(res.status).toBe(200);
-    expect(indexContent).toHaveBeenCalledWith({
-      type: 'moodle_file',
-      fileId: 'file-1',
-      courseId: 'tn-course-1',
-    });
+    expect(indexContent).not.toHaveBeenCalled();
+    // Indexing was scheduled for after the response.
+    expect(scheduleAfterResponse).toHaveBeenCalledTimes(1);
+    expect(scheduled).toBeTypeOf('function');
   });
 });

--- a/src/app/api/moodle/import-existing/route.test.ts
+++ b/src/app/api/moodle/import-existing/route.test.ts
@@ -16,11 +16,18 @@ vi.mock('@/lib/actions/ai-context', () => ({
   indexContent: vi.fn().mockResolvedValue({ success: true, skipped: true }),
 }));
 
+// Default: no existing embedding, so a claim re-indexes. Tests that exercise
+// the skip-when-already-indexed path override this per-case.
+vi.mock('@/lib/queries/embeddings', () => ({
+  getContentHash: vi.fn().mockResolvedValue(null),
+}));
+
 import { POST } from './route';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { recordUserFileImport } from '@/lib/actions/moodle-sync';
 import { indexContent } from '@/lib/actions/ai-context';
+import { getContentHash } from '@/lib/queries/embeddings';
 
 type FileRow = {
   id: string;
@@ -212,6 +219,56 @@ describe('POST /api/moodle/import-existing', () => {
     expect(data.imported).toBe(true);
     expect(data.deduplicated).toBe(true);
     expect(recordUserFileImport).toHaveBeenCalledWith('u1', 'file-1', 'mc-1');
+  });
+
+  it('skips re-indexing when an embedding already exists at the registry hash', async () => {
+    // The expensive part of a "dedup" claim is indexContent downloading +
+    // hashing the file. When an embedding already exists at the same content
+    // hash, the claim must skip it — that is the speed fix for a second user's
+    // sync of an already-indexed course.
+    vi.mocked(getContentHash).mockResolvedValueOnce('abc'); // matches file.content_hash
+    const admin = buildAdmin({
+      file: {
+        id: 'file-1',
+        storage_path: 'm.org/c1/abc.pdf',
+        content_hash: 'abc',
+        file_size: 12345,
+        mime_type: 'application/pdf',
+      },
+    });
+    setupAuth(admin);
+
+    const res = await POST(makeRequest(body) as never);
+    const data = await res.json();
+
+    expect(data.imported).toBe(true);
+    expect(recordUserFileImport).toHaveBeenCalledWith('u1', 'file-1', 'mc-1');
+    // The whole point: no re-index when embeddings are already present + current.
+    expect(indexContent).not.toHaveBeenCalled();
+  });
+
+  it('re-indexes when the existing embedding hash is stale', async () => {
+    vi.mocked(getContentHash).mockResolvedValueOnce('OLD-HASH'); // != file.content_hash
+    const admin = buildAdmin({
+      file: {
+        id: 'file-1',
+        storage_path: 'm.org/c1/abc.pdf',
+        content_hash: 'abc',
+        file_size: 12345,
+        mime_type: 'application/pdf',
+      },
+    });
+    setupAuth(admin);
+
+    const res = await POST(makeRequest(body) as never);
+    const data = await res.json();
+
+    expect(data.imported).toBe(true);
+    expect(indexContent).toHaveBeenCalledWith({
+      type: 'moodle_file',
+      fileId: 'file-1',
+      courseId: 'tn-course-1',
+    });
   });
 
   it('does not claim a registry row that has no content hash (not materialized)', async () => {

--- a/src/app/api/moodle/import-existing/route.ts
+++ b/src/app/api/moodle/import-existing/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { indexContent } from '@/lib/actions/ai-context';
 import { recordUserFileImport } from '@/lib/actions/moodle-sync';
 import { getContentHash } from '@/lib/queries/embeddings';
+import { scheduleAfterResponse } from '@/lib/server/after-response';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 
@@ -113,30 +114,31 @@ export async function POST(request: NextRequest) {
     }
 
     if (appCourseId) {
-      // Skip indexing entirely when an embedding already exists for this file
-      // at the registry's content hash. indexContent would otherwise download
-      // the full file from storage and SHA-256 it just to discover it can
-      // skip — ~1.5s per file, the dominant cost of a second user's "dedup"
-      // sync. getContentHash is a single cheap row read. The per-user import
-      // row recorded above is what grants AI access; the embeddings are shared
-      // across users by canonical moodle_courses.id, so we don't need to
-      // re-create them. Only index when missing or stale (hash mismatch).
+      // Embeddings are shared across users by canonical moodle_courses.id, so a
+      // file only needs embedding ONCE — never on a claim where it already
+      // exists. getContentHash is a single cheap row read. The per-user import
+      // recorded above is what grants AI access; we never re-create embeddings
+      // that are already current.
       const embeddedHash = await getContentHash('moodle_file', file.id);
       const alreadyIndexed =
         !!embeddedHash && embeddedHash === file.content_hash;
       if (!alreadyIndexed) {
-        // Awaited (not fire-and-forget): a detached promise is dropped when the
-        // serverless function freezes after responding, leaving the file
-        // un-embedded and unfindable. Failure is logged, not fatal.
-        try {
-          await indexContent({
-            type: 'moodle_file',
-            fileId: file.id,
-            courseId: appCourseId,
-          });
-        } catch (err) {
-          console.error('Index failed:', err);
-        }
+        // Index in the BACKGROUND (after the response). Embedding takes tens of
+        // seconds and nobody is waiting on its result, so it must not block the
+        // sync — that was why even deduped files took ~60s each. scheduleAfter-
+        // Response uses Next after() so the work survives the serverless freeze.
+        const fileId = file.id;
+        scheduleAfterResponse(async () => {
+          try {
+            await indexContent({
+              type: 'moodle_file',
+              fileId,
+              courseId: appCourseId,
+            });
+          } catch (err) {
+            console.error('Background index failed:', err);
+          }
+        });
       }
     }
 

--- a/src/app/api/moodle/import-existing/route.ts
+++ b/src/app/api/moodle/import-existing/route.ts
@@ -63,19 +63,25 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    if (file.file_size == null) {
-      // First import never populated file_size — we can't prove the
-      // current Moodle file matches what we have. Force a fresh download.
-      return NextResponse.json({ imported: false, reason: 'size_unknown' });
+    if (!file.content_hash) {
+      // A registry row with no content hash hasn't been fully materialized
+      // (scrape-time placeholder). We can't claim bytes we don't have —
+      // force a fresh download.
+      return NextResponse.json({ imported: false, reason: 'not_materialized' });
     }
 
-    if (
-      typeof observedSize === 'number' &&
-      Number.isFinite(observedSize) &&
-      file.file_size !== observedSize
-    ) {
-      return NextResponse.json({ imported: false, reason: 'size_changed' });
-    }
+    // Claim-from-registry: the shared registry already has this file's bytes
+    // (storage_path + content_hash). Register the import for THIS user and skip
+    // the Moodle download entirely — that's the whole point of the shared
+    // registry, and it makes a second user's sync near-instant for files that
+    // are already stored.
+    //
+    // Tradeoff (intentional): we do NOT re-verify the file hasn't changed on
+    // Moodle here. If an instructor replaces a file under the same URL, users
+    // who claim from the registry keep the existing version until a future
+    // change-detecting re-sync refreshes the registry. `observedSize` is no
+    // longer used to gate this; it's accepted for backward compatibility only.
+    void observedSize;
 
     // Resolve the linked Typenote course (best-effort; AI indexing needs it
     // but registration of the user import does not).

--- a/src/app/api/moodle/import-existing/route.ts
+++ b/src/app/api/moodle/import-existing/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { indexContent } from '@/lib/actions/ai-context';
 import { recordUserFileImport } from '@/lib/actions/moodle-sync';
+import { getContentHash } from '@/lib/queries/embeddings';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 
@@ -112,18 +113,30 @@ export async function POST(request: NextRequest) {
     }
 
     if (appCourseId) {
-      // Awaited (not fire-and-forget): a detached promise is dropped when the
-      // serverless function freezes after responding, leaving the file
-      // un-embedded and unfindable. indexContent short-circuits on a content
-      // hash match, so re-imports stay cheap. Failure is logged, not fatal.
-      try {
-        await indexContent({
-          type: 'moodle_file',
-          fileId: file.id,
-          courseId: appCourseId,
-        });
-      } catch (err) {
-        console.error('Index failed:', err);
+      // Skip indexing entirely when an embedding already exists for this file
+      // at the registry's content hash. indexContent would otherwise download
+      // the full file from storage and SHA-256 it just to discover it can
+      // skip — ~1.5s per file, the dominant cost of a second user's "dedup"
+      // sync. getContentHash is a single cheap row read. The per-user import
+      // row recorded above is what grants AI access; the embeddings are shared
+      // across users by canonical moodle_courses.id, so we don't need to
+      // re-create them. Only index when missing or stale (hash mismatch).
+      const embeddedHash = await getContentHash('moodle_file', file.id);
+      const alreadyIndexed =
+        !!embeddedHash && embeddedHash === file.content_hash;
+      if (!alreadyIndexed) {
+        // Awaited (not fire-and-forget): a detached promise is dropped when the
+        // serverless function freezes after responding, leaving the file
+        // un-embedded and unfindable. Failure is logged, not fatal.
+        try {
+          await indexContent({
+            type: 'moodle_file',
+            fileId: file.id,
+            courseId: appCourseId,
+          });
+        } catch (err) {
+          console.error('Index failed:', err);
+        }
       }
     }
 

--- a/src/app/api/moodle/upload-finalize/route.ts
+++ b/src/app/api/moodle/upload-finalize/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { indexContent } from '@/lib/actions/ai-context';
 import { recordUserFileImport } from '@/lib/actions/moodle-sync';
+import { scheduleAfterResponse } from '@/lib/server/after-response';
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
 
@@ -128,18 +129,22 @@ export async function POST(request: NextRequest) {
           console.error('user_file_imports upsert failed:', err),
         );
       }
-      // Index for AI search. Awaited (not fire-and-forget): detached promises
-      // are dropped on serverless freeze, leaving the file unfindable.
+      // Index for AI search in the BACKGROUND (after the response). Embedding
+      // takes tens of seconds; the user's sync must not wait on it. scheduleAfter-
+      // Response uses Next after() so the work survives the serverless freeze.
       if (appCourseId) {
-        try {
-          await indexContent({
-            type: 'moodle_file',
-            fileId: fileRecord.id,
-            courseId: appCourseId,
-          });
-        } catch (err) {
-          console.error('Index failed:', err);
-        }
+        const fileId = fileRecord.id;
+        scheduleAfterResponse(async () => {
+          try {
+            await indexContent({
+              type: 'moodle_file',
+              fileId,
+              courseId: appCourseId,
+            });
+          } catch (err) {
+            console.error('Background index failed:', err);
+          }
+        });
       }
       return NextResponse.json({
         fileId: fileRecord.id,
@@ -179,18 +184,20 @@ export async function POST(request: NextRequest) {
         (err) => console.error('user_file_imports upsert failed:', err),
       );
     }
-    // Index for AI search. Awaited (not fire-and-forget): detached promises
-    // are dropped on serverless freeze, leaving the file unfindable.
+    // Index for AI search in the BACKGROUND (after the response) — see above.
     if (appCourseId) {
-      try {
-        await indexContent({
-          type: 'moodle_file',
-          fileId: newRecord.id,
-          courseId: appCourseId,
-        });
-      } catch (err) {
-        console.error('Index failed:', err);
-      }
+      const fileId = newRecord.id;
+      scheduleAfterResponse(async () => {
+        try {
+          await indexContent({
+            type: 'moodle_file',
+            fileId,
+            courseId: appCourseId,
+          });
+        } catch (err) {
+          console.error('Background index failed:', err);
+        }
+      });
     }
 
     return NextResponse.json({

--- a/src/app/api/moodle/upload-prepare/route.ts
+++ b/src/app/api/moodle/upload-prepare/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { createClient } from '@/lib/supabase/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { buildStorageFileName } from '@/lib/moodle/storage-path';
 
 /**
  * Step 1 of the extension's two-phase upload.
@@ -66,8 +67,13 @@ export async function POST(request: NextRequest) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (section as any)?.moodle_courses?.moodle_course_id ?? 'unknown';
 
-    const ext = fileName.includes('.') ? fileName.split('.').pop() : '';
-    const safeFileName = ext ? `${contentHash}.${ext}` : contentHash;
+    // The "fileName" is often the Moodle activity TITLE (e.g.
+    // "2025.12.24 - שיעור (CML ו-SML)"), not a real filename. Deriving the
+    // extension by splitting on the last dot then yields garbage with spaces /
+    // parens / unicode, which Supabase Storage rejects (InvalidKey). The key is
+    // content-hash based anyway, so the extension is cosmetic — use a sanitized
+    // one or none. (mime_type, stored separately, is the source of truth.)
+    const safeFileName = buildStorageFileName(contentHash, fileName);
     const storagePath = `${domain}/${moodleCourseId}/${safeFileName}`;
 
     // The storage key is derived from the SHA-256 content hash, so a

--- a/src/components/dashboard/create-document-dialog.test.tsx
+++ b/src/components/dashboard/create-document-dialog.test.tsx
@@ -30,9 +30,10 @@ describe('CreateDocumentDialog', () => {
     expect(screen.getByLabelText(/title/i)).toHaveValue('Untitled');
   });
 
-  it('renders subject select trigger', () => {
+  it('does not render a subject selector (removed at creation time)', () => {
     renderDialog();
-    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.queryByText(/^subject$/i)).not.toBeInTheDocument();
   });
 
   it('renders canvas type options', () => {

--- a/src/components/dashboard/create-document-dialog.tsx
+++ b/src/components/dashboard/create-document-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { SUBJECTS, CANVAS_TYPES } from '@/lib/constants/subjects';
+import { CANVAS_TYPES } from '@/lib/constants/subjects';
 import { createDocument } from '@/lib/actions/documents';
 import { trackEvent } from '@/lib/analytics/events';
 import {
@@ -17,13 +17,6 @@ import {
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { PageTypeThumb } from '@/components/ui/page-type-thumb';
 
 interface CreateDocumentDialogProps {
@@ -42,8 +35,6 @@ export function CreateDocumentDialog({
   const router = useRouter();
   const [open, setOpen] = useState(defaultOpen);
   const [title, setTitle] = useState('Untitled');
-  const [subject, setSubject] = useState('calculus');
-  const [subjectCustom, setSubjectCustom] = useState('');
   const [canvasType, setCanvasType] = useState('blank');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -56,8 +47,9 @@ export function CreateDocumentDialog({
     try {
       const doc = await createDocument({
         title: title.trim() || 'Untitled',
-        subject,
-        subject_custom: subject === 'other' ? subjectCustom : undefined,
+        // Subject is no longer chosen at creation time; the column defaults to
+        // 'other' (see documents.subject in 00001_initial_schema.sql).
+        subject: 'other',
         canvas_type: canvasType,
         folder_id: courseId ? null : folderId,
         course_id: courseId,
@@ -82,8 +74,6 @@ export function CreateDocumentDialog({
 
   function resetForm() {
     setTitle('Untitled');
-    setSubject('calculus');
-    setSubjectCustom('');
     setCanvasType('blank');
     setError(null);
   }
@@ -102,7 +92,7 @@ export function CreateDocumentDialog({
           <DialogHeader>
             <DialogTitle>Create New Document</DialogTitle>
             <DialogDescription>
-              Set up your new document with a title, subject, and canvas type.
+              Set up your new document with a title and canvas type.
             </DialogDescription>
           </DialogHeader>
 
@@ -116,34 +106,6 @@ export function CreateDocumentDialog({
                 placeholder="Untitled"
               />
             </div>
-
-            <div className="grid gap-2">
-              <Label htmlFor="subject">Subject</Label>
-              <Select value={subject} onValueChange={setSubject}>
-                <SelectTrigger id="subject">
-                  <SelectValue placeholder="Select a subject" />
-                </SelectTrigger>
-                <SelectContent>
-                  {SUBJECTS.map((s) => (
-                    <SelectItem key={s.value} value={s.value}>
-                      {s.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-
-            {subject === 'other' && (
-              <div className="grid gap-2">
-                <Label htmlFor="subject-custom">Custom Subject</Label>
-                <Input
-                  id="subject-custom"
-                  value={subjectCustom}
-                  onChange={(e) => setSubjectCustom(e.target.value)}
-                  placeholder="Enter custom subject"
-                />
-              </div>
-            )}
 
             <div className="grid gap-2">
               <Label>Page Style</Label>

--- a/src/components/dashboard/moodle-sync-dialog.test.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.test.tsx
@@ -527,4 +527,99 @@ describe('MoodleSyncDialog', () => {
     });
     expect(previewButton).toBeDisabled();
   });
+
+  it('cancel during sync stops downloads not yet started and reports partial progress', async () => {
+    const user = userEvent.setup();
+
+    // More files than the download concurrency (4), so once we cancel before
+    // the pool pulls the rest, only the first `concurrency` ever start.
+    const CONCURRENCY = 4;
+    const files = Array.from({ length: CONCURRENCY + 4 }, (_, i) => ({
+      type: 'file' as const,
+      name: `f${i}.pdf`,
+      moodleUrl: `https://moodle.test.ac.il/file/${i}`,
+    }));
+
+    const mockScrape = vi.fn().mockResolvedValue(mockScrapedCourses);
+    const mockScrapeContent = vi.fn().mockResolvedValue({
+      sections: [
+        {
+          moodleSectionId: 'sec-1',
+          title: 'Week 1',
+          position: 0,
+          items: files,
+        },
+      ],
+    });
+
+    // Each download hangs until we release it, so we can click Cancel while the
+    // first batch is genuinely in-flight.
+    const releases: Array<() => void> = [];
+    const mockDownloadAndUpload = vi.fn(
+      () => new Promise<void>((resolve) => releases.push(resolve)),
+    );
+
+    mockUseMoodleExtension.mockReturnValue(
+      makeExtensionMock({
+        scrapeCourses: mockScrape,
+        scrapeCourseContent: mockScrapeContent,
+        downloadAndUpload: mockDownloadAndUpload,
+      }),
+    );
+    mockCompare.mockResolvedValue(mockComparisons);
+    mockSync.mockResolvedValue({
+      syncedCount: 1,
+      courses: [
+        {
+          moodleCourseId: 'CS101',
+          sections: [
+            {
+              id: 'section-db-1',
+              moodleSectionId: 'sec-1',
+              items: files.map((f) => ({ moodleUrl: f.moodleUrl })),
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <MoodleSyncDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        moodleConnection={mockConnection}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Intro to CS')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /preview content/i }));
+    await waitFor(() => {
+      expect(screen.getByText('f0.pdf')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /sync selected/i }));
+
+    // Pool launches exactly `concurrency` workers and then waits on the
+    // hanging downloads.
+    await waitFor(() => {
+      expect(mockDownloadAndUpload).toHaveBeenCalledTimes(CONCURRENCY);
+    });
+
+    // Cancel while that first batch is in-flight.
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    // Release the in-flight downloads; the workers should then see the cancel
+    // flag and NOT pull the remaining queued jobs.
+    releases.forEach((resolve) => resolve());
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/downloaded before stopping/i),
+      ).toBeInTheDocument();
+    });
+
+    // Still `concurrency` — the queued files never started.
+    expect(mockDownloadAndUpload).toHaveBeenCalledTimes(CONCURRENCY);
+  });
 });

--- a/src/components/dashboard/moodle-sync-dialog.test.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.test.tsx
@@ -622,4 +622,86 @@ describe('MoodleSyncDialog', () => {
     // Still `concurrency` — the queued files never started.
     expect(mockDownloadAndUpload).toHaveBeenCalledTimes(CONCURRENCY);
   });
+
+  it('does not close on Escape while a sync is in progress', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+
+    const files = [
+      {
+        type: 'file' as const,
+        name: 'a.pdf',
+        moodleUrl: 'https://moodle.test.ac.il/file/a',
+      },
+    ];
+    const mockScrape = vi.fn().mockResolvedValue(mockScrapedCourses);
+    const mockScrapeContent = vi.fn().mockResolvedValue({
+      sections: [
+        {
+          moodleSectionId: 'sec-1',
+          title: 'Week 1',
+          position: 0,
+          items: files,
+        },
+      ],
+    });
+    // Download hangs so the dialog stays in the 'syncing' phase.
+    const mockDownloadAndUpload = vi.fn(() => new Promise<void>(() => {}));
+
+    mockUseMoodleExtension.mockReturnValue(
+      makeExtensionMock({
+        scrapeCourses: mockScrape,
+        scrapeCourseContent: mockScrapeContent,
+        downloadAndUpload: mockDownloadAndUpload,
+      }),
+    );
+    mockCompare.mockResolvedValue(mockComparisons);
+    mockSync.mockResolvedValue({
+      syncedCount: 1,
+      courses: [
+        {
+          moodleCourseId: 'CS101',
+          sections: [
+            {
+              id: 'section-db-1',
+              moodleSectionId: 'sec-1',
+              items: [{ moodleUrl: 'https://moodle.test.ac.il/file/a' }],
+            },
+          ],
+        },
+      ],
+    });
+
+    render(
+      <MoodleSyncDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        moodleConnection={mockConnection}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Intro to CS')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /preview content/i }));
+    await waitFor(() => {
+      expect(screen.getByText('a.pdf')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /sync selected/i }));
+
+    // In the syncing phase: the Cancel button is the signal we're mid-sync.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /^cancel$/i }),
+      ).toBeInTheDocument();
+    });
+
+    // Escape must NOT dismiss the dialog mid-sync.
+    await user.keyboard('{Escape}');
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(
+      screen.getByRole('button', { name: /^cancel$/i }),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -635,23 +635,8 @@ export function MoodleSyncDialog({
   }> {
     let downloaded = 0;
     let failed = 0;
-    let totalBytes = 0;
     const errors: string[] = [];
     const newFailed: typeof jobs = [];
-
-    // Lightweight timing so a manual run shows real download speed in the
-    // browser console (e.g. "[Typenote sync] 37 files in 9.4s"). Logged with
-    // console.info — harmless in prod, easy to spot when verifying the fix.
-    // We log each file's size + throughput so a slow file is obviously "big
-    // bytes" vs "overhead" at a glance.
-    const batchStart =
-      typeof performance !== 'undefined' ? performance.now() : Date.now();
-    const now = () =>
-      typeof performance !== 'undefined' ? performance.now() : Date.now();
-    const fmtSize = (bytes: number) =>
-      bytes >= 1_000_000
-        ? `${(bytes / 1_000_000).toFixed(1)}MB`
-        : `${Math.round(bytes / 1000)}KB`;
 
     // Download a few files at once instead of one-by-one. Each worker handles
     // its own failure so a single bad file never rejects the whole pool, and
@@ -659,9 +644,8 @@ export function MoodleSyncDialog({
     await runWithConcurrency(
       jobs,
       async (job) => {
-        const fileStart = now();
         try {
-          const res = await downloadAndUpload({
+          await downloadAndUpload({
             moodleFileUrl: job.moodleUrl,
             uploadEndpoint,
             authToken,
@@ -672,19 +656,6 @@ export function MoodleSyncDialog({
             },
           });
           downloaded++;
-          const ms = Math.round(now() - fileStart);
-          const bytes = res?.fileSize ?? 0;
-          totalBytes += bytes;
-          const mbps =
-            bytes > 0 && ms > 0
-              ? ((bytes * 8) / 1e6 / (ms / 1000)).toFixed(1)
-              : '?';
-          console.info(
-            `[Typenote sync] ✓ ${job.fileName} in ${ms}ms` +
-              (bytes > 0
-                ? ` (${fmtSize(bytes)}, ${mbps} Mbps${res?.deduplicated ? ', dedup' : ''})`
-                : ''),
-          );
         } catch (dlErr) {
           failed++;
           if (errors.length < 3) {
@@ -693,9 +664,6 @@ export function MoodleSyncDialog({
             );
           }
           newFailed.push(job);
-          console.info(
-            `[Typenote sync] ✗ ${job.fileName} in ${Math.round(now() - fileStart)}ms — ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
-          );
         }
         setProgress(
           `Downloading files... (${downloaded + failed}/${jobs.length})`,
@@ -705,25 +673,6 @@ export function MoodleSyncDialog({
         concurrency: DOWNLOAD_CONCURRENCY,
         shouldCancel: () => pollCancelRef.current,
       },
-    );
-
-    const elapsedMs = now() - batchStart;
-    const totalSec = (elapsedMs / 1000).toFixed(1);
-    const attempted = downloaded + failed;
-    const aggMbps =
-      totalBytes > 0 && elapsedMs > 0
-        ? ((totalBytes * 8) / 1e6 / (elapsedMs / 1000)).toFixed(1)
-        : '?';
-    console.info(
-      `[Typenote sync] done: ${downloaded} downloaded, ${failed} failed ` +
-        `(${attempted}/${jobs.length} attempted) in ${totalSec}s at ` +
-        `concurrency ${DOWNLOAD_CONCURRENCY}` +
-        (attempted > 0
-          ? ` — avg ${Math.round(elapsedMs / attempted)}ms/file`
-          : '') +
-        (totalBytes > 0
-          ? `, ${fmtSize(totalBytes)} total @ ${aggMbps} Mbps`
-          : ''),
     );
 
     return {

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -931,6 +931,16 @@ export function MoodleSyncDialog({
   const selectedItemCount =
     phase === 'select-content' ? getSelectedItemCount() : 0;
 
+  // Phases where work is actively running. While busy we block accidental
+  // dismissal (clicking the backdrop or pressing Esc) so a stray click can't
+  // silently cancel an in-progress sync/scan. The explicit Cancel button and
+  // the X still close it — this only stops *accidental* dismissal.
+  const isBusy =
+    phase === 'scraping' ||
+    phase === 'comparing' ||
+    phase === 'scraping-content' ||
+    phase === 'syncing';
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
@@ -940,6 +950,12 @@ export function MoodleSyncDialog({
           display: 'flex',
           flexDirection: 'column',
           overflow: 'hidden',
+        }}
+        onInteractOutside={(e) => {
+          if (isBusy) e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (isBusy) e.preventDefault();
         }}
       >
         <DialogHeader style={{ flexShrink: 0 }}>

--- a/src/components/dashboard/moodle-sync-dialog.tsx
+++ b/src/components/dashboard/moodle-sync-dialog.tsx
@@ -20,6 +20,7 @@ import {
   syncMoodleCourses,
   getExistingFileUrls,
 } from '@/lib/actions/moodle-sync';
+import { runWithConcurrency } from '@/lib/concurrency';
 import type {
   CourseComparison,
   CourseComparisonStatus,
@@ -123,6 +124,17 @@ function friendlyFileLabel(mimeType: string | undefined): string {
     return 'PPTX';
   return 'file';
 }
+
+// How many Moodle files to process at once. The extension resolves+downloads
+// each file via a credentialed fetch (no browser window anymore), so several in
+// parallel is a big speedup over the old one-at-a-time loop. Kept at 4 on
+// purpose: each file's upload-finalize runs AI indexing (per-chunk embedding
+// calls) synchronously server-side, so a higher fan-out just overloads the
+// embedding API (observed: multi-minute finalizes + "fetch failed") without
+// downloading any faster. Raise this only once indexing moves off the
+// finalize path. The worker pool re-checks cancellation before each new file,
+// so Cancel / closing the dialog still stops promptly.
+const DOWNLOAD_CONCURRENCY = 4;
 
 export function MoodleSyncDialog({
   open,
@@ -340,6 +352,9 @@ export function MoodleSyncDialog({
 
   // ---- Phase 1: Load courses ----
   const loadCourses = useCallback(async () => {
+    // Fresh run — clear any stale cancel flag left by a previous close, so the
+    // scrape/permission path can't inherit a `true` from an earlier session.
+    pollCancelRef.current = false;
     setError(null);
     setAuthError(false);
     setNetworkError(false);
@@ -506,6 +521,8 @@ export function MoodleSyncDialog({
   // ---- Phase 2: Scrape content and show picker ----
   async function handlePreviewContent() {
     setPhase('scraping-content');
+    // Fresh run — clear any stale cancel flag left by a previous close.
+    pollCancelRef.current = false;
     setError(null);
 
     try {
@@ -515,6 +532,12 @@ export function MoodleSyncDialog({
       const results: CourseWithContent[] = [];
 
       for (let i = 0; i < selected.length; i++) {
+        // Scanning a course opens a Moodle window per course; bail out
+        // immediately if the user cancelled instead of grinding through them.
+        if (pollCancelRef.current) {
+          setPhase('select-courses');
+          return;
+        }
         const course = selected[i];
         setProgress(
           `Scanning "${course.name}" (${i + 1}/${selected.length})...`,
@@ -608,43 +631,114 @@ export function MoodleSyncDialog({
     failed: number;
     failedJobs: typeof jobs;
     errors: string[];
+    cancelled: boolean;
   }> {
     let downloaded = 0;
     let failed = 0;
+    let totalBytes = 0;
     const errors: string[] = [];
     const newFailed: typeof jobs = [];
 
-    for (const job of jobs) {
-      try {
-        await downloadAndUpload({
-          moodleFileUrl: job.moodleUrl,
-          uploadEndpoint,
-          authToken,
-          metadata: {
-            sectionId: job.sectionId,
-            moodleUrl: job.moodleUrl,
-            fileName: job.fileName,
-          },
-        });
-        downloaded++;
-      } catch (dlErr) {
-        failed++;
-        if (errors.length < 3) {
-          errors.push(
-            `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
+    // Lightweight timing so a manual run shows real download speed in the
+    // browser console (e.g. "[Typenote sync] 37 files in 9.4s"). Logged with
+    // console.info — harmless in prod, easy to spot when verifying the fix.
+    // We log each file's size + throughput so a slow file is obviously "big
+    // bytes" vs "overhead" at a glance.
+    const batchStart =
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const now = () =>
+      typeof performance !== 'undefined' ? performance.now() : Date.now();
+    const fmtSize = (bytes: number) =>
+      bytes >= 1_000_000
+        ? `${(bytes / 1_000_000).toFixed(1)}MB`
+        : `${Math.round(bytes / 1000)}KB`;
+
+    // Download a few files at once instead of one-by-one. Each worker handles
+    // its own failure so a single bad file never rejects the whole pool, and
+    // the pool stops pulling new files the moment pollCancelRef flips.
+    await runWithConcurrency(
+      jobs,
+      async (job) => {
+        const fileStart = now();
+        try {
+          const res = await downloadAndUpload({
+            moodleFileUrl: job.moodleUrl,
+            uploadEndpoint,
+            authToken,
+            metadata: {
+              sectionId: job.sectionId,
+              moodleUrl: job.moodleUrl,
+              fileName: job.fileName,
+            },
+          });
+          downloaded++;
+          const ms = Math.round(now() - fileStart);
+          const bytes = res?.fileSize ?? 0;
+          totalBytes += bytes;
+          const mbps =
+            bytes > 0 && ms > 0
+              ? ((bytes * 8) / 1e6 / (ms / 1000)).toFixed(1)
+              : '?';
+          console.info(
+            `[Typenote sync] ✓ ${job.fileName} in ${ms}ms` +
+              (bytes > 0
+                ? ` (${fmtSize(bytes)}, ${mbps} Mbps${res?.deduplicated ? ', dedup' : ''})`
+                : ''),
+          );
+        } catch (dlErr) {
+          failed++;
+          if (errors.length < 3) {
+            errors.push(
+              `${job.fileName}: ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
+            );
+          }
+          newFailed.push(job);
+          console.info(
+            `[Typenote sync] ✗ ${job.fileName} in ${Math.round(now() - fileStart)}ms — ${dlErr instanceof Error ? dlErr.message : String(dlErr)}`,
           );
         }
-        newFailed.push(job);
-      }
-      setProgress(
-        `Downloading files... (${downloaded + failed}/${jobs.length})`,
-      );
-    }
-    return { downloaded, failed, failedJobs: newFailed, errors };
+        setProgress(
+          `Downloading files... (${downloaded + failed}/${jobs.length})`,
+        );
+      },
+      {
+        concurrency: DOWNLOAD_CONCURRENCY,
+        shouldCancel: () => pollCancelRef.current,
+      },
+    );
+
+    const elapsedMs = now() - batchStart;
+    const totalSec = (elapsedMs / 1000).toFixed(1);
+    const attempted = downloaded + failed;
+    const aggMbps =
+      totalBytes > 0 && elapsedMs > 0
+        ? ((totalBytes * 8) / 1e6 / (elapsedMs / 1000)).toFixed(1)
+        : '?';
+    console.info(
+      `[Typenote sync] done: ${downloaded} downloaded, ${failed} failed ` +
+        `(${attempted}/${jobs.length} attempted) in ${totalSec}s at ` +
+        `concurrency ${DOWNLOAD_CONCURRENCY}` +
+        (attempted > 0
+          ? ` — avg ${Math.round(elapsedMs / attempted)}ms/file`
+          : '') +
+        (totalBytes > 0
+          ? `, ${fmtSize(totalBytes)} total @ ${aggMbps} Mbps`
+          : ''),
+    );
+
+    return {
+      downloaded,
+      failed,
+      failedJobs: newFailed,
+      errors,
+      cancelled: pollCancelRef.current,
+    };
   }
 
   async function handleSync() {
     setPhase('syncing');
+    // Fresh run — clear any stale cancel flag left by a previous close.
+    pollCancelRef.current = false;
     setError(null);
     setFailedJobs([]);
     setProgress('Saving to registry...');
@@ -720,6 +814,7 @@ export function MoodleSyncDialog({
       setTotalFileJobs(fileJobs.length);
       let downloaded = 0;
       let failed = 0;
+      let cancelled = false;
       const errors: string[] = [];
       if (fileJobs.length > 0) {
         const {
@@ -736,6 +831,7 @@ export function MoodleSyncDialog({
         );
         downloaded = dlResult.downloaded;
         failed = dlResult.failed;
+        cancelled = dlResult.cancelled;
         errors.push(...dlResult.errors);
         setFailedJobs(dlResult.failedJobs);
       }
@@ -743,7 +839,11 @@ export function MoodleSyncDialog({
       setSyncedCount(result.syncedCount);
       setDownloadedCount(downloaded);
       setFailedCount(failed);
-      if (errors.length > 0) {
+      if (cancelled) {
+        setError(
+          `Sync cancelled — ${downloaded} file(s) downloaded before stopping.`,
+        );
+      } else if (errors.length > 0) {
         setError(`${failed} file(s) failed:\n${errors.join('\n')}`);
       }
       setPhase('done');
@@ -761,6 +861,14 @@ export function MoodleSyncDialog({
     pollCancelRef.current = true;
   }
 
+  // Stop an in-progress scan or download run. The worker pool / scan loop
+  // re-checks pollCancelRef before each item, so this halts new work without
+  // closing the dialog (closing also cancels, via the open-change effect).
+  function cancelSync() {
+    pollCancelRef.current = true;
+    setProgress('Cancelling…');
+  }
+
   async function handleRetryLogin() {
     // User has (presumably) just logged into Moodle in another tab.
     // Re-run the full handshake from the top.
@@ -770,27 +878,49 @@ export function MoodleSyncDialog({
   async function handleRetryFailed() {
     if (failedJobs.length === 0) return;
     setPhase('syncing');
+    // Fresh run — clear any stale cancel flag left by a previous close.
+    pollCancelRef.current = false;
     setError(null);
     setProgress(`Retrying ${failedJobs.length} failed file(s)...`);
 
-    const {
-      data: { session },
-    } = await supabaseRef.current.auth.getSession();
-    const authToken = session?.access_token;
-    const uploadEndpoint = `${window.location.origin}/api/moodle/upload`;
+    // Wrapped so a throw before/around the download run (e.g. getSession
+    // failing) lands on the error phase instead of wedging on 'syncing' —
+    // whose only footer button is a now-useless Cancel.
+    try {
+      const {
+        data: { session },
+      } = await supabaseRef.current.auth.getSession();
+      const authToken = session?.access_token;
+      const uploadEndpoint = `${window.location.origin}/api/moodle/upload`;
 
-    const result = await runDownloadJobs(failedJobs, authToken, uploadEndpoint);
-    setDownloadedCount((prev) => prev + result.downloaded);
-    setFailedCount(result.failed);
-    setFailedJobs(result.failedJobs);
-    if (result.errors.length > 0) {
-      setError(
-        `${result.failed} file(s) still failed:\n${result.errors.join('\n')}`,
+      const result = await runDownloadJobs(
+        failedJobs,
+        authToken,
+        uploadEndpoint,
       );
-    } else {
-      setError(null);
+      setDownloadedCount((prev) => prev + result.downloaded);
+      setFailedCount(result.failed);
+      setFailedJobs(result.failedJobs);
+      if (result.cancelled) {
+        setError(
+          `Cancelled — ${result.downloaded} of ${failedJobs.length} retried before stopping.`,
+        );
+      } else if (result.errors.length > 0) {
+        setError(
+          `${result.failed} file(s) still failed:\n${result.errors.join('\n')}`,
+        );
+      } else {
+        setError(null);
+      }
+      setPhase('done');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Retry failed';
+      setError(message);
+      setAuthError(isAuthError(message));
+      setNetworkError(isNetworkError(message) && !isAuthError(message));
+      setPermissionError(isPermissionError(message) && !isAuthError(message));
+      setPhase('error');
     }
-    setPhase('done');
   }
 
   // ---- Render ----
@@ -1235,6 +1365,11 @@ export function MoodleSyncDialog({
           {phase === 'error' && (
             <Button variant="outline" onClick={loadCourses}>
               Retry
+            </Button>
+          )}
+          {(phase === 'syncing' || phase === 'scraping-content') && (
+            <Button variant="outline" onClick={cancelSync}>
+              Cancel
             </Button>
           )}
           {phase === 'awaiting-permission' && (

--- a/src/components/dashboard/sidebar-folder-tree.tsx
+++ b/src/components/dashboard/sidebar-folder-tree.tsx
@@ -127,6 +127,7 @@ function CourseNode({ course, level }: CourseNodeProps) {
 export function SidebarFolderTree() {
   const [folders, setFolders] = useState<FolderType[]>([]);
   const [courses, setCourses] = useState<Course[]>([]);
+  const [sharedCourses, setSharedCourses] = useState<Course[]>([]);
   const [loading, setLoading] = useState(true);
   const pathname = usePathname();
 
@@ -142,11 +143,13 @@ export function SidebarFolderTree() {
         setFolders(data as FolderType[]);
       }
 
-      // Scope to OWN courses: the course-sharing member-SELECT RLS policy would
-      // otherwise surface courses shared with the user in the owner sidebar.
       const {
         data: { user },
       } = await supabase.auth.getUser();
+
+      // Owned courses. Scope explicitly to user_id: the course-sharing
+      // member-SELECT RLS policy would otherwise mix shared courses into this
+      // query — we list those separately under "Shared with me" below.
       const { data: courseData } = await supabase
         .from('courses')
         .select('*')
@@ -156,6 +159,27 @@ export function SidebarFolderTree() {
       if (courseData) {
         setCourses(courseData as Course[]);
       }
+
+      // Courses shared with this user via course_members (e.g. a synced Moodle
+      // course another user shared). RLS lets a member read their own
+      // membership rows and the joined course. We query course_members directly
+      // (not getSharedWithMe, which needs the server-only admin client) since
+      // the sidebar only needs the course itself, not owner display names.
+      const { data: memberRows } = await supabase
+        .from('course_members')
+        .select(
+          'courses(id, user_id, folder_id, name, color, position, created_at, updated_at)',
+        )
+        .eq('user_id', user?.id ?? '');
+
+      if (memberRows) {
+        const shared = (memberRows as { courses: Course | Course[] | null }[])
+          .map((r) => (Array.isArray(r.courses) ? r.courses[0] : r.courses))
+          .filter((c): c is Course => c !== null)
+          .sort((a, b) => a.position - b.position);
+        setSharedCourses(shared);
+      }
+
       setLoading(false);
     }
 
@@ -175,7 +199,11 @@ export function SidebarFolderTree() {
     );
   }
 
-  if (rootFolders.length === 0 && rootCourses.length === 0) {
+  if (
+    rootFolders.length === 0 &&
+    rootCourses.length === 0 &&
+    sharedCourses.length === 0
+  ) {
     return (
       <p className="px-2 py-4 text-center text-sm text-muted-foreground">
         No courses or folders yet
@@ -197,6 +225,16 @@ export function SidebarFolderTree() {
           level={0}
         />
       ))}
+      {sharedCourses.length > 0 && (
+        <div className="pt-2">
+          <p className="px-2 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Shared with me
+          </p>
+          {sharedCourses.map((course) => (
+            <CourseNode key={course.id} course={course} level={0} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/dashboard/sidebar-layout.tsx
+++ b/src/components/dashboard/sidebar-layout.tsx
@@ -196,6 +196,7 @@ export function SidebarLayout({ sidebar, children }: SidebarLayoutProps) {
         {/* Desktop: inline sidebar */}
         {!isMobile && (
           <aside
+            data-testid="dashboard-sidebar"
             className={`flex shrink-0 flex-col border-r border-border/30 bg-sidebar transition-[width] duration-200 overflow-hidden ${
               isOpen ? 'w-[250px]' : 'w-0 border-r-0'
             }`}

--- a/src/lib/ai/__tests__/prompts.test.ts
+++ b/src/lib/ai/__tests__/prompts.test.ts
@@ -45,6 +45,17 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('smart AI');
   });
 
+  it('puts a prominent, highest-priority language directive near the top', () => {
+    const prompt = buildSystemPrompt({ hasDocumentContent: false });
+    expect(prompt).toContain('LANGUAGE (HIGHEST PRIORITY)');
+    expect(prompt).toMatch(/same language/i);
+    // The language rule must come before the materials guidance so the model
+    // anchors on it first.
+    expect(prompt.indexOf('LANGUAGE (HIGHEST PRIORITY)')).toBeLessThan(
+      prompt.indexOf('HOW TO USE COURSE MATERIALS'),
+    );
+  });
+
   it('cites materials with name-colon format', () => {
     const prompt = buildSystemPrompt({ hasDocumentContent: false });
     expect(prompt).toContain(

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -24,6 +24,10 @@ The student attached these files as the primary context for this note: ${context
 
   return `${courseContext} You are a knowledgeable, friendly tutor and study partner. You have deep expertise in the subject matter AND access to the student's course materials.
 
+## LANGUAGE (HIGHEST PRIORITY)
+
+**Always reply in the SAME language the student wrote their question in.** Detect the language of the student's latest message and answer entirely in that language — even when the course materials, attached files, or your sources are in a different language. Never switch to the materials' language. (e.g., a question in Hebrew gets a Hebrew answer; a question in English gets an English answer.)
+
 ## HOW TO USE COURSE MATERIALS
 
 - **Course materials are your primary source.** When they contain relevant information, ground your answers in them and cite them.

--- a/src/lib/concurrency.test.ts
+++ b/src/lib/concurrency.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { runWithConcurrency } from './concurrency';
+
+describe('runWithConcurrency', () => {
+  it('runs every item and returns results in input order', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const results = await runWithConcurrency(
+      items,
+      async (n) => {
+        // Stagger completion so out-of-order resolution would be observable.
+        await new Promise((r) => setTimeout(r, (5 - n) * 2));
+        return n * 10;
+      },
+      { concurrency: 3 },
+    );
+    expect(results).toEqual([10, 20, 30, 40, 50]);
+  });
+
+  it('never exceeds the configured concurrency', async () => {
+    let active = 0;
+    let maxActive = 0;
+    const items = Array.from({ length: 12 }, (_, i) => i);
+
+    await runWithConcurrency(
+      items,
+      async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await new Promise((r) => setTimeout(r, 3));
+        active -= 1;
+      },
+      { concurrency: 4 },
+    );
+
+    expect(maxActive).toBeLessThanOrEqual(4);
+    expect(maxActive).toBeGreaterThan(1); // proves it actually parallelised
+  });
+
+  it('stops pulling new items once shouldCancel returns true', async () => {
+    let cancel = false;
+    const started: number[] = [];
+    const items = Array.from({ length: 20 }, (_, i) => i);
+
+    const results = await runWithConcurrency(
+      items,
+      async (n) => {
+        started.push(n);
+        // Cancel as soon as the second item begins.
+        if (n === 1) cancel = true;
+        await new Promise((r) => setTimeout(r, 1));
+        return n;
+      },
+      { concurrency: 2, shouldCancel: () => cancel },
+    );
+
+    // With concurrency 2, only the first two items get pulled before both
+    // workers observe the cancel flag and bail.
+    expect(started).toEqual([0, 1]);
+    expect(results[0]).toBe(0);
+    expect(results[1]).toBe(1);
+    expect(results[2]).toBeUndefined();
+  });
+
+  it('does not start anything when cancelled up front', async () => {
+    const started: number[] = [];
+    const results = await runWithConcurrency(
+      [1, 2, 3],
+      async (n) => {
+        started.push(n);
+        return n;
+      },
+      { concurrency: 2, shouldCancel: () => true },
+    );
+    expect(started).toEqual([]);
+    expect(results).toEqual([undefined, undefined, undefined]);
+  });
+
+  it('handles an empty input list', async () => {
+    const results = await runWithConcurrency([], async () => 1, {
+      concurrency: 3,
+    });
+    expect(results).toEqual([]);
+  });
+
+  it('isolates per-item errors handled inside the worker', async () => {
+    const items = [1, 2, 3, 4];
+    const outcomes = await runWithConcurrency(
+      items,
+      async (n) => {
+        try {
+          if (n % 2 === 0) throw new Error(`boom ${n}`);
+          return `ok ${n}`;
+        } catch (err) {
+          return `failed ${(err as Error).message}`;
+        }
+      },
+      { concurrency: 2 },
+    );
+    expect(outcomes).toEqual([
+      'ok 1',
+      'failed boom 2',
+      'ok 3',
+      'failed boom 4',
+    ]);
+  });
+});

--- a/src/lib/concurrency.ts
+++ b/src/lib/concurrency.ts
@@ -1,0 +1,49 @@
+/**
+ * Runs an async `worker` over `items` with a bounded number of concurrent
+ * in-flight calls, optionally stopping early when `shouldCancel` returns true.
+ *
+ * Why this exists: Moodle file downloads used to run strictly one-at-a-time,
+ * which (combined with the old per-file popup) made a full-course sync crawl.
+ * Running a few at a time is dramatically faster, but we still need to stop
+ * promptly when the user cancels — a naive `Promise.all(items.map(...))` would
+ * fire every request at once and ignore cancellation. This is the smallest
+ * primitive that gives us both: a fixed-size worker pool that re-checks
+ * `shouldCancel` before pulling each new item.
+ *
+ * Results are returned in the SAME order as `items`. Items that were never
+ * started (because the run was cancelled first) are left `undefined`.
+ *
+ * Errors are NOT caught here — the caller's `worker` is expected to handle its
+ * own failures so one bad item doesn't reject the whole pool.
+ */
+export interface RunWithConcurrencyOptions {
+  /** Maximum number of workers running at once (clamped to >= 1). */
+  concurrency: number;
+  /** Polled before each item is pulled; return true to stop starting new work. */
+  shouldCancel?: () => boolean;
+}
+
+export async function runWithConcurrency<T, R>(
+  items: readonly T[],
+  worker: (item: T, index: number) => Promise<R>,
+  { concurrency, shouldCancel }: RunWithConcurrencyOptions,
+): Promise<Array<R | undefined>> {
+  const results: Array<R | undefined> = new Array(items.length);
+  // Shared cursor: JS is single-threaded, so the read-then-increment between
+  // awaits is atomic — no two workers ever grab the same index.
+  let cursor = 0;
+  const poolSize = Math.max(1, Math.min(concurrency, items.length || 1));
+
+  async function runWorker(): Promise<void> {
+    while (true) {
+      if (shouldCancel?.()) return;
+      const index = cursor;
+      cursor += 1;
+      if (index >= items.length) return;
+      results[index] = await worker(items[index], index);
+    }
+  }
+
+  await Promise.all(Array.from({ length: poolSize }, () => runWorker()));
+  return results;
+}

--- a/src/lib/moodle/storage-path.test.ts
+++ b/src/lib/moodle/storage-path.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { safeStorageExtension, buildStorageFileName } from './storage-path';
+
+describe('safeStorageExtension', () => {
+  it('returns a clean lowercase extension for a real filename', () => {
+    expect(safeStorageExtension('lecture.PDF')).toBe('pdf');
+    expect(safeStorageExtension('notes.docx')).toBe('docx');
+    expect(safeStorageExtension('slides.pptx')).toBe('pptx');
+  });
+
+  it('returns "" when there is no dot', () => {
+    expect(safeStorageExtension('lecture notes')).toBe('');
+  });
+
+  it('rejects a date/title tail that is not a real extension (the InvalidKey bug)', () => {
+    // The exact shape that broke Supabase Storage with InvalidKey.
+    expect(safeStorageExtension('2025.12.24 - שיעור תשיעי (CML ו-SML)')).toBe(
+      '',
+    );
+  });
+
+  it('rejects tails with spaces, parens, or unicode', () => {
+    expect(safeStorageExtension('report.final version')).toBe('');
+    expect(safeStorageExtension('a.(copy)')).toBe('');
+    expect(safeStorageExtension('סיכום.שיעור')).toBe('');
+  });
+
+  it('rejects an overly long tail (not a plausible extension)', () => {
+    expect(safeStorageExtension('archive.superlongword')).toBe('');
+  });
+
+  it('handles a trailing dot', () => {
+    expect(safeStorageExtension('weird.')).toBe('');
+  });
+});
+
+describe('buildStorageFileName', () => {
+  const HASH = 'a'.repeat(64);
+
+  it('appends a clean extension', () => {
+    expect(buildStorageFileName(HASH, 'lecture.pdf')).toBe(`${HASH}.pdf`);
+  });
+
+  it('falls back to the bare hash for a title-as-name (no valid ext)', () => {
+    const key = buildStorageFileName(
+      HASH,
+      '2025.12.24 - שיעור תשיעי (CML ו-SML)',
+    );
+    expect(key).toBe(HASH);
+    // The key must be a valid storage key: no spaces, parens, or unicode.
+    expect(/^[a-zA-Z0-9.]+$/.test(key)).toBe(true);
+  });
+
+  it('uses the bare hash when there is no extension at all', () => {
+    expect(buildStorageFileName(HASH, 'lecture notes')).toBe(HASH);
+  });
+});

--- a/src/lib/moodle/storage-path.ts
+++ b/src/lib/moodle/storage-path.ts
@@ -1,0 +1,36 @@
+/**
+ * Storage-key helpers for Moodle file uploads.
+ *
+ * Files are stored under a content-hash key, so the extension appended after
+ * the hash is purely cosmetic — the real MIME type lives in
+ * `moodle_files.mime_type`. The danger is that the "filename" we receive is
+ * often the Moodle *activity title* (e.g. "2025.12.24 - שיעור (CML ו-SML)"),
+ * not a real filename. Naively taking everything after the last dot as the
+ * extension produces keys with spaces / parens / unicode, which Supabase
+ * Storage rejects with `InvalidKey`.
+ */
+
+/**
+ * Returns a safe, lowercase storage extension for a display name, or '' when
+ * the name has no usable extension. Only a short alphanumeric tail (1–8 chars)
+ * counts — anything else (spaces, punctuation, unicode, a date fragment) is
+ * treated as "no extension" so it never leaks into the storage key.
+ */
+export function safeStorageExtension(fileName: string): string {
+  if (!fileName.includes('.')) return '';
+  const tail = fileName.split('.').pop() ?? '';
+  return /^[a-zA-Z0-9]{1,8}$/.test(tail) ? tail.toLowerCase() : '';
+}
+
+/**
+ * Builds the content-hash storage key for a Moodle file. The extension is
+ * appended only when `safeStorageExtension` yields a clean one; otherwise the
+ * bare hash is used (still a valid, unique key).
+ */
+export function buildStorageFileName(
+  contentHash: string,
+  fileName: string,
+): string {
+  const ext = safeStorageExtension(fileName);
+  return ext ? `${contentHash}.${ext}` : contentHash;
+}

--- a/src/lib/server/after-response.ts
+++ b/src/lib/server/after-response.ts
@@ -1,0 +1,25 @@
+import { after } from 'next/server';
+
+/**
+ * Runs `work` AFTER the HTTP response has been sent, without blocking it.
+ *
+ * Why this exists: AI indexing (embedding every chunk of a file) takes tens of
+ * seconds and was being `await`ed inside the Moodle sync routes, so the user's
+ * sync hung on it — even for files already stored/deduped. Embedding only needs
+ * to happen ONCE per file and nobody is waiting on its result, so it belongs
+ * after the response.
+ *
+ * We use Next's `after()` rather than a bare detached promise because on
+ * serverless (Vercel) the function can freeze the moment it responds, dropping
+ * any in-flight detached promise. `after()` keeps the runtime alive until the
+ * work finishes. If `after()` isn't usable in the current context (e.g. a unit
+ * test with no request scope) we fall back to a best-effort detached run.
+ */
+export function scheduleAfterResponse(work: () => Promise<void>): void {
+  try {
+    after(work);
+  } catch {
+    // No request scope available — best-effort detached execution.
+    void work().catch(() => {});
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,19 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
     css: false,
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
-    exclude: ['node_modules', 'e2e', 'src/**/*.integration.test.ts'],
+    include: [
+      'src/**/*.{test,spec}.{ts,tsx}',
+      // Pure extension helpers (no chrome/DOM globals at import) run under the
+      // same jsdom runner — keeps them in the single `pnpm test` CI step.
+      'extension/src/**/*.{test,spec}.ts',
+    ],
+    exclude: [
+      'node_modules',
+      'e2e',
+      'src/**/*.integration.test.ts',
+      'extension/node_modules',
+      'extension/dist',
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Originally a Moodle-sync speed/cancel fix; grew to include a few small dashboard + AI fixes requested alongside it.

### Moodle sync (the core fix)
- **Parallel downloads + working cancel.** Replaced the per-file popup/tab-per-download mechanism (which made full-course sync take hours) with a bounded-concurrency worker pool. Cancel (X) now actually stops in-flight work via a ref-checked cancel flag.
- **Claim-from-registry.** A second user syncing the same course claims already-stored files from the shared registry (storage_path + content_hash) instead of re-downloading from Moodle.
- **Embed once, in the background.** AI indexing (embedding, ~tens of seconds/file) was `await`ed inline in the sync routes, so even *deduped* files stalled ~60s each. Moved to Next `after()` so it never blocks the response, and skipped entirely when an embedding at the current content hash already exists.
- **Safe storage keys.** Moodle activity titles (spaces, parens, unicode) were producing `InvalidKey` on Storage PUT; keys are now derived from the content hash with a sanitized/none extension.
- **No accidental dialog dismissal** on backdrop click / Esc while a sync is running.

### Dashboard
- **Shared courses now appear in the left sidebar** under a "Shared with me" group (previously only on the dashboard cards; the sidebar listed owned courses only).
- **Removed the subject picker** from the New Document dialog (the `subject` column already defaults to `'other'`).

### AI
- **Answer-language is now a top-priority prompt rule** (standalone section before the materials guidance) so the model replies in the student's language instead of drifting into the materials' language.

## Tests
- New: `src/lib/concurrency*`, `extension/src/lib/url-resolve*`, `src/lib/moodle/storage-path*`, `import-existing` route, `after-response`.
- E2E: shared course shows in member sidebar (`sharing.spec.ts`); create-document has no subject selector (`documents.spec.ts`). `TEST_REGISTRY.md` updated.
- ✅ 971 unit tests pass locally; lint + prettier clean. Full E2E runs in CI (local Supabase + seed).

## Notes
- `[Typenote sync]` `console.info` timing diagnostics are intentionally kept (browser-console only). Say the word and I'll strip them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)