### PR TITLE
fix: contain AI chat scroll within panel on desktop

### DIFF
--- a/src/components/ai/ai-chat-panel.tsx
+++ b/src/components/ai/ai-chat-panel.tsx
@@ -111,13 +111,17 @@ export function AiChatPanel({
   >(null);
   const [view, setView] = useState<'chat' | 'list'>('chat');
   const [loadingConversation, setLoadingConversation] = useState(false);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const initialLoadDone = useRef(false);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
   }, [messages, streamingText]);
 
   useEffect(() => {
@@ -492,7 +496,7 @@ export function AiChatPanel({
   // - docked: becomes a static flex column on lg+ (must sit in a flex row).
   // - overlay: stays fixed and docks to the right edge on lg+ (works anywhere).
   const containerClassName = docked
-    ? 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:static lg:z-auto lg:w-[480px] lg:shrink-0 xl:w-[560px] 2xl:w-[640px]'
+    ? 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:static lg:z-auto lg:min-h-0 lg:overflow-hidden lg:w-[480px] lg:shrink-0 xl:w-[560px] 2xl:w-[640px]'
     : 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-[480px] xl:w-[560px] 2xl:w-[640px]';
 
   return (
@@ -594,7 +598,7 @@ export function AiChatPanel({
       ) : (
         <>
           {/* Chat Messages */}
-          <div className="flex-1 overflow-y-auto px-4 py-4">
+          <div ref={messagesContainerRef} className="flex-1 overflow-y-auto px-4 py-4">
             {loadingConversation ? (
               <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/ai/ai-chat-panel.tsx
+++ b/src/components/ai/ai-chat-panel.tsx
@@ -598,7 +598,10 @@ export function AiChatPanel({
       ) : (
         <>
           {/* Chat Messages */}
-          <div ref={messagesContainerRef} className="flex-1 overflow-y-auto px-4 py-4">
+          <div
+            ref={messagesContainerRef}
+            className="flex-1 overflow-y-auto px-4 py-4"
+          >
             {loadingConversation ? (
               <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />


### PR DESCRIPTION
## Summary

- Fix AI chat panel causing the entire page to scroll when messages accumulate on desktop
- Add `lg:min-h-0` to override CSS flex `min-height:auto` default, allowing the panel to shrink within its parent
- Add `lg:overflow-hidden` as a safety net to clip any content overflow from the panel
- Replace `scrollIntoView` with direct `container.scrollTop` assignment to prevent scrolling ancestor containers

## Test plan

- [x] Open AI chat on desktop with many messages — only chat scrolls, page stays fixed
- [x] Stress tested with 300 paragraphs (41,663px of content) — page scroll remains at 0
- [x] Mobile chat overlay unaffected (fixes scoped to `lg:` breakpoint)
- [x] E2E test passes (`e2e/chat-scroll.spec.ts`)
- [ ] CI passes

Generated with [Claude Code](https://claude.com/claude-code)