### PR TITLE
fix: resolve overflow clipping for LaTeX menus and Ask AI widget

### DIFF
--- a/src/components/canvas/canvas-page.tsx
+++ b/src/components/canvas/canvas-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createPortal } from 'react-dom';
 import { useRef, useEffect, useCallback, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -768,7 +769,7 @@ export function CanvasPage({
       {/* Layer 4: Text content layer — only interactive in text mode */}
       <div
         ref={textLayerRef}
-        className="absolute inset-0 overflow-hidden"
+        className="absolute inset-0 overflow-visible"
         style={{
           pointerEvents:
             isInteractionMode ||
@@ -1027,46 +1028,50 @@ export function CanvasPage({
         </div>
       )}
 
-      {/* Layer 5.8: Floating action bar for Read mode text selection */}
-      {activeTool === 'read' && textSelectionRect && (
-        <div
-          className="fixed z-[100] flex items-center gap-1 rounded-full border bg-white px-2 py-1 shadow-lg"
-          style={{
-            left: textSelectionRect.left + textSelectionRect.width / 2,
-            top: textSelectionRect.top - 40,
-            transform: 'translateX(-50%)',
-            pointerEvents: 'auto',
-          }}
-        >
-          <button
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const text = selectedTextRef.current;
-              if (text && onAskAiWithText) {
-                onAskAiWithText(text);
-              }
+      {/* Layer 5.8: Floating action bar for Read mode text selection
+           Rendered via Portal to escape CSS transform container so position: fixed works correctly */}
+      {activeTool === 'read' &&
+        textSelectionRect &&
+        createPortal(
+          <div
+            className="fixed z-[100] flex items-center gap-1 rounded-full border bg-white px-2 py-1 shadow-lg"
+            style={{
+              left: textSelectionRect.left + textSelectionRect.width / 2,
+              top: textSelectionRect.top - 40,
+              transform: 'translateX(-50%)',
+              pointerEvents: 'auto',
             }}
-            className="flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium text-purple-700 transition-colors hover:bg-purple-50"
           >
-            <Sparkles className="h-3.5 w-3.5" />
-            Ask AI
-          </button>
-          <button
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              selectedTextRef.current = '';
-              selectedRectRef.current = null;
-              setTextSelectionRect(null);
-            }}
-            className="flex items-center justify-center rounded-full p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
-            aria-label="Dismiss"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      )}
+            <button
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const text = selectedTextRef.current;
+                if (text && onAskAiWithText) {
+                  onAskAiWithText(text);
+                }
+              }}
+              className="flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium text-purple-700 transition-colors hover:bg-purple-50"
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              Ask AI
+            </button>
+            <button
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                selectedTextRef.current = '';
+                selectedRectRef.current = null;
+                setTextSelectionRect(null);
+              }}
+              className="flex items-center justify-center rounded-full p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
+              aria-label="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>,
+          document.body,
+        )}
 
       {/* Layer 6: Interaction layer — ALWAYS present
           In draw/erase mode: captures all events (pointer-events: auto, touch-action: none)

--- a/src/components/editor/math-node-view.tsx
+++ b/src/components/editor/math-node-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createPortal } from 'react-dom';
 import { NodeViewWrapper } from '@tiptap/react';
 import type { NodeViewProps } from '@tiptap/react';
 import type { EditorView } from '@tiptap/pm/view';
@@ -24,9 +25,14 @@ export function MathNodeView({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [menuPos, setMenuPos] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
 
   const html = useMemo(() => {
     if (!latex) return '';
@@ -39,6 +45,16 @@ export function MathNodeView({
       return `<span style="color: red;">${latex}</span>`;
     }
   }, [latex]);
+
+  // Compute menu position when selected or editing
+  useEffect(() => {
+    if ((selected || isEditing) && wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      setMenuPos({ left: rect.left, top: rect.bottom + 4 });
+    } else {
+      setMenuPos(null);
+    }
+  }, [selected, isEditing]);
 
   const openEditor = useCallback(() => {
     setIsEditing(true);
@@ -218,98 +234,103 @@ export function MathNodeView({
           : {}),
       }}
     >
-      <span dangerouslySetInnerHTML={{ __html: html }} />
-      {selected && !isEditing && (
-        <div
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: '100%',
-            zIndex: 50,
-            marginTop: '4px',
-          }}
-          className="flex gap-1 rounded-lg border border-zinc-300 bg-white p-1 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
-        >
-          {/* preventDefault on mouseDown keeps ProseMirror NodeSelection active */}
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={openEditor}
-            className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+      <span ref={wrapperRef} dangerouslySetInnerHTML={{ __html: html }} />
+      {selected &&
+        !isEditing &&
+        menuPos &&
+        createPortal(
+          <div
+            style={{
+              position: 'fixed',
+              left: menuPos.left,
+              top: menuPos.top,
+              zIndex: 9999,
+            }}
+            className="flex gap-1 rounded-lg border border-zinc-300 bg-white p-1 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
           >
-            Edit
-          </button>
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={handleCopy}
-            className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
-          >
-            {copied ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-      )}
-      {isEditing && (
-        <div
-          ref={panelRef}
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: '100%',
-            zIndex: 50,
-            marginTop: '4px',
-          }}
-          className="flex flex-col gap-2 rounded-lg border border-zinc-300 bg-white p-2 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
-        >
-          {/* Mode selector */}
-          <div className="flex gap-1">
+            {/* preventDefault on mouseDown keeps ProseMirror NodeSelection active */}
             <button
               type="button"
-              onClick={() => switchMode('expression')}
-              className={`rounded px-2 py-0.5 text-xs font-medium ${
-                editMode === 'expression'
-                  ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
-                  : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-              }`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={openEditor}
+              className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
-              Edit Expression
+              Edit
             </button>
             <button
               type="button"
-              onClick={() => switchMode('latex')}
-              className={`rounded px-2 py-0.5 text-xs font-medium ${
-                editMode === 'latex'
-                  ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
-                  : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-              }`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleCopy}
+              className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
-              Edit LaTeX
+              {copied ? 'Copied!' : 'Copy'}
             </button>
-          </div>
-          {/* Input */}
-          <div className="flex items-center gap-2">
-            <textarea
-              ref={inputRef}
-              rows={1}
-              value={editValue}
-              onChange={(e) => setEditValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={
-                editMode === 'expression'
-                  ? 'Describe math in plain English...'
-                  : 'Enter LaTeX code...'
-              }
-              disabled={isLoading}
-              className="min-w-[220px] max-h-[200px] resize-none overflow-y-auto border-none bg-transparent text-sm outline-none placeholder:text-zinc-400 disabled:opacity-50"
-            />
-            {isLoading && (
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-violet-500" />
-            )}
-          </div>
-          {/* Error message */}
-          {error && <span className="text-xs text-red-500">{error}</span>}
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
+      {isEditing &&
+        menuPos &&
+        createPortal(
+          <div
+            ref={panelRef}
+            style={{
+              position: 'fixed',
+              left: menuPos.left,
+              top: menuPos.top,
+              zIndex: 9999,
+            }}
+            className="flex flex-col gap-2 rounded-lg border border-zinc-300 bg-white p-2 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
+          >
+            {/* Mode selector */}
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => switchMode('expression')}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  editMode === 'expression'
+                    ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
+                    : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                }`}
+              >
+                Edit Expression
+              </button>
+              <button
+                type="button"
+                onClick={() => switchMode('latex')}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  editMode === 'latex'
+                    ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
+                    : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                }`}
+              >
+                Edit LaTeX
+              </button>
+            </div>
+            {/* Input */}
+            <div className="flex items-center gap-2">
+              <textarea
+                ref={inputRef}
+                rows={1}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  editMode === 'expression'
+                    ? 'Describe math in plain English...'
+                    : 'Enter LaTeX code...'
+                }
+                disabled={isLoading}
+                className="min-w-[220px] max-h-[200px] resize-none overflow-y-auto border-none bg-transparent text-sm outline-none placeholder:text-zinc-400 disabled:opacity-50"
+              />
+              {isLoading && (
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-violet-500" />
+              )}
+            </div>
+            {/* Error message */}
+            {error && <span className="text-xs text-red-500">{error}</span>}
+          </div>,
+          document.body,
+        )}
     </NodeViewWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- Fix LaTeX bubble menu (Edit/Copy) and edit panel being clipped near page edges and at the last line — now rendered via Portal to escape ProseMirror bounds
- Change text layer overflow from hidden to visible so LaTeX boxes aren't clipped at page edges
- Render Ask AI floating bar via Portal to escape CSS transform container
- Use Sparkles icon for all Ask AI buttons for consistency

## Test plan
- [ ] Click a LaTeX expression on the last line of a page — Edit/Copy buttons fully visible
- [ ] Click a LaTeX expression near the right/left edge — bubble menu not clipped
- [ ] Open LaTeX edit panel at last line — input panel fully visible and usable
- [ ] Verify Ask AI widget appears near text selection, not in distant corner
- [ ] Verify no regression for LaTeX expressions in the middle of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)