### PR TITLE
fix(ai-chat): dock chat panel on the course page instead of collapsing inline

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -141,6 +141,7 @@ Covers the Phase 1 refactor that removed the "Weeks" model and replaced it with 
 - [x] Chat renders markdown in responses — ⚠️ SKIPPED IN CI (needs AI API key)
 - [x] Start new conversation — ⚠️ SKIPPED IN CI
 - [x] Switch between conversations — ⚠️ SKIPPED IN CI
+- [x] Course page: chat panel docks to the right edge, not inline in the toolbar — ⚠️ SKIPPED IN CI (needs course page)
 
 ---
 
@@ -309,7 +310,7 @@ and the per-`(source, page)` `p. N` citation in
 | Courses               | Implemented | `e2e/courses.spec.ts`                    | 5/6        |
 | Flat Course Page      | Implemented | `e2e/course-materials.spec.ts`           | 3/3        |
 | File Upload           | Implemented | `e2e/file-upload.spec.ts`                | 3/4        |
-| AI Chat               | Implemented | `e2e/ai-chat.spec.ts`                    | 6/6        |
+| AI Chat               | Implemented | `e2e/ai-chat.spec.ts`                    | 7/7        |
 | AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2        |
 | PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`               | 6/7        |
 | Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`              | 3/3        |

--- a/e2e/ai-chat.spec.ts
+++ b/e2e/ai-chat.spec.ts
@@ -132,4 +132,44 @@ test.describe('AI Chat', () => {
         .or(page.locator('ul.divide-y li').first()),
     ).toBeVisible({ timeout: 5_000 });
   });
+
+  // Regression: on the course page the chat panel is rendered inside the
+  // header button toolbar (normal document flow), not as a flex-row sibling
+  // of the main content. With the old `lg:static` layout it collapsed inline
+  // into the toolbar on desktop. With `docked={false}` it must stay a fixed
+  // drawer pinned to the right edge, full height.
+  test('course page: chat panel docks to the right edge, not inline in the toolbar', async ({
+    page,
+  }) => {
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    // Desktop width is required for the bug to manifest (lg+ breakpoint).
+    expect(viewport!.width).toBeGreaterThanOrEqual(1024);
+
+    // Open via the floating bubble (uncontrolled on the course page).
+    await page.getByRole('button', { name: /open ai chat/i }).click();
+    await expect(page.getByText('AI Tutor')).toBeVisible({ timeout: 5_000 });
+
+    // Measure the panel container (nearest fixed-position ancestor of the header).
+    const box = await page.evaluate(() => {
+      const header = Array.from(document.querySelectorAll('*')).find(
+        (el) => el.textContent?.trim() === 'AI Tutor',
+      );
+      let el: Element | null = header ?? null;
+      while (el && !String((el as HTMLElement).className).includes('fixed')) {
+        el = el.parentElement;
+      }
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { x: r.x, right: r.right, width: r.width, height: r.height };
+    });
+
+    expect(box).not.toBeNull();
+    // Pinned to the right edge…
+    expect(box!.right).toBeGreaterThanOrEqual(viewport!.width - 2);
+    // …occupying the right portion (never collapsed to the top-left toolbar)…
+    expect(box!.x).toBeGreaterThan(viewport!.width / 2);
+    // …and full-height like a drawer, not a short inline toolbar element.
+    expect(box!.height).toBeGreaterThan(viewport!.height * 0.8);
+  });
 });

--- a/src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx
@@ -164,7 +164,11 @@ export default async function CoursePage({
           </BreadcrumbList>
         </Breadcrumb>
         <div className="flex flex-wrap items-center gap-2">
-          <AiChatWrapper courseId={courseId} courseName={typedCourse.name} />
+          <AiChatWrapper
+            courseId={courseId}
+            courseName={typedCourse.name}
+            docked={false}
+          />
           <CreateDocumentDialog folderId={null} courseId={courseId}>
             <Button variant="outline" size="sm">
               New Document

--- a/src/components/ai/ai-chat-panel.test.tsx
+++ b/src/components/ai/ai-chat-panel.test.tsx
@@ -110,6 +110,34 @@ describe('AiChatPanel', () => {
   });
 
   // -----------------------------------------------------------------------
+  // 1b. Layout: docked (default) vs overlay
+  // -----------------------------------------------------------------------
+  it('uses the static side-column layout by default (docked)', () => {
+    setupDefaultFetchResponses();
+
+    const { container } = render(<AiChatPanel {...defaultProps} />);
+    const panel = container.firstElementChild as HTMLElement;
+
+    // Docked panels become a static flex column on lg+.
+    expect(panel.className).toContain('lg:static');
+    expect(panel.className).not.toContain('lg:right-0');
+  });
+
+  it('stays a fixed right-docked drawer when docked={false}', () => {
+    setupDefaultFetchResponses();
+
+    const { container } = render(
+      <AiChatPanel {...defaultProps} docked={false} />,
+    );
+    const panel = container.firstElementChild as HTMLElement;
+
+    // Overlay panels must never collapse to static flow — they dock right.
+    expect(panel.className).not.toContain('lg:static');
+    expect(panel.className).toContain('lg:right-0');
+    expect(panel.className).toContain('lg:left-auto');
+  });
+
+  // -----------------------------------------------------------------------
   // 2. Does not render when closed
   // -----------------------------------------------------------------------
   it('does not render when closed', () => {

--- a/src/components/ai/ai-chat-panel.tsx
+++ b/src/components/ai/ai-chat-panel.tsx
@@ -72,6 +72,17 @@ interface AiChatPanelProps {
   ) => void;
   focusFiles?: ResolvedContextFile[];
   onFocusFilesChanged?: () => void | Promise<void>;
+  /**
+   * Layout mode.
+   * - `true` (default): the panel is a static flex column (`lg:static`), meant
+   *   to sit as a sibling of the main content in a flex row (e.g. the document
+   *   editor). It only works when its parent is a flex container.
+   * - `false`: the panel stays `fixed` and docks to the right edge on every
+   *   breakpoint. Use this when the panel is rendered in normal document flow
+   *   (e.g. inside the course page toolbar), where `lg:static` would otherwise
+   *   collapse it inline.
+   */
+  docked?: boolean;
 }
 
 export function AiChatPanel({
@@ -87,6 +98,7 @@ export function AiChatPanel({
   onOpenSource,
   focusFiles,
   onFocusFilesChanged,
+  docked = true,
 }: AiChatPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
@@ -476,8 +488,15 @@ export function AiChatPanel({
 
   if (!isOpen) return null;
 
+  // Base: full-screen overlay on mobile/tablet.
+  // - docked: becomes a static flex column on lg+ (must sit in a flex row).
+  // - overlay: stays fixed and docks to the right edge on lg+ (works anywhere).
+  const containerClassName = docked
+    ? 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:static lg:z-auto lg:w-[480px] lg:shrink-0 xl:w-[560px] 2xl:w-[640px]'
+    : 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-[480px] xl:w-[560px] 2xl:w-[640px]';
+
   return (
-    <div className="fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:static lg:z-auto lg:w-[480px] lg:shrink-0 xl:w-[560px] 2xl:w-[640px]">
+    <div className={containerClassName}>
       {/* Header */}
       <div className="flex items-center justify-between border-b px-4 py-3">
         <div className="flex min-w-0 items-center gap-2">

--- a/src/components/ai/ai-chat-wrapper.tsx
+++ b/src/components/ai/ai-chat-wrapper.tsx
@@ -27,6 +27,12 @@ interface AiChatWrapperProps {
   /** Per-document focus files (owned by the host) + a reload callback. */
   focusFiles?: ResolvedContextFile[];
   onFocusFilesChanged?: () => void | Promise<void>;
+  /**
+   * Pass `false` when the panel is rendered in normal document flow (e.g. the
+   * course page toolbar) rather than as a flex-row sibling of the main content.
+   * Defaults to `true` (static side-column layout). See {@link AiChatPanel}.
+   */
+  docked?: boolean;
 }
 
 export function AiChatWrapper({
@@ -43,6 +49,7 @@ export function AiChatWrapper({
   onOpenSource,
   focusFiles,
   onFocusFilesChanged,
+  docked = true,
 }: AiChatWrapperProps) {
   const [internalIsOpen, setInternalIsOpen] = useState(false);
 
@@ -82,6 +89,7 @@ export function AiChatWrapper({
         onOpenSource={onOpenSource}
         focusFiles={focusFiles}
         onFocusFilesChanged={onFocusFilesChanged}
+        docked={docked}
       />
     </>
   );


### PR DESCRIPTION
## Problem
On the **course page**, opening the AI chat looked broken on desktop — the panel collapsed inline into the header button toolbar instead of opening as a side panel.

## Root cause
`AiChatPanel` is styled `lg:static lg:w-[480px] lg:shrink-0`: on `lg+` it stops being a fixed overlay and becomes a **static flex column**. That only works when it's a flex-row sibling of the main content — which is exactly how the document editor (`document-with-ai.tsx`) uses it. But the course page renders the same panel **inside the header button toolbar** (`flex flex-wrap items-center gap-2`), in normal document flow, so on desktop it laid out inline in the toolbar.

## Fix
Add a `docked` prop:
- `docked` **(default `true`)** — unchanged `lg:static` side-column behavior (document editor).
- `docked={false}` — panel stays `fixed` and pins to the right edge on every breakpoint (`lg:inset-y-0 lg:left-auto lg:right-0 lg:w-[480px]`), so it works regardless of DOM position.

The course page now passes `docked={false}`. Mobile/tablet behavior (full-screen overlay) is unchanged on both variants.

## Files
- `src/components/ai/ai-chat-panel.tsx` — `docked` prop + conditional container classes
- `src/components/ai/ai-chat-wrapper.tsx` — threads `docked` through
- `src/app/(dashboard)/dashboard/courses/[courseId]/page.tsx` — passes `docked={false}`

## Tests
- **Unit** (`ai-chat-panel.test.tsx`): asserts docked vs. overlay container classes — 11/11 pass.
- **E2E** (`ai-chat.spec.ts`): course-page chat panel docks to the right edge, full-height, not collapsed into the toolbar (measured at desktop viewport). Added to `TEST_REGISTRY.md`. *(Inherits the existing AI-chat describe's CI skip — the course page is documented as flaky in CI — but runs and passes locally.)*
- Full local suite: unit **973 passed**, integration **191 passed**.
- Manually verified in the browser on both the course page (fixed) and the document page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)