### PR TITLE
release: promote dev to main — AI usage admin dashboard + token ledger

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,4 @@ public/pdf.worker.min.mjs
 .chrome-debug
 .chrome-debug-moodle
 .claude/worktrees
+extension/dist

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ The project uses a two-branch model: `dev` (integration) and `main` (production)
 
 ## Active Technologies
 
+- TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, @supabase/ssr, @supabase/supabase-js (048-fix-ipad-google-auth)
+
 - TypeScript 5 / Node.js 22+ + Next.js 16 (App Router), React 19, Tailwind 4 (`pointer-fine:` variant), Chrome Manifest V3, Vitest, Playwright (2026-05-13-extension-readiness)
 - N/A — manifest tightening + client-side gating; no schema changes (2026-05-13-extension-readiness)
 

--- a/docs/superpowers/plans/2026-06-04-ai-usage-admin-dashboard.md
+++ b/docs/superpowers/plans/2026-06-04-ai-usage-admin-dashboard.md
@@ -1,0 +1,1873 @@
+# AI Usage Admin Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build an admin-only, read-only dashboard showing accurate per-user AI usage (chat/latex query counts, per-model token totals, estimated switchable cost, % quota used) including per-user-attributed embedding cost.
+
+**Architecture:** A new `ai_token_usage` cost ledger (keyed by user+month+model) feeds real token counts captured from the AI calls. Admin access is a single Supabase auth identity gated by an `is_admin` flag + `requireAdmin()` server guard; data is read via the service-role client only after the gate. Prices are env-overridable so cost-per-token is switchable without a deploy.
+
+**Tech Stack:** Next.js 16 (App Router, Server Components), Supabase (Postgres + RPC + RLS), `@google/genai`, Vercel AI SDK, shadcn/ui, Vitest (unit/integration), Playwright (E2E).
+
+**Spec:** `docs/superpowers/specs/2026-06-04-ai-usage-admin-dashboard-design.md`
+
+**Branch:** `feat/ai-usage-admin-dashboard` (already created)
+
+---
+
+## File Structure
+
+**Layer 1 — accurate ledger**
+
+- Create `supabase/migrations/20260604120000_ai_token_usage.sql` — new cost-ledger table, new `record_token_usage(model)` upsert RPC, drop zeroed columns, lock down the leaky view.
+- Create `src/lib/ai/tokens.ts` — `estimateTokens(text)` (single source of the char→token estimate).
+- Create `src/lib/ai/pricing.ts` — env-overridable per-model prices + `estimateCostUsd()`.
+- Modify `src/lib/ai/embeddings.ts` — return `{ values, tokens }`.
+- Modify `src/lib/ai/rate-limit.ts` — `recordTokenUsage(userId, model, input, output)` → new RPC.
+- Modify `src/lib/ai/latex.ts` — return token usage.
+- Modify `src/app/api/ai/ask/route.ts` — record real generation tokens.
+- Modify `src/app/api/ai/latex/route.ts` — record real latex tokens.
+- Modify `src/lib/actions/ai-context.ts` — record embedding tokens; add `triggeredByUserId` to the moodle `IndexSource`.
+- Modify the Moodle routes that call `indexContent` — thread `triggeredByUserId`.
+
+**Layer 2/3 — auth + dashboard**
+
+- Create `supabase/migrations/20260604120100_profiles_is_admin.sql` — `is_admin` column.
+- Modify `supabase/seed.sql` — add admin user + deterministic dashboard seed rows.
+- Create `src/lib/auth/require-admin.ts` — `requireAdmin()` guard.
+- Create `src/lib/queries/admin-usage.ts` — aggregate query for the dashboard.
+- Create `src/app/(admin)/admin/layout.tsx` — gate.
+- Create `src/app/(admin)/admin/page.tsx` — dashboard UI.
+- Create `src/components/admin/month-select.tsx` — month picker (client).
+- Create `e2e/admin-dashboard.spec.ts` — E2E.
+- Modify `e2e/TEST_REGISTRY.md`.
+
+---
+
+## Task 1: Token-ledger migration (`ai_token_usage` + upsert RPC + view lockdown)
+
+**Files:**
+
+- Create: `supabase/migrations/20260604120000_ai_token_usage.sql`
+- Test: `src/lib/queries/ai-token-usage.integration.test.ts`
+
+- [ ] **Step 1: Write the migration**
+
+Create `supabase/migrations/20260604120000_ai_token_usage.sql`:
+
+```sql
+-- AI usage admin dashboard: accurate per-model token cost ledger.
+--
+-- Why a new table instead of more columns on ai_usage?
+-- ai_usage is the RATE-LIMIT ledger (query_count per query_type, drives the
+-- atomic quota RPC). Token COST has a different grain — it must be split by
+-- model (flash/pro/embedding) so a user who mixes Flash + Pro is priced
+-- correctly. Single-responsibility tables: ai_usage counts queries,
+-- ai_token_usage accounts tokens.
+
+-- 1. Cost ledger table
+CREATE TABLE public.ai_token_usage (
+  id            bigserial PRIMARY KEY,
+  user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  usage_month   text NOT NULL DEFAULT to_char(CURRENT_DATE, 'YYYY-MM'),
+  model         text NOT NULL,            -- 'flash' | 'pro' | 'embedding'
+  input_tokens  bigint NOT NULL DEFAULT 0,
+  output_tokens bigint NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ai_token_usage_user_month_model_idx
+  ON public.ai_token_usage (user_id, usage_month, model);
+
+CREATE TRIGGER ai_token_usage_updated_at
+  BEFORE UPDATE ON public.ai_token_usage
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+ALTER TABLE public.ai_token_usage ENABLE ROW LEVEL SECURITY;
+
+-- Users may read their own token rows; admin reads bypass RLS via service role.
+CREATE POLICY "Users can view their own token usage"
+  ON public.ai_token_usage FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- 2. Replace record_token_usage: key by MODEL, and UPSERT (embedding rows never
+-- pass through increment_ai_usage, so the row may not exist yet).
+-- Param names change (p_query_type -> p_model), so DROP then CREATE.
+DROP FUNCTION IF EXISTS public.record_token_usage(uuid, text, integer, integer);
+
+CREATE FUNCTION public.record_token_usage(
+  p_user_id uuid,
+  p_model text,
+  p_input_tokens integer,
+  p_output_tokens integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  INSERT INTO public.ai_token_usage (user_id, usage_month, model, input_tokens, output_tokens)
+    VALUES (p_user_id, to_char(CURRENT_DATE, 'YYYY-MM'), p_model, p_input_tokens, p_output_tokens)
+    ON CONFLICT (user_id, usage_month, model)
+    DO UPDATE SET
+      input_tokens  = public.ai_token_usage.input_tokens  + p_input_tokens,
+      output_tokens = public.ai_token_usage.output_tokens + p_output_tokens,
+      updated_at    = now();
+END;
+$$;
+
+-- 3. Security fix + cleanup of the old zeroed columns.
+-- The admin_user_ai_usage VIEW referenced these columns, so drop the view first.
+-- It was created without security_invoker (RLS-bypass leak) and joined every
+-- user's email — recreate it security_invoker and REVOKE from public roles.
+DROP VIEW IF EXISTS public.admin_user_ai_usage;
+
+ALTER TABLE public.ai_usage
+  DROP COLUMN IF EXISTS total_input_tokens,
+  DROP COLUMN IF EXISTS total_output_tokens;
+
+CREATE VIEW public.admin_user_ai_usage
+  WITH (security_invoker = true) AS
+SELECT
+  p.id AS user_id,
+  p.display_name,
+  p.email,
+  p.subscription_tier,
+  au.usage_month,
+  au.query_type,
+  au.query_count,
+  au.updated_at
+FROM public.profiles p
+LEFT JOIN public.ai_usage au ON au.user_id = p.id
+ORDER BY au.usage_month DESC, p.display_name;
+
+REVOKE ALL ON public.admin_user_ai_usage FROM anon, authenticated;
+```
+
+- [ ] **Step 2: Reset the DB and confirm the migration applies**
+
+Run: `pnpm supabase db reset`
+Expected: completes without error; output lists `20260604120000_ai_token_usage.sql` applied.
+
+- [ ] **Step 3: Write the failing integration test**
+
+Create `src/lib/queries/ai-token-usage.integration.test.ts`:
+
+```ts
+/**
+ * Integration test: record_token_usage upserts into ai_token_usage,
+ * keyed by (user, month, model), accumulating on repeat calls.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createAdminClient, TEST_USER_ID } from '@/test/supabase-client';
+
+let supabase: SupabaseClient;
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+async function cleanup() {
+  await supabase
+    .from('ai_token_usage')
+    .delete()
+    .eq('user_id', TEST_USER_ID)
+    .eq('usage_month', currentMonth());
+}
+
+beforeAll(async () => {
+  supabase = createAdminClient();
+  await cleanup();
+});
+
+afterAll(cleanup);
+
+describe('record_token_usage', () => {
+  it('inserts a new row for a model on first call', async () => {
+    const { error } = await supabase.rpc('record_token_usage', {
+      p_user_id: TEST_USER_ID,
+      p_model: 'flash',
+      p_input_tokens: 100,
+      p_output_tokens: 40,
+    });
+    expect(error).toBeNull();
+
+    const { data } = await supabase
+      .from('ai_token_usage')
+      .select('input_tokens, output_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('usage_month', currentMonth())
+      .eq('model', 'flash')
+      .single();
+
+    expect(data?.input_tokens).toBe(100);
+    expect(data?.output_tokens).toBe(40);
+  });
+
+  it('accumulates on repeat calls for the same model', async () => {
+    await supabase.rpc('record_token_usage', {
+      p_user_id: TEST_USER_ID,
+      p_model: 'flash',
+      p_input_tokens: 10,
+      p_output_tokens: 5,
+    });
+
+    const { data } = await supabase
+      .from('ai_token_usage')
+      .select('input_tokens, output_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('usage_month', currentMonth())
+      .eq('model', 'flash')
+      .single();
+
+    expect(data?.input_tokens).toBe(110);
+    expect(data?.output_tokens).toBe(45);
+  });
+
+  it('keeps separate models in separate rows', async () => {
+    await supabase.rpc('record_token_usage', {
+      p_user_id: TEST_USER_ID,
+      p_model: 'embedding',
+      p_input_tokens: 999,
+      p_output_tokens: 0,
+    });
+
+    const { data } = await supabase
+      .from('ai_token_usage')
+      .select('model, input_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('usage_month', currentMonth());
+
+    const embedding = data?.find((r) => r.model === 'embedding');
+    expect(embedding?.input_tokens).toBe(999);
+    expect(data?.length).toBe(2); // flash + embedding
+  });
+});
+```
+
+- [ ] **Step 4: Run the integration test**
+
+Run: `pnpm test:integration -- ai-token-usage`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260604120000_ai_token_usage.sql src/lib/queries/ai-token-usage.integration.test.ts
+git commit -m "feat(ai): add ai_token_usage cost ledger + model-keyed upsert RPC
+
+Adds per-model token ledger, replaces record_token_usage with an upsert
+keyed by model, drops the zeroed ai_usage token columns, and locks down
+the leaky admin_user_ai_usage view (security_invoker + REVOKE).
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Token estimate helper (`tokens.ts`)
+
+**Files:**
+
+- Create: `src/lib/ai/tokens.ts`
+- Test: `src/lib/ai/__tests__/tokens.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/ai/__tests__/tokens.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { estimateTokens } from '../tokens';
+
+describe('estimateTokens', () => {
+  it('approximates ~1 token per 4 characters, rounding up', () => {
+    expect(estimateTokens('12345678')).toBe(2); // 8 / 4
+    expect(estimateTokens('123456789')).toBe(3); // ceil(9 / 4)
+  });
+
+  it('returns 0 for empty or whitespace-only text', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens('   ')).toBe(0);
+  });
+
+  it('handles undefined/null defensively', () => {
+    expect(estimateTokens(undefined as unknown as string)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- tokens`
+Expected: FAIL ("Cannot find module '../tokens'").
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/ai/tokens.ts`:
+
+```ts
+/**
+ * Rough token estimate from text length. The Gemini Developer API does not
+ * return token counts for embeddings, and generation usage can be absent, so
+ * this is the fallback. ~4 characters per token is the standard heuristic for
+ * Latin-script text. Estimates are accepted — tokens are the metric we report;
+ * the dollar figure derived from them is labeled an estimate.
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return Math.ceil(trimmed.length / 4);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- tokens`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ai/tokens.ts src/lib/ai/__tests__/tokens.test.ts
+git commit -m "feat(ai): add estimateTokens char-based heuristic
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Pricing module (`pricing.ts`)
+
+**Files:**
+
+- Create: `src/lib/ai/pricing.ts`
+- Test: `src/lib/ai/__tests__/pricing.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/ai/__tests__/pricing.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { estimateCostUsd, getModelPrices } from '../pricing';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('estimateCostUsd', () => {
+  it('prices flash input + output per 1M tokens using defaults', () => {
+    // defaults: flash input 0.30, output 2.50 per 1M
+    const cost = estimateCostUsd('flash', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(0.3 + 2.5, 6);
+  });
+
+  it('prices embedding as input-only', () => {
+    // default embedding input 0.15 per 1M, output unused
+    const cost = estimateCostUsd('embedding', 2_000_000, 0);
+    expect(cost).toBeCloseTo(0.3, 6);
+  });
+
+  it('returns 0 for an unknown model', () => {
+    expect(estimateCostUsd('mystery', 1_000_000, 1_000_000)).toBe(0);
+  });
+
+  it('honours env overrides so prices are switchable without a deploy', () => {
+    vi.stubEnv('AI_PRICE_FLASH_INPUT', '1.00');
+    vi.stubEnv('AI_PRICE_FLASH_OUTPUT', '3.00');
+    expect(getModelPrices().flash).toEqual({ input: 1.0, output: 3.0 });
+    expect(estimateCostUsd('flash', 1_000_000, 1_000_000)).toBeCloseTo(4.0, 6);
+  });
+
+  it('ignores invalid env values and falls back to default', () => {
+    vi.stubEnv('AI_PRICE_FLASH_INPUT', 'not-a-number');
+    expect(getModelPrices().flash.input).toBe(0.3);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- pricing`
+Expected: FAIL ("Cannot find module '../pricing'").
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/ai/pricing.ts`:
+
+```ts
+/**
+ * Per-model AI token prices, in USD per 1,000,000 tokens.
+ *
+ * Prices are ENV-OVERRIDABLE so cost-per-token can be switched without a code
+ * deploy (mirrors the AI_LIMIT_* rate-limit override pattern). Defaults are
+ * approximate published Gemini prices and are safe to adjust.
+ *
+ * Tokens are the primary, accurate metric. The dollar figure is a derived,
+ * switchable estimate and is labeled as such in the UI.
+ */
+
+export interface ModelPrice {
+  input: number; // USD per 1M input tokens
+  output: number; // USD per 1M output tokens
+}
+
+function envPrice(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (!Number.isNaN(n) && n >= 0) return n;
+  }
+  return fallback;
+}
+
+export function getModelPrices(): Record<string, ModelPrice> {
+  return {
+    flash: {
+      input: envPrice('AI_PRICE_FLASH_INPUT', 0.3),
+      output: envPrice('AI_PRICE_FLASH_OUTPUT', 2.5),
+    },
+    pro: {
+      input: envPrice('AI_PRICE_PRO_INPUT', 1.25),
+      output: envPrice('AI_PRICE_PRO_OUTPUT', 10.0),
+    },
+    embedding: {
+      input: envPrice('AI_PRICE_EMBEDDING', 0.15),
+      output: 0,
+    },
+  };
+}
+
+export function estimateCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const price = getModelPrices()[model];
+  if (!price) return 0;
+  return (
+    (inputTokens / 1_000_000) * price.input +
+    (outputTokens / 1_000_000) * price.output
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- pricing`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ai/pricing.ts src/lib/ai/__tests__/pricing.test.ts
+git commit -m "feat(ai): add env-overridable per-model pricing + cost estimate
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Embeddings return token estimate
+
+**Files:**
+
+- Modify: `src/lib/ai/embeddings.ts:16-47`
+- Test: `src/lib/ai/__tests__/embeddings.test.ts` (update existing assertions)
+
+- [ ] **Step 1: Update the failing tests first**
+
+In `src/lib/ai/__tests__/embeddings.test.ts`, the existing `embedText`/`embedQuery` tests assert the function returns the raw array. Change them to assert the new `{ values, tokens }` shape. Replace the body of the first `embedText` test with:
+
+```ts
+it('sends text with RETRIEVAL_DOCUMENT task type and returns values + token estimate', async () => {
+  const mockValues = Array.from({ length: 1536 }, () => 0.2);
+  mockEmbedContent.mockResolvedValueOnce({
+    embeddings: [{ values: mockValues }],
+  });
+
+  const result = await embedText('Some document text'); // 18 chars -> ceil(18/4)=5
+  expect(result.values).toEqual(mockValues);
+  expect(result.tokens).toBe(5);
+});
+```
+
+For any other test in this file that does `const result = await embedText(...)` / `embedQuery(...)` and asserts on the array directly, change it to assert on `result.values`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test -- embeddings`
+Expected: FAIL (result is `{values, tokens}`, not an array).
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/ai/embeddings.ts`, add the import at the top:
+
+```ts
+import { estimateTokens } from '@/lib/ai/tokens';
+```
+
+Replace the `embedText` and `embedQuery` functions (lines 13-47) with:
+
+```ts
+export interface EmbedResult {
+  values: number[];
+  /** Estimated token count (Developer API returns none for embeddings). */
+  tokens: number;
+}
+
+/**
+ * Embed a text string for storage (document side of asymmetric retrieval).
+ */
+export async function embedText(text: string): Promise<EmbedResult> {
+  const genai = getGenAI();
+
+  const response = await genai.models.embedContent({
+    model: EMBEDDING_MODEL,
+    contents: text,
+    config: {
+      outputDimensionality: EMBEDDING_DIMENSIONS,
+      taskType: 'RETRIEVAL_DOCUMENT',
+    },
+  });
+
+  return {
+    values: response.embeddings?.[0]?.values ?? [],
+    tokens: estimateTokens(text),
+  };
+}
+
+/**
+ * Embed a search query (query side of asymmetric retrieval).
+ */
+export async function embedQuery(text: string): Promise<EmbedResult> {
+  const genai = getGenAI();
+
+  const response = await genai.models.embedContent({
+    model: EMBEDDING_MODEL,
+    contents: text,
+    config: {
+      outputDimensionality: EMBEDDING_DIMENSIONS,
+      taskType: 'RETRIEVAL_QUERY',
+    },
+  });
+
+  return {
+    values: response.embeddings?.[0]?.values ?? [],
+    tokens: estimateTokens(text),
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test -- embeddings`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ai/embeddings.ts src/lib/ai/__tests__/embeddings.test.ts
+git commit -m "feat(ai): embeddings return token estimate alongside vector
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: `recordTokenUsage` keyed by model
+
+**Files:**
+
+- Modify: `src/lib/ai/rate-limit.ts:202-222`
+- Test: `src/lib/ai/__tests__/rate-limit.test.ts` (add a case)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/lib/ai/__tests__/rate-limit.test.ts`, add (the file already mocks `@/lib/supabase/server`; mirror its existing `recordTokenUsage` mock setup — if none exists, add a `vi.mock` for the server client exposing an `rpc` spy). Add this test inside the file:
+
+```ts
+describe('recordTokenUsage', () => {
+  it('calls record_token_usage RPC keyed by model', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+    vi.mocked(createClient).mockResolvedValue({ rpc } as never);
+
+    await recordTokenUsage('user-1', 'pro', 123, 45);
+
+    expect(rpc).toHaveBeenCalledWith('record_token_usage', {
+      p_user_id: 'user-1',
+      p_model: 'pro',
+      p_input_tokens: 123,
+      p_output_tokens: 45,
+    });
+  });
+
+  it('never throws if the RPC errors (fire-and-forget)', async () => {
+    const rpc = vi.fn().mockRejectedValue(new Error('db down'));
+    vi.mocked(createClient).mockResolvedValue({ rpc } as never);
+
+    await expect(
+      recordTokenUsage('user-1', 'flash', 1, 1),
+    ).resolves.toBeUndefined();
+  });
+});
+```
+
+Ensure `createClient` and `recordTokenUsage` are imported at the top of the test file (add to existing imports if missing):
+
+```ts
+import { createClient } from '@/lib/supabase/server';
+import { recordTokenUsage } from '../rate-limit';
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- rate-limit`
+Expected: FAIL (RPC called with `p_query_type`, not `p_model`).
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/ai/rate-limit.ts`, replace the `recordTokenUsage` function (lines ~193-222) with:
+
+```ts
+/**
+ * Record token counts for cost observability. Called AFTER the AI response.
+ *
+ * Keyed by MODEL ('flash' | 'pro' | 'embedding') so mixed-model usage is priced
+ * correctly. Fire-and-forget — never throws; a metrics-write failure must never
+ * fail the user's AI response.
+ */
+export async function recordTokenUsage(
+  userId: string,
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): Promise<void> {
+  try {
+    const supabase = await createClient();
+    await supabase.rpc('record_token_usage', {
+      p_user_id: userId,
+      p_model: model,
+      p_input_tokens: inputTokens,
+      p_output_tokens: outputTokens,
+    });
+  } catch (err) {
+    console.error('[rate-limit] Failed to record token usage:', err);
+  }
+}
+```
+
+(Leave `QueryType`, `checkAndIncrementUsage`, `getQuota`, and `resolveLimitForTier` unchanged — `QueryType` is still used by the rate-limit path.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- rate-limit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/ai/rate-limit.ts src/lib/ai/__tests__/rate-limit.test.ts
+git commit -m "feat(ai): recordTokenUsage keyed by model
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Capture real generation tokens in the ask route
+
+**Files:**
+
+- Modify: `src/app/api/ai/ask/route.ts:319-382`
+
+- [ ] **Step 1: Add the estimate import**
+
+At the top of `src/app/api/ai/ask/route.ts`, add:
+
+```ts
+import { estimateTokens } from '@/lib/ai/tokens';
+```
+
+- [ ] **Step 2: Capture usageMetadata in the stream loop**
+
+In the `ReadableStream`'s `start`, before the `for await` loop, add accumulators next to `let fullResponse = '';`:
+
+```ts
+let fullResponse = '';
+let usageInput = 0;
+let usageOutput = 0;
+```
+
+Inside the loop, after the `if (text) { ... }` block, capture usage from each chunk (the final chunk carries cumulative `usageMetadata`):
+
+```ts
+for await (const chunk of streamResult) {
+  const text = chunk.text ?? '';
+  if (text) {
+    fullResponse += text;
+    controller.enqueue(
+      encoder.encode(`data: ${JSON.stringify({ type: 'text', text })}\n\n`),
+    );
+  }
+  const usage = chunk.usageMetadata;
+  if (usage) {
+    usageInput = usage.promptTokenCount ?? usageInput;
+    usageOutput = usage.candidatesTokenCount ?? usageOutput;
+  }
+}
+```
+
+- [ ] **Step 3: Record real tokens (with estimate fallback)**
+
+Replace the existing fire-and-forget line:
+
+```ts
+// Fire-and-forget token recording for admin observability
+recordTokenUsage(user.id, 'chat', 0, 0).catch(() => {});
+```
+
+with:
+
+```ts
+// Fire-and-forget token recording for cost observability.
+// Prefer the model's reported usage; fall back to a char estimate so
+// we never silently record zeros.
+const inputTokens =
+  usageInput || estimateTokens(`${systemPrompt}\n${question}`);
+const outputTokens = usageOutput || estimateTokens(fullResponse);
+recordTokenUsage(user.id, modelLabel, inputTokens, outputTokens).catch(
+  () => {},
+);
+```
+
+(`modelLabel` is already defined at line 325 as `mode === 'deep' ? 'pro' : 'flash'`.)
+
+- [ ] **Step 4: Update the debug-mode token line**
+
+In debug mode the route returns early without a Gemini call. Leave the debug branch as-is (it does not record tokens), so CI's keyless runs record nothing rather than zeros. No change needed here — just confirm no other `recordTokenUsage(... 'chat' ...)` call remains:
+
+Run: `grep -n "recordTokenUsage" src/app/api/ai/ask/route.ts`
+Expected: exactly one call, using `modelLabel`.
+
+- [ ] **Step 5: Typecheck + existing route tests**
+
+Run: `pnpm test -- ask && pnpm typecheck`
+Expected: PASS (existing ask tests still green; no type errors). If `chunk.usageMetadata` types complain, the `@google/genai` `GenerateContentResponse` exposes `usageMetadata?` — no cast needed; if a type error appears, narrow with `const usage = chunk.usageMetadata;` as written.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app/api/ai/ask/route.ts
+git commit -m "feat(ai): record real chat tokens by model in ask route
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Capture real latex tokens
+
+**Files:**
+
+- Modify: `src/lib/ai/latex.ts`
+- Modify: `src/app/api/ai/latex/route.ts:83-88`
+- Test: `src/lib/ai/latex.test.ts` (update return-shape assertions)
+
+- [ ] **Step 1: Update the latex unit test**
+
+In `src/lib/ai/latex.test.ts`, the existing tests expect `convertToLatex` to resolve to a string. Update them to the new object shape. For each `expect(await convertToLatex(...)).toBe('...')`, change to:
+
+```ts
+const result = await convertToLatex('five times a half');
+expect(result.latex).toBe('5 \\times \\frac{1}{2}');
+expect(result.inputTokens).toBeGreaterThan(0);
+expect(result.outputTokens).toBeGreaterThan(0);
+```
+
+If the test mocks `generateText`, make the mock return `{ text: '...', usage: { inputTokens: 12, outputTokens: 7 } }` and assert `result.inputTokens === 12`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- latex`
+Expected: FAIL (result is a string).
+
+- [ ] **Step 3: Implement in `latex.ts`**
+
+Replace `src/lib/ai/latex.ts` with:
+
+```ts
+import { generateText } from 'ai';
+import { getModel } from './provider';
+import { buildLatexPrompt } from './prompts';
+import { estimateTokens } from './tokens';
+
+export interface LatexResult {
+  latex: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export async function convertToLatex(
+  text: string,
+  courseName?: string,
+): Promise<LatexResult> {
+  const system = buildLatexPrompt(courseName);
+  const result = await generateText({
+    model: getModel(),
+    system,
+    prompt: text,
+    temperature: 0,
+  });
+
+  const latex = result.text.trim();
+  // AI SDK usage field naming has varied across versions; read both, then
+  // fall back to a char estimate so we never record zeros.
+  const usage = result.usage as
+    | {
+        inputTokens?: number;
+        promptTokens?: number;
+        outputTokens?: number;
+        completionTokens?: number;
+      }
+    | undefined;
+  const inputTokens =
+    usage?.inputTokens ??
+    usage?.promptTokens ??
+    estimateTokens(`${system}\n${text}`);
+  const outputTokens =
+    usage?.outputTokens ?? usage?.completionTokens ?? estimateTokens(latex);
+
+  return { latex, inputTokens, outputTokens };
+}
+```
+
+- [ ] **Step 4: Update the latex route**
+
+In `src/app/api/ai/latex/route.ts`, replace lines 83-90:
+
+```ts
+const latex = await convertToLatex(text.trim(), courseName || undefined);
+
+// Fire-and-forget token recording
+// convertToLatex returns just the string for now; token recording
+// will be enhanced when we update latex.ts to return usage in US3
+recordTokenUsage(user.id, 'latex', 0, 0).catch(() => {});
+
+return NextResponse.json({ latex });
+```
+
+with:
+
+```ts
+const { latex, inputTokens, outputTokens } = await convertToLatex(
+  text.trim(),
+  courseName || undefined,
+);
+
+// Fire-and-forget token recording (latex always runs on Flash).
+recordTokenUsage(user.id, 'flash', inputTokens, outputTokens).catch(() => {});
+
+return NextResponse.json({ latex });
+```
+
+- [ ] **Step 5: Run tests + typecheck**
+
+Run: `pnpm test -- latex && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/ai/latex.ts src/app/api/ai/latex/route.ts src/lib/ai/latex.test.ts
+git commit -m "feat(ai): record real latex tokens (Flash) from generateText usage
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Attribute embedding tokens per user
+
+**Files:**
+
+- Modify: `src/lib/actions/ai-context.ts` (IndexSource type L37-40; indexContent L118-336; searchContext L353-358)
+- Modify: `src/app/api/moodle/upload/route.ts`, `src/app/api/moodle/upload-finalize/route.ts`, `src/app/api/moodle/import-existing/route.ts` (thread triggering user)
+- Test: `src/lib/actions/__tests__/personal-file-embedding.integration.test.ts` (extend) — see Step 6
+
+- [ ] **Step 1: Add `triggeredByUserId` to the moodle IndexSource**
+
+In `src/lib/actions/ai-context.ts`, change the `IndexSource` union (lines 37-40):
+
+```ts
+export type IndexSource =
+  | {
+      type: 'moodle_file';
+      fileId: string;
+      courseId: string;
+      /** User who triggered the one-time shared embed (for cost attribution). */
+      triggeredByUserId?: string;
+    }
+  | { type: 'course_material'; materialId: string; courseId: string }
+  | { type: 'personal_file'; fileId: string; courseId: string };
+```
+
+- [ ] **Step 2: Track a cost-attribution user id in indexContent**
+
+In `indexContent`, add a cost-attribution variable next to the existing `let userId` declaration (line 124):
+
+```ts
+let userId: string | null = null;
+let costUserId: string | null = null; // who pays for the embed (may differ from row owner)
+```
+
+In the `moodle_file` branch (after `userId = null;` at line 134) add:
+
+```ts
+userId = null;
+costUserId = source.triggeredByUserId ?? null; // shared vector, attributed cost
+```
+
+In the `course_material` branch (after `userId = await getAuthUserId();` ~line 190) add `costUserId = userId;`. Do the same in the `personal_file` branch (after line 222): `costUserId = userId;`.
+
+- [ ] **Step 3: Accumulate and record embedding tokens**
+
+In the chunk loop (lines 294-314), accumulate tokens. Replace:
+
+```ts
+    const rows: EmbeddingRow[] = [];
+    for (const chunk of chunks) {
+      const embedding = await embedText(chunk.text);
+      // embedText returns [] only on a malformed embeddings API response.
+      if (!embedding.length) continue;
+```
+
+with:
+
+```ts
+    const rows: EmbeddingRow[] = [];
+    let embedTokens = 0;
+    for (const chunk of chunks) {
+      const { values: embedding, tokens } = await embedText(chunk.text);
+      embedTokens += tokens;
+      // embedText returns [] only on a malformed embeddings API response.
+      if (!embedding.length) continue;
+```
+
+After `await upsertEmbeddings(rows);` (line 334), record the cost:
+
+```ts
+await upsertEmbeddings(rows);
+
+// Fire-and-forget embedding cost attribution. The vector is shared
+// (user_id may be null for Moodle); the COST belongs to whoever triggered it.
+if (costUserId && embedTokens > 0) {
+  await recordTokenUsage(costUserId, 'embedding', embedTokens, 0).catch(
+    () => {},
+  );
+}
+
+return { success: true, segmentsIndexed: rows.length, skipped: false };
+```
+
+Add the import at the top of the file:
+
+```ts
+import { recordTokenUsage } from '@/lib/ai/rate-limit';
+```
+
+- [ ] **Step 4: Record query-embedding cost in searchContext**
+
+In `searchContext` (line ~356-358), replace:
+
+```ts
+  const userId = await getAuthUserId();
+  ...
+  const queryEmbedding = await embedQuery(params.query);
+```
+
+so the embed call destructures and records:
+
+```ts
+const userId = await getAuthUserId();
+```
+
+…and where `embedQuery` is called:
+
+```ts
+const { values: queryEmbedding, tokens: queryTokens } = await embedQuery(
+  params.query,
+);
+recordTokenUsage(userId, 'embedding', queryTokens, 0).catch(() => {});
+```
+
+(Confirm `queryEmbedding` is still used by the downstream similarity call unchanged.)
+
+- [ ] **Step 5: Thread `triggeredByUserId` from the Moodle routes**
+
+In each of `src/app/api/moodle/upload/route.ts`, `src/app/api/moodle/upload-finalize/route.ts`, and `src/app/api/moodle/import-existing/route.ts`, every `indexContent({ type: 'moodle_file', fileId: ..., courseId: ... })` call gains `triggeredByUserId: user.id` (each route already authenticates a `user` before reaching the indexing call — use that variable; if it is named differently, e.g. `userId`, pass that). Example edit:
+
+```ts
+await indexContent({
+  type: 'moodle_file',
+  fileId: file.id,
+  courseId,
+  triggeredByUserId: user.id,
+});
+```
+
+Run to find every call site to update:
+
+Run: `grep -rn "type: 'moodle_file'" src/app/api/moodle`
+Expected: update each listed call to include `triggeredByUserId`.
+
+- [ ] **Step 6: Extend the embedding integration test**
+
+In `src/lib/actions/__tests__/personal-file-embedding.integration.test.ts`, add an assertion that after indexing a personal file, an `ai_token_usage` row with `model='embedding'` exists for the user with `input_tokens > 0`. Mirror the file's existing setup; add:
+
+```ts
+it('records embedding token cost for the indexing user', async () => {
+  // (after the existing indexContent personal_file call in this suite)
+  const { data } = await supabase
+    .from('ai_token_usage')
+    .select('input_tokens')
+    .eq('user_id', TEST_USER_ID)
+    .eq('model', 'embedding')
+    .eq('usage_month', currentMonth())
+    .maybeSingle();
+
+  expect(data?.input_tokens ?? 0).toBeGreaterThan(0);
+});
+```
+
+Add a cleanup of `ai_token_usage` for `TEST_USER_ID` in this file's `afterAll`/`beforeAll` (mirror the `ai-token-usage.integration.test.ts` cleanup helper) and a local `currentMonth()` if the file lacks one.
+
+- [ ] **Step 7: Run unit + integration + typecheck**
+
+Run: `pnpm test -- ai-context && pnpm test:integration -- personal-file-embedding && pnpm typecheck`
+Expected: PASS. Then run the broader AI unit suite to catch the changed `embedText` return shape in any other caller: `pnpm test -- embeddings ai-context`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/actions/ai-context.ts src/app/api/moodle src/lib/actions/__tests__/personal-file-embedding.integration.test.ts
+git commit -m "feat(ai): attribute embedding token cost to the triggering user
+
+Vector ownership stays shared (Moodle user_id=null); embedding cost is
+attributed to whoever triggered the one-time embed.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: `is_admin` migration + seed admin user + deterministic dashboard seed
+
+**Files:**
+
+- Create: `supabase/migrations/20260604120100_profiles_is_admin.sql`
+- Modify: `supabase/seed.sql`
+
+- [ ] **Step 1: Write the migration**
+
+Create `supabase/migrations/20260604120100_profiles_is_admin.sql`:
+
+```sql
+-- Admin authorization flag. Authentication stays Supabase Auth (single identity);
+-- this flag is the authorization gate for the /admin area. Default false so no
+-- existing user becomes an admin implicitly.
+ALTER TABLE public.profiles
+  ADD COLUMN is_admin boolean NOT NULL DEFAULT false;
+```
+
+- [ ] **Step 2: Add the admin user to the seed**
+
+In `supabase/seed.sql`, after the existing `test-b@typenote.dev` block, add an admin auth user. Mirror the existing `test@typenote.dev` `auth.users` + `auth.identities` insert (around lines 5-66), changing the id, email, and password. Use a fixed UUID `00000000-0000-4000-a000-000000000001`:
+
+```sql
+-- Admin user (local/CI only): admin@typenote.dev / Admin1234
+INSERT INTO auth.users (
+  instance_id, id, aud, role, email, encrypted_password,
+  email_confirmed_at, created_at, updated_at, raw_app_meta_data, raw_user_meta_data
+) VALUES (
+  '00000000-0000-0000-0000-000000000000',
+  '00000000-0000-4000-a000-000000000001',
+  'authenticated', 'authenticated', 'admin@typenote.dev',
+  crypt('Admin1234', gen_salt('bf')),
+  now(), now(), now(),
+  '{"provider":"email","providers":["email"]}',
+  '{"email":"admin@typenote.dev","email_verified":true,"full_name":"Admin User"}'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.identities (
+  provider_id, user_id, identity_data, provider, last_sign_in_at, created_at, updated_at
+) VALUES (
+  '00000000-0000-4000-a000-000000000001',
+  '00000000-0000-4000-a000-000000000001',
+  '{"sub":"00000000-0000-4000-a000-000000000001","email":"admin@typenote.dev","email_verified":true}',
+  'email', now(), now(), now()
+)
+ON CONFLICT (provider_id, provider) DO NOTHING;
+
+-- The handle_new_user trigger creates the profile row; flip the admin flag.
+UPDATE public.profiles SET is_admin = true
+  WHERE id = '00000000-0000-4000-a000-000000000001';
+```
+
+(Match the exact column list of the existing `auth.users`/`auth.identities` inserts in this file — if they differ from the above, copy that block's columns verbatim and only change id/email/password/meta.)
+
+- [ ] **Step 3: Add deterministic dashboard seed rows (fixed month `2099-01`)**
+
+Append to `supabase/seed.sql` so the E2E has known values independent of the real date:
+
+```sql
+-- Deterministic AI-usage rows for the admin dashboard E2E (month 2099-01).
+INSERT INTO public.ai_usage (user_id, usage_month, query_type, query_count, last_model)
+VALUES
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'chat', 12, 'flash'),
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'latex', 30, 'flash')
+ON CONFLICT (user_id, usage_month, query_type) DO NOTHING;
+
+INSERT INTO public.ai_token_usage (user_id, usage_month, model, input_tokens, output_tokens)
+VALUES
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'flash', 1000000, 500000),
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'embedding', 2000000, 0)
+ON CONFLICT (user_id, usage_month, model) DO NOTHING;
+```
+
+(`ac3be77d-...` is the seeded `test@typenote.dev` id, from `supabase/seed.sql:56`.)
+
+- [ ] **Step 4: Reset DB and confirm seed applies**
+
+Run: `pnpm supabase db reset`
+Expected: completes; both new migrations applied; no seed errors.
+
+- [ ] **Step 5: Confirm the admin flag and rows exist**
+
+Run:
+
+```bash
+pnpm supabase db reset >/dev/null 2>&1; \
+psql "$(pnpm -s supabase status | grep 'DB URL' | awk '{print $NF}')" \
+  -c "select email, is_admin from profiles where email in ('admin@typenote.dev','test@typenote.dev');"
+```
+
+Expected: `admin@typenote.dev | t` and `test@typenote.dev | f`.
+(If the worktree uses isolated Supabase ports, source `.env.worktree.sh` first per project memory.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260604120100_profiles_is_admin.sql supabase/seed.sql
+git commit -m "feat(admin): add is_admin flag, seed admin user + deterministic usage
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: `requireAdmin()` guard
+
+**Files:**
+
+- Create: `src/lib/auth/require-admin.ts`
+- Test: `src/lib/auth/__tests__/require-admin.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/auth/__tests__/require-admin.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const notFound = vi.fn(() => {
+  throw new Error('NEXT_NOT_FOUND');
+});
+vi.mock('next/navigation', () => ({ notFound }));
+
+const getUser = vi.fn();
+const from = vi.fn();
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser }, from })),
+}));
+
+import { requireAdmin } from '../require-admin';
+
+function mockProfile(is_admin: boolean | null) {
+  from.mockReturnValue({
+    select: () => ({
+      eq: () => ({
+        single: async () => ({
+          data: is_admin === null ? null : { is_admin },
+          error: null,
+        }),
+      }),
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('requireAdmin', () => {
+  it('returns the user id for an admin', async () => {
+    getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } } });
+    mockProfile(true);
+    await expect(requireAdmin()).resolves.toBe('admin-1');
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('calls notFound for a logged-in non-admin', async () => {
+    getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+    mockProfile(false);
+    await expect(requireAdmin()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('calls notFound when unauthenticated', async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    await expect(requireAdmin()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test -- require-admin`
+Expected: FAIL ("Cannot find module '../require-admin'").
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/auth/require-admin.ts`:
+
+```ts
+import { notFound } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Server-only authorization gate for the /admin area.
+ *
+ * Authentication is handled upstream by middleware (an unauthenticated /admin
+ * hit is redirected to /login before any layout runs). This enforces
+ * AUTHORIZATION: only an is_admin profile may proceed. Non-admins get a 404 so
+ * the admin area is not discoverable. Returns the admin user id.
+ */
+export async function requireAdmin(): Promise<string> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    notFound();
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    notFound();
+  }
+
+  return user.id;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test -- require-admin`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/auth/require-admin.ts src/lib/auth/__tests__/require-admin.test.ts
+git commit -m "feat(admin): add requireAdmin authorization guard
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: Admin usage aggregate query
+
+**Files:**
+
+- Create: `src/lib/queries/admin-usage.ts`
+- Test: `src/lib/queries/admin-usage.integration.test.ts`
+
+- [ ] **Step 1: Write the failing integration test**
+
+Create `src/lib/queries/admin-usage.integration.test.ts`:
+
+```ts
+/**
+ * Integration test: getAdminUsage aggregates per-user usage + token cost for a
+ * given month against the seeded deterministic rows (month 2099-01).
+ */
+import { describe, it, expect } from 'vitest';
+import { getAdminUsage } from './admin-usage';
+
+const TEST_USER_ID = 'ac3be77d-4566-406c-9ac0-7c410634ad41';
+
+describe('getAdminUsage (2099-01 seed)', () => {
+  it('returns the seeded user with correct counts and a positive cost', async () => {
+    const { users, totals } = await getAdminUsage('2099-01');
+    const row = users.find((u) => u.userId === TEST_USER_ID);
+
+    expect(row).toBeDefined();
+    expect(row!.chatCount).toBe(12);
+    expect(row!.latexCount).toBe(30);
+    expect(row!.tokensByModel.flash).toEqual({
+      input: 1000000,
+      output: 500000,
+    });
+    expect(row!.tokensByModel.embedding.input).toBe(2000000);
+    // flash 1M in*0.30 + 0.5M out*2.50 + embedding 2M*0.15 = 0.30 + 1.25 + 0.30
+    expect(row!.estimatedCostUsd).toBeCloseTo(1.85, 4);
+    expect(totals.estimatedCostUsd).toBeGreaterThanOrEqual(1.85);
+  });
+
+  it('returns no rows for a month with no activity', async () => {
+    const { users } = await getAdminUsage('1999-01');
+    expect(users).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:integration -- admin-usage`
+Expected: FAIL ("Cannot find module './admin-usage'").
+
+- [ ] **Step 3: Implement**
+
+Create `src/lib/queries/admin-usage.ts`:
+
+```ts
+import { createAdminClient } from '@/lib/supabase/admin';
+import { estimateCostUsd } from '@/lib/ai/pricing';
+import { resolveLimitForTier } from '@/lib/ai/rate-limit';
+
+export interface ModelTokens {
+  input: number;
+  output: number;
+}
+
+export interface AdminUserUsage {
+  userId: string;
+  email: string;
+  displayName: string | null;
+  tier: string;
+  chatCount: number;
+  latexCount: number;
+  tokensByModel: Record<string, ModelTokens>;
+  estimatedCostUsd: number;
+  /** Chat queries used as a percentage of the tier's chat limit (0-100+). */
+  chatQuotaPct: number;
+}
+
+export interface AdminUsageTotals {
+  chatCount: number;
+  latexCount: number;
+  totalTokens: number;
+  embeddingTokens: number;
+  estimatedCostUsd: number;
+}
+
+export interface AdminUsage {
+  users: AdminUserUsage[];
+  totals: AdminUsageTotals;
+}
+
+const EMPTY_MODEL: ModelTokens = { input: 0, output: 0 };
+
+/**
+ * Aggregate per-user AI usage + cost for one month. Reads via the service-role
+ * client (bypasses RLS) — call ONLY after requireAdmin() in a Server Component.
+ */
+export async function getAdminUsage(month: string): Promise<AdminUsage> {
+  const admin = createAdminClient();
+
+  const [{ data: profiles }, { data: usage }, { data: tokens }] =
+    await Promise.all([
+      admin
+        .from('profiles')
+        .select('id, email, display_name, subscription_tier'),
+      admin
+        .from('ai_usage')
+        .select('user_id, query_type, query_count')
+        .eq('usage_month', month),
+      admin
+        .from('ai_token_usage')
+        .select('user_id, model, input_tokens, output_tokens')
+        .eq('usage_month', month),
+    ]);
+
+  const byUser = new Map<string, AdminUserUsage>();
+  for (const p of profiles ?? []) {
+    byUser.set(p.id, {
+      userId: p.id,
+      email: p.email,
+      displayName: p.display_name ?? null,
+      tier: p.subscription_tier ?? 'free',
+      chatCount: 0,
+      latexCount: 0,
+      tokensByModel: {},
+      estimatedCostUsd: 0,
+      chatQuotaPct: 0,
+    });
+  }
+
+  for (const u of usage ?? []) {
+    const row = byUser.get(u.user_id);
+    if (!row) continue;
+    if (u.query_type === 'chat') row.chatCount = u.query_count;
+    else if (u.query_type === 'latex') row.latexCount = u.query_count;
+  }
+
+  for (const t of tokens ?? []) {
+    const row = byUser.get(t.user_id);
+    if (!row) continue;
+    row.tokensByModel[t.model] = {
+      input: t.input_tokens,
+      output: t.output_tokens,
+    };
+  }
+
+  const totals: AdminUsageTotals = {
+    chatCount: 0,
+    latexCount: 0,
+    totalTokens: 0,
+    embeddingTokens: 0,
+    estimatedCostUsd: 0,
+  };
+
+  for (const row of byUser.values()) {
+    let cost = 0;
+    for (const [model, tk] of Object.entries(row.tokensByModel)) {
+      cost += estimateCostUsd(model, tk.input, tk.output);
+      totals.totalTokens += tk.input + tk.output;
+      if (model === 'embedding') totals.embeddingTokens += tk.input;
+    }
+    row.estimatedCostUsd = cost;
+    const chatLimit = resolveLimitForTier(row.tier, 'chat');
+    row.chatQuotaPct =
+      chatLimit > 0 ? Math.round((row.chatCount / chatLimit) * 100) : 0;
+
+    totals.chatCount += row.chatCount;
+    totals.latexCount += row.latexCount;
+    totals.estimatedCostUsd += cost;
+  }
+
+  // Only surface users with activity this month (sorted by cost desc — top
+  // spenders first). Zero-activity users add noise; totals already exclude them
+  // since their contribution is zero.
+  const users = [...byUser.values()]
+    .filter(
+      (u) =>
+        u.chatCount > 0 ||
+        u.latexCount > 0 ||
+        Object.keys(u.tokensByModel).length > 0,
+    )
+    .sort((a, b) => b.estimatedCostUsd - a.estimatedCostUsd);
+
+  return { users, totals };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:integration -- admin-usage`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/queries/admin-usage.ts src/lib/queries/admin-usage.integration.test.ts
+git commit -m "feat(admin): add per-user usage+cost aggregate query
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: Month selector component
+
+**Files:**
+
+- Create: `src/components/admin/month-select.tsx`
+
+- [ ] **Step 1: Implement (no unit test — thin client wrapper, covered by E2E)**
+
+Create `src/components/admin/month-select.tsx`:
+
+```tsx
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+/** Last 12 months as 'YYYY-MM', most recent first, plus any current selection. */
+function recentMonths(selected: string): string[] {
+  const months = new Set<string>([selected]);
+  const now = new Date();
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1),
+    );
+    months.add(
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`,
+    );
+  }
+  return [...months].sort().reverse();
+}
+
+export function MonthSelect({ selected }: { selected: string }) {
+  const router = useRouter();
+  return (
+    <select
+      aria-label="Usage month"
+      className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+      value={selected}
+      onChange={(e) => router.push(`/admin?month=${e.target.value}`)}
+    >
+      {recentMonths(selected).map((m) => (
+        <option key={m} value={m}>
+          {m}
+        </option>
+      ))}
+    </select>
+  );
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/admin/month-select.tsx
+git commit -m "feat(admin): add month selector component
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 13: Admin layout (gate) + dashboard page
+
+**Files:**
+
+- Create: `src/app/(admin)/admin/layout.tsx`
+- Create: `src/app/(admin)/admin/page.tsx`
+
+- [ ] **Step 1: Implement the gated layout**
+
+Create `src/app/(admin)/admin/layout.tsx`:
+
+```tsx
+import { requireAdmin } from '@/lib/auth/require-admin';
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAdmin(); // 404s for non-admins; redirects handled by middleware
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">AI Usage</h1>
+      {children}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Implement the dashboard page**
+
+Create `src/app/(admin)/admin/page.tsx`:
+
+```tsx
+import { getAdminUsage } from '@/lib/queries/admin-usage';
+import { MonthSelect } from '@/components/admin/month-select';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const dynamic = 'force-dynamic';
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function usd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function tokensFor(
+  tokensByModel: Record<string, { input: number; output: number }>,
+  model: string,
+): number {
+  const t = tokensByModel[model];
+  return t ? t.input + t.output : 0;
+}
+
+export default async function AdminUsagePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ month?: string }>;
+}) {
+  const { month } = await searchParams;
+  const selectedMonth = month ?? currentMonth();
+  const { users, totals } = await getAdminUsage(selectedMonth);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Source-of-truth usage from the token ledger. Cost is an estimate
+          (switchable via per-model price env vars).
+        </p>
+        <MonthSelect selected={selectedMonth} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Chat queries
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {totals.chatCount}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              LaTeX queries
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {totals.latexCount}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total tokens
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {totals.totalTokens.toLocaleString()}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Est. cost
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {usd(totals.estimatedCostUsd)}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium">User</th>
+              <th className="px-3 py-2 font-medium">Tier</th>
+              <th className="px-3 py-2 text-right font-medium">Chat</th>
+              <th className="px-3 py-2 text-right font-medium">LaTeX</th>
+              <th className="px-3 py-2 text-right font-medium">Flash tok</th>
+              <th className="px-3 py-2 text-right font-medium">Pro tok</th>
+              <th className="px-3 py-2 text-right font-medium">Embed tok</th>
+              <th className="px-3 py-2 text-right font-medium">Est. cost</th>
+              <th className="px-3 py-2 text-right font-medium">Chat quota</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.userId} className="border-t">
+                <td className="px-3 py-2">{u.email}</td>
+                <td className="px-3 py-2">{u.tier}</td>
+                <td className="px-3 py-2 text-right">{u.chatCount}</td>
+                <td className="px-3 py-2 text-right">{u.latexCount}</td>
+                <td className="px-3 py-2 text-right">
+                  {tokensFor(u.tokensByModel, 'flash').toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {tokensFor(u.tokensByModel, 'pro').toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {tokensFor(u.tokensByModel, 'embedding').toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {usd(u.estimatedCostUsd)}
+                </td>
+                <td
+                  className={
+                    'px-3 py-2 text-right ' +
+                    (u.chatQuotaPct >= 100
+                      ? 'font-semibold text-destructive'
+                      : u.chatQuotaPct >= 80
+                        ? 'font-medium text-amber-600'
+                        : '')
+                  }
+                >
+                  {u.chatQuotaPct}%
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Confirm the shadcn Card component exists**
+
+Run: `ls src/components/ui/card.tsx`
+Expected: file exists. If missing, run `pnpm dlx shadcn@latest add card` and commit it.
+
+- [ ] **Step 4: Typecheck + build**
+
+Run: `pnpm typecheck && pnpm build`
+Expected: PASS (route `/admin` compiles).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "src/app/(admin)"
+git commit -m "feat(admin): read-only AI usage dashboard page + gate
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 14: E2E coverage + test registry
+
+**Files:**
+
+- Modify: `e2e/TEST_REGISTRY.md`
+- Create: `e2e/admin-dashboard.spec.ts`
+
+- [ ] **Step 1: Update the test registry first**
+
+In `e2e/TEST_REGISTRY.md`, add an "Admin AI Usage Dashboard" section listing:
+
+- Admin logs in and views the usage dashboard for a seeded month (asserts totals + a seeded user row + cost).
+- Non-admin is blocked from `/admin` (404).
+
+- [ ] **Step 2: Write the E2E spec**
+
+Create `e2e/admin-dashboard.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { login, loginAs } from './helpers/auth';
+
+const ADMIN_EMAIL = process.env.ADMIN_USER_EMAIL ?? 'admin@typenote.dev';
+const ADMIN_PASSWORD = process.env.ADMIN_USER_PASSWORD ?? 'Admin1234';
+
+test.describe('Admin AI Usage Dashboard', () => {
+  test('admin sees seeded usage for a given month', async ({ page }) => {
+    await loginAs(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+
+    // Navigate to the deterministic seeded month (2099-01).
+    await page.goto('/admin?month=2099-01');
+
+    await expect(page.getByRole('heading', { name: 'AI Usage' })).toBeVisible();
+
+    // Seeded test user row is present with its email.
+    await expect(page.getByText('test@typenote.dev')).toBeVisible();
+
+    // Seeded totals: 12 chat, 30 latex. Summary cards show them.
+    await expect(page.getByText('Chat queries')).toBeVisible();
+    await expect(page.getByText('LaTeX queries')).toBeVisible();
+
+    // Seeded cost for the test user is $1.85 (see admin-usage seed).
+    await expect(page.getByText('$1.85')).toBeVisible();
+  });
+
+  test('non-admin is blocked from /admin (404)', async ({ page }) => {
+    await login(page); // seeded non-admin test@typenote.dev
+    const response = await page.goto('/admin');
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole('heading', { name: 'AI Usage' })).toHaveCount(
+      0,
+    );
+  });
+});
+```
+
+- [ ] **Step 3: Run the E2E spec**
+
+Run: `pnpm test:e2e -- admin-dashboard`
+Expected: PASS (2 tests). (Requires a DB reset so the new seed rows exist: `pnpm supabase db reset` first if the local DB predates Task 9.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add e2e/admin-dashboard.spec.ts e2e/TEST_REGISTRY.md
+git commit -m "test(e2e): admin dashboard view + non-admin lockout
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 15: Full-suite verification
+
+- [ ] **Step 1: Run the complete suite**
+
+Run: `pnpm test && pnpm test:integration && pnpm test:e2e`
+Expected: all green. (Per project memory, run a fresh `pnpm supabase db reset` beforehand so integration + E2E see the new migrations and seed rows.)
+
+- [ ] **Step 2: Lint + format + build**
+
+Run: `pnpm lint && pnpm format:check && pnpm build`
+Expected: PASS. `format:check` is a separate CI gate — run it before pushing.
+
+- [ ] **Step 3: Push and open the PR to `dev`**
+
+```bash
+git push -u origin feat/ai-usage-admin-dashboard
+gh pr create --base dev --title "feat: AI usage admin dashboard + accurate token ledger" \
+  --body "Implements docs/superpowers/specs/2026-06-04-ai-usage-admin-dashboard-design.md.
+
+- Accurate per-model token ledger (ai_token_usage) replacing the zeroed columns
+- Real token capture for chat, latex, and per-user-attributed embeddings
+- Env-overridable per-model pricing (switchable cost/token)
+- Admin-only, read-only dashboard gated by is_admin + requireAdmin()
+- Security fix: locked down the leaky admin_user_ai_usage view
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+---
+
+## Notes for the implementer
+
+- **Env vars (document in your env example / Vercel):** `AI_PRICE_FLASH_INPUT`, `AI_PRICE_FLASH_OUTPUT`, `AI_PRICE_PRO_INPUT`, `AI_PRICE_PRO_OUTPUT`, `AI_PRICE_EMBEDDING`. All optional; defaults are approximate Gemini prices.
+- **Prod:** the admin user is seeded for local/CI only. In production, set `is_admin=true` on the real owner account via SQL once.
+- **AI E2E has no Gemini key in CI** — the dashboard E2E deliberately asserts against _seeded_ rows, never live AI calls.
+- **Worktree Supabase:** if running in an isolated worktree with its own stack, source the worktree env (`.env.worktree.sh`) before `supabase`/test commands.

--- a/docs/superpowers/specs/2026-06-04-ai-usage-admin-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-04-ai-usage-admin-dashboard-design.md
@@ -1,0 +1,241 @@
+# AI Usage Admin Dashboard — Design
+
+**Date:** 2026-06-04
+**Status:** Approved design, pending implementation plan
+**Scope:** One combined PR (ledger accuracy + admin auth + read-only dashboard + a security fix)
+
+## 1. Problem & Goal
+
+We have no first-party, accurate, _named_ view of AI usage and cost. We need
+observability over: AI generation usage (chat + LaTeX), token consumption, an
+estimated dollar cost, per-user quota state, and embedding usage — plus the
+foundation to add controls later.
+
+PostHog (already integrated) is the analytics/exploration layer (trends, traces,
+latency, per-model charts). It deliberately **cannot** answer the operational
+questions this dashboard targets, because:
+
+- Per project rules it receives **no PII** — so it only knows UUIDs, never "who
+  by email is my top spender."
+- It is sampled / eventually-consistent / ad-blockable — fine for trends, wrong
+  for a source-of-truth count.
+- It cannot JOIN to our Postgres domain data (courses, profiles, quotas).
+
+So this dashboard is the **named, accurate, source-of-truth operational view**.
+Historical trend charts are explicitly **out of scope** — PostHog wins those for
+free and we will not rebuild them.
+
+### Division of responsibility
+
+| Concern                                             | Home                  | Why                                           |
+| --------------------------------------------------- | --------------------- | --------------------------------------------- |
+| Trends, latency, traces, per-model charts           | PostHog LLM Analytics | Free, exploratory, time-series                |
+| Exact per-named-user usage, cost, quota %, controls | This dashboard        | Accurate, named, joined to domain, actionable |
+
+## 2. Current State (verified against code)
+
+- `ai_usage` table (`supabase/migrations/00016`, `00018`): one row per
+  `(user_id, usage_month, query_type)`. `query_type ∈ {chat, latex}` today
+  (no CHECK constraint — values are app-enforced). `query_count` drives
+  rate-limiting via the atomic `increment_ai_usage` RPC.
+- `00018` added `total_input_tokens` / `total_output_tokens` columns and a
+  `record_token_usage` RPC — but the RPC is **UPDATE-only**, and the ask route
+  calls `recordTokenUsage(user.id, 'chat', 0, 0)`
+  (`src/app/api/ai/ask/route.ts:382`). **Result: those columns are all zeros.**
+- `00018` created `admin_user_ai_usage` as a plain VIEW (no `security_invoker`,
+  no `REVOKE`) that joins every user's `email`. **Likely RLS-bypass leak** via
+  the auto-generated REST API. Pre-existing; fixed here.
+- Embeddings (`src/lib/ai/embeddings.ts`) call `embedContent` and record
+  **nothing**. On the Gemini **Developer API** the embedding response has **no
+  token field** (token stats are Vertex-only) — so embedding tokens must be
+  **estimated**, not read.
+- No `is_admin` concept, no `/admin` route. `createAdminClient()`
+  (`src/lib/supabase/admin.ts`) provides a service-role client.
+- Middleware (`src/lib/supabase/middleware.ts`) redirects unauthenticated users
+  off non-auth pages to `/login`, and redirects authenticated users _away_ from
+  auth pages.
+- Seed has `test@typenote.dev` and `test-b@typenote.dev`; no admin user.
+
+## 3. Architecture
+
+Three layers, built bottom-up so numbers are real before they are drawn. One PR.
+
+### Layer 1 — Accurate token/cost ledger
+
+**New table `ai_token_usage`** — the cost ledger, separate from the rate-limit
+ledger (single responsibility: `ai_usage` counts queries for quotas;
+`ai_token_usage` accounts tokens for cost).
+
+```
+ai_token_usage(
+  id            bigserial pk,
+  user_id       uuid not null references auth.users(id) on delete cascade,
+  usage_month   text not null default to_char(CURRENT_DATE,'YYYY-MM'),
+  model         text not null,          -- 'flash' | 'pro' | 'embedding'
+  input_tokens  bigint not null default 0,
+  output_tokens bigint not null default 0,
+  created_at    timestamptz not null default now(),
+  updated_at    timestamptz not null default now()
+)
+unique (user_id, usage_month, model)
+```
+
+- RLS: users may SELECT their own rows (mirrors `ai_usage`). Admin reads bypass
+  RLS via service-role behind the `requireAdmin()` gate (§Layer 2).
+- `updated_at` trigger reuses `handle_updated_at`.
+
+**New RPC `record_token_usage(p_user_id, p_model, p_input, p_output)`** — an
+**UPSERT** into `ai_token_usage` (INSERT … ON CONFLICT DO UPDATE adding to the
+running totals). Replaces the old UPDATE-only RPC. Per-model keying eliminates
+the lossy `last_model` problem (a user mixing Flash + Pro is priced correctly).
+
+**Token capture:**
+
+- `src/app/api/ai/ask/route.ts`: after the stream completes, read generation
+  token counts from the final chunk's `usageMetadata` **if present**, else fall
+  back to a char-based estimate (never record zeros again). Record under the
+  real model (`'flash'` for quick, `'pro'` for deep).
+- `src/app/api/ai/latex/route.ts`: record under `'flash'`.
+- `src/lib/ai/embeddings.ts`: `embedText`/`embedQuery` return
+  `{ values, tokens }` where `tokens` is an **estimate** (`ceil(chars / 4)`;
+  chunking already targets ~1600 chars ≈ ~400 tokens).
+- `src/lib/actions/ai-context.ts`: at the two embed call sites
+  (`indexContent` ~L296, `searchContext` ~L358) record estimated embedding
+  tokens under model `'embedding'`. **Full observability — every embed is
+  attributed:**
+  - `course_material` / `personal_file`: attributed to the authenticated owner
+    (already in scope as `userId`).
+  - `searchContext`: attributed to the searching user.
+  - `moodle_file`: the stored embedding row stays **shared** (`user_id = null`,
+    so retrieval works for everyone), but the **cost** is attributed to the user
+    who _triggered_ the one-time embed. The triggering user id is threaded in
+    from the authenticated Moodle API routes (`/api/moodle/upload`,
+    `upload-finalize`, `import-existing`) via a new field on the `moodle_file`
+    `IndexSource`. **Artifact ownership and cost attribution are separate
+    concerns** (interview point): the vector is shared; the cost belongs to
+    whoever caused it.
+  - **Dedup means embed-once:** the content-hash check (`ai-context.ts:254`) and
+    the `getContentHash` guard in `import-existing` skip already-embedded files,
+    so a Moodle file is embedded exactly once — by the first importer — and
+    later importers incur **zero** embed cost. Attributing to the first importer
+    is therefore both complete and fair.
+
+**Pricing** — `src/lib/ai/pricing.ts`: per-1M-token prices per model
+(`flash`, `pro`, `embedding`) and direction (input/output). **Prices must be
+switchable without a code change**, so each is **env-overridable** with a
+sensible default, mirroring the existing rate-limit pattern
+(`AI_LIMIT_*` / `AI_LATEX_LIMIT_*` in `rate-limit.ts`): e.g.
+`AI_PRICE_FLASH_INPUT`, `AI_PRICE_FLASH_OUTPUT`, `AI_PRICE_PRO_INPUT`,
+`AI_PRICE_PRO_OUTPUT`, `AI_PRICE_EMBEDDING`. Cost is computed in app code:
+`Σ over models (tokens × price)`. **Tokens are the primary, accurate metric;
+the dollar figure is a switchable estimate derived from them** and is labeled as
+such in the UI.
+
+**Cleanup:** drop the now-superseded `total_input_tokens` /
+`total_output_tokens` columns from `ai_usage` (only ever held zeros).
+
+### Layer 2 — Admin authorization
+
+**Best practice: one auth system, authorization by role.** No separate admin
+credentials/login (that fragments auth and doubles attack surface). Concretely:
+
+- Migration: `ALTER TABLE profiles ADD COLUMN is_admin boolean NOT NULL DEFAULT false`.
+- Flip `is_admin=true` for the admin account via SQL (and the seed for local/CI).
+- Admin signs in through the existing `/login`.
+- `requireAdmin()` helper (server-only): `getUser()` → load `profiles.is_admin`
+  → if not admin, `notFound()` (404-feel: the area isn't discoverable). Used in
+  the `/admin` server layout, so it gates every nested admin page.
+- Dashboard data is read in **Server Components** via `createAdminClient()`
+  (service-role), reached **only after** `requireAdmin()` passes, and never
+  passed raw to client components (see "heavy props to client components"
+  guidance — pass derived rows only). Defense in depth: authz gate first,
+  privileged read second, server-only throughout.
+- Future hardening lever (out of scope): MFA / step-up auth on admin _actions_.
+
+**Authentication vs authorization (interview point):** Supabase proves _who you
+are_; `is_admin` decides _what you may do_. Keeping them separate is the pattern.
+
+### Layer 3 — Read-only dashboard at `/admin`
+
+- **Summary cards (current month):** total chat queries, total latex queries,
+  total tokens, **estimated total cost**, embedding tokens + estimated cost.
+- **Per-user table:** email, display name, tier, chat count, latex count,
+  per-model tokens (Flash/Pro/embedding input+output), **estimated cost**,
+  **% of chat quota used** (rows near/over the cap highlighted). Sorted by
+  estimated cost desc — top spenders first.
+- **Month selector:** defaults to current `usage_month`.
+- Data assembled server-side: join `ai_token_usage` (cost) + `ai_usage`
+  (counts/quota) + `profiles` (identity/tier), aggregated per user for the
+  selected month.
+
+### Security fix (folded in)
+
+Recreate `admin_user_ai_usage` `WITH (security_invoker = true)` and `REVOKE`
+SELECT from `anon`/`authenticated`, closing the cross-user email/usage leak.
+The recreated view **omits** the dropped `total_input_tokens` /
+`total_output_tokens` columns (token/cost now lives in `ai_token_usage`); it
+keeps identity + query-count fields for ad-hoc SQL. The dashboard itself does
+not depend on this view (it aggregates the base tables server-side), so locking
+it down is safe.
+
+## 4. Data Flow
+
+1. User asks a question → ask route runs `increment_ai_usage` (quota, fail-closed)
+   → streams answer → on completion records **real** tokens via
+   `record_token_usage(user, model, input, output)` (fire-and-forget, never
+   throws).
+2. User imports a file / searches → embedding tokens estimated → recorded under
+   model `embedding`, attributed to the triggering user (Moodle: the first
+   importer who caused the one-time embed; the vector itself stays shared).
+3. Admin visits `/admin` → middleware lets the logged-in user through →
+   `requireAdmin()` confirms `is_admin` → Server Component reads + aggregates via
+   service-role → renders cards + table. No state changes.
+
+## 5. Error Handling
+
+- Token recording is **fire-and-forget** and never throws — a metrics write
+  failure must never fail a user's AI answer. (Rate-limit check, by contrast,
+  fails **closed**. Opposite choices, both correct: enforcement must not leak
+  free usage; observability must not break the product.)
+- `requireAdmin()` failure → `notFound()` (not a redirect to a login that the
+  user is already past).
+- Missing/زero token data renders as `0` / `$0.00`, not an error.
+
+## 6. Testing
+
+- **Unit:** `pricing.ts` math (per-model sums); `usageMetadata` extraction +
+  char-estimate fallback; `requireAdmin` allow/deny logic; embedding token
+  estimate.
+- **Integration:** `record_token_usage` upsert creates and then accumulates
+  per-model rows; chat/latex/embedding stay correctly separated; the per-user
+  aggregate query returns correct sums against seeded data; RLS denies a normal
+  user reading another user's `ai_token_usage`.
+- **E2E (Playwright, real flows):** CI has no Gemini key and debug mode records
+  zeros, so the dashboard E2E **seeds `ai_token_usage` + `ai_usage` rows with
+  known values** and an admin user, then:
+  - admin logs in via the shared `e2e/helpers/auth.ts` helper → opens `/admin` →
+    sees expected totals, per-user rows, and cost;
+  - a non-admin (`test@typenote.dev`) is blocked from `/admin` (404-feel).
+  - Update `e2e/TEST_REGISTRY.md` first.
+- Seeding an admin requires an `auth.users` + `auth.identities` block (mirroring
+  the existing seed users) plus `is_admin=true`; `is_admin` migration must
+  precede the seed reference.
+
+## 7. Out of Scope (YAGNI / deferred)
+
+- Write-controls (change tier, reset quota, global AI kill switch) — a focused
+  follow-up once the numbers are trusted.
+- Historical trend charts / per-model time series — PostHog covers these free.
+- All-time cost rollup, alerting, MFA/step-up — deferred.
+
+## 8. Known Limitations
+
+- Embedding token counts are **estimates** (Developer API exposes none) — this
+  is accepted; tokens are the metric we care about and the estimate is close.
+- Dollar cost is a **derived, switchable estimate** (env-overridable per-model
+  prices). Per-model keying makes it accurate to the model mix; the only
+  inaccuracy is drift between configured and actual published prices, which the
+  env override exists to correct.
+- Moodle embedding cost is attributed to the _first importer_ (who triggered the
+  one-time embed), not split across later reusers — by design, since reuse is
+  free.

--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -21,6 +21,8 @@ When adding or modifying a feature, update this registry and write the correspon
 - [x] Unauthenticated user is redirected to login
 - [x] Login page still shows both email/password and Google options
 - [x] Privacy policy (`/privacy`) is publicly reachable while logged out (required for Chrome Web Store review)
+- [x] OAuth callback without code redirects to login with error message
+- [x] Login page shows error message when redirected with session_exchange_failed error
 
 ---
 
@@ -32,7 +34,6 @@ When adding or modifying a feature, update this registry and write the correspon
 - [x] Delete document with confirmation dialog
 - [x] Document appears in correct folder
 - [x] Move document to different folder/course
-- [x] Create document dialog has no subject selector (subject removed at creation)
 
 ---
 
@@ -113,18 +114,6 @@ Follow-up to issue #118. Guards against cursor jumps when a multi-page overflow 
 
 ---
 
-## Flat Course Page — Materials Layout (`e2e/course-materials.spec.ts`) — IMPLEMENTED
-
-Covers the Phase 1 refactor that removed the "Weeks" model and replaced it with a flat
-**Documents + Materials** layout on the course page.
-
-- [x] No "Weeks" heading is present on the course page (flat layout confirmed)
-- [x] A "Materials" heading IS visible (seeded `course_materials` + `personal_files` shown)
-- [x] Imported personal files appear under the Materials section
-- [x] Moodle materials section is present without crashing (lazy-loaded on demand)
-
----
-
 ## File Upload (`e2e/file-upload.spec.ts`) — IMPLEMENTED
 
 - [x] Import file into course (PDF upload)
@@ -141,7 +130,6 @@ Covers the Phase 1 refactor that removed the "Weeks" model and replaced it with 
 - [x] Chat renders markdown in responses — ⚠️ SKIPPED IN CI (needs AI API key)
 - [x] Start new conversation — ⚠️ SKIPPED IN CI
 - [x] Switch between conversations — ⚠️ SKIPPED IN CI
-- [x] Course page: chat panel docks to the right edge, not inline in the toolbar — ⚠️ SKIPPED IN CI (needs course page)
 
 ---
 
@@ -200,30 +188,6 @@ context-menu entry point works end-to-end.
 
 ---
 
-## ~~Homework-focused AI context (Phase 2)~~ — REMOVED
-
-The Start Homework feature (dialog, sessions, context chip, AI plumbing) has been removed
-and replaced by the Document Context Files feature. The spec file
-`e2e/homework-ai-context.spec.ts` and all associated source files have been deleted.
-
----
-
-## Document Focus Files (`e2e/document-context-files.spec.ts`) — IMPLEMENTED
-
-Covers the labeled **Focus files** toolbar button (`focus-files-toggle`), the panel, the
-**Add files dialog** (`add-files-dialog`, grouped multi-select with `context-files-candidate`
-rows and an "Add N files" confirm), attachment/detachment, the file viewer overlay, and the
-AI citation → viewer flow. Mocks `/api/ai/ask` with an SSE stub for the citation test so no
-live Gemini key is required.
-
-- [x] "Start Homework" button is absent on the course page (regression gate for removal)
-- [x] Open the panel from the toolbar button → add a file via the dialog (tick candidate → "Add 1 file") → detach it with the Remove button
-- [x] Click an attached focus-file item opens the file viewer (`file-viewer`); close it
-- [x] Mocked AI response with a source citation renders an `ai-citation` button that opens the viewer
-- [x] Focus files can be added from inside the AI chat (`chat-focus-files` control → `chat-focus-add` → dialog → chip appears as `chat-focus-chip`)
-
----
-
 ## Version History (`e2e/version-history.spec.ts`) — PLANNED
 
 - [ ] Open version history sidebar from canvas editor toolbar
@@ -270,60 +234,38 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 
 ---
 
-## Course Sharing (`e2e/sharing.spec.ts`) — IMPLEMENTED
+## Admin AI Usage Dashboard (`e2e/admin-dashboard.spec.ts`) — IMPLEMENTED
 
-- [x] Contributor link: member joins, sees materials, uploads a file, owner sees it
-- [x] Viewer link: member cannot see upload controls
-- [x] Leave: member removes course from list; course persists for owner
-- [x] Shared course appears in the member's left sidebar tree (under "Shared with me"), not only the dashboard cards
-- [ ] Privacy: member's note in a shared course is invisible to the owner (covered by integration tests; E2E optional)
-- [ ] AI: member's chat cites an owner-uploaded file (needs Gemini key; covered by integration + manual)
+Covers the admin-only `/admin` AI usage dashboard (token-ledger aggregation + cost estimate). The route is in the `(admin)` group whose layout calls `requireAdmin()`, which `notFound()`s for non-admins. Uses the seeded admin user (`admin@typenote.dev`) and the deterministic month `2099-01` (test user: chat=12, latex=30, flash 1M/0.5M tokens, embedding 2M tokens → estimated cost `$1.85`).
 
----
-
-## Evidence Citations (`e2e/evidence-citations.spec.ts`) — IMPLEMENTED
-
-Covers the **jump-to-source** payoff of the evidence-citations feature (Phase 2):
-sending an AI chat message surfaces a clickable citation badge that opens the
-in-app file viewer. The AI endpoint has a page.route SSE stub, but the app's PWA
-service worker + the route's server-side `AI_RATE_LIMIT_DEBUG` path mean the AI
-response _body_ can't be reliably mock-driven in CI, so this E2E asserts only the
-browser-level behavior. The answer-content guarantees are unit-tested instead:
-the verbatim blockquote in `src/components/ai/__tests__/markdown-response.test.tsx`
-and the per-`(source, page)` `p. N` citation in
-`src/lib/actions/__tests__/ai-context.test.ts`.
-
-- [x] Sending a chat message surfaces a citation badge (`data-testid="ai-citation"`)
-- [x] Clicking the citation badge opens the file viewer (`data-testid="file-viewer"`) — the jump-to-source behavior only a browser can verify
+- [x] Admin logs in and views the dashboard for `/admin?month=2099-01` — asserts the "AI Usage" heading, the seeded test user's email row, the "Chat queries"/"LaTeX queries" summary cards, and the seeded `$1.85` cost
+- [x] Admin sees the "AI Usage" sidebar nav link and reaches the dashboard by clicking it
+- [x] Non-admin (`test@typenote.dev`) is blocked from `/admin` — HTTP 404, and the admin-only "AI Usage" nav link does not render
 
 ---
 
 ## Summary
 
-| Feature               | Status      | Spec File                                | Tests      |
-| --------------------- | ----------- | ---------------------------------------- | ---------- |
-| Auth                  | Implemented | `e2e/auth.spec.ts`                       | 7/7        |
-| Documents             | Implemented | `e2e/documents.spec.ts`                  | 6/6        |
-| Canvas Editor         | Implemented | `e2e/canvas-editor.spec.ts`              | 15/15      |
-| Text Editor Toolbar   | Implemented | `e2e/editor-toolbar.spec.ts`             | 12/12      |
-| LaTeX Math            | Implemented | `e2e/latex-math.spec.ts`                 | 5/5        |
-| Courses               | Implemented | `e2e/courses.spec.ts`                    | 5/6        |
-| Flat Course Page      | Implemented | `e2e/course-materials.spec.ts`           | 3/3        |
-| File Upload           | Implemented | `e2e/file-upload.spec.ts`                | 3/4        |
-| AI Chat               | Implemented | `e2e/ai-chat.spec.ts`                    | 7/7        |
-| AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2        |
-| PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`               | 6/7        |
-| Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`              | 3/3        |
-| Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`         | 8/8        |
-| Moodle Ext Gating     | Implemented | `e2e/moodle-touch-gating.spec.ts`        | 2/2        |
-| Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`             | 3/3        |
-| Document Focus Files  | Implemented | `e2e/document-context-files.spec.ts`     | 5/5        |
-| Evidence Citations    | Implemented | `e2e/evidence-citations.spec.ts`         | 1/1        |
-| Homework AI Context   | Removed     | (deleted)                                | —          |
-| Version History       | Planned     | `e2e/version-history.spec.ts`            | 0/5        |
-| PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts`      | 8/8        |
-| Course Sharing        | Implemented | `e2e/sharing.spec.ts`                    | 4/6        |
-| **Total**             |             |                                          | **97/107** |
+| Feature               | Status      | Spec File                                | Tests       |
+| --------------------- | ----------- | ---------------------------------------- | ----------- |
+| Auth                  | Implemented | `e2e/auth.spec.ts`                       | 9/9         |
+| Documents             | Implemented | `e2e/documents.spec.ts`                  | 6/6         |
+| Canvas Editor         | Implemented | `e2e/canvas-editor.spec.ts`              | 15/15       |
+| Text Editor Toolbar   | Implemented | `e2e/editor-toolbar.spec.ts`             | 12/12       |
+| LaTeX Math            | Implemented | `e2e/latex-math.spec.ts`                 | 5/5         |
+| Courses               | Implemented | `e2e/courses.spec.ts`                    | 5/6         |
+| File Upload           | Implemented | `e2e/file-upload.spec.ts`                | 3/4         |
+| AI Chat               | Implemented | `e2e/ai-chat.spec.ts`                    | 6/6         |
+| AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2         |
+| PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`               | 6/7         |
+| Real-time Sync        | Implemented | `e2e/realtime-sync.spec.ts`              | 3/3         |
+| Drawing Copy/Paste    | Implemented | `e2e/drawing-copy-paste.spec.ts`         | 8/8         |
+| Moodle Ext Gating     | Implemented | `e2e/moodle-touch-gating.spec.ts`        | 2/2         |
+| Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`             | 3/3         |
+| Version History       | Planned     | `e2e/version-history.spec.ts`            | 0/5         |
+| PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts`      | 8/8         |
+| Admin AI Usage        | Implemented | `e2e/admin-dashboard.spec.ts`            | 3/3         |
+| **Total**             |             |                                          | **102/112** |
 
 ---
 

--- a/e2e/admin-dashboard.spec.ts
+++ b/e2e/admin-dashboard.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { login, loginAs } from './helpers/auth';
+
+const ADMIN_EMAIL = process.env.ADMIN_USER_EMAIL ?? 'admin@typenote.dev';
+const ADMIN_PASSWORD = process.env.ADMIN_USER_PASSWORD ?? 'Admin1234';
+
+test.describe('Admin AI Usage Dashboard', () => {
+  test('admin sees seeded usage for a given month', async ({ page }) => {
+    await loginAs(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+
+    // Navigate to the deterministic seeded month (2099-01).
+    await page.goto('/admin?month=2099-01');
+
+    await expect(page.getByRole('heading', { name: 'AI Usage' })).toBeVisible();
+
+    // Seeded test user row is present with its email.
+    await expect(page.getByText('test@typenote.dev')).toBeVisible();
+
+    // Summary cards present.
+    await expect(page.getByText('Chat queries')).toBeVisible();
+    await expect(page.getByText('LaTeX queries')).toBeVisible();
+
+    // Seeded cost for the test user is $1.95 (see admin-usage seed:
+    // flash 0.30+1.25 + embedding 2M*0.20=0.40). $1.95 appears in both the
+    // "Est. cost" summary card and the user's table row (the test user is the
+    // only one with activity, so the total equals the row), which trips strict
+    // mode — scope to the table cell for the per-user value.
+    await expect(page.getByRole('cell', { name: '$1.95' })).toBeVisible();
+  });
+
+  test('admin sees the AI Usage nav link and can reach the dashboard from it', async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    // login lands on /dashboard; the admin-only sidebar link is present.
+    const navLink = page.getByRole('link', { name: 'AI Usage' });
+    await expect(navLink).toBeVisible();
+    await navLink.click();
+    await expect(page).toHaveURL(/\/admin/);
+    await expect(page.getByRole('heading', { name: 'AI Usage' })).toBeVisible();
+  });
+
+  test('non-admin is blocked from /admin (404) and has no nav link', async ({
+    page,
+  }) => {
+    await login(page); // seeded non-admin test@typenote.dev
+    // The admin-only nav link must not render for non-admins.
+    await expect(page.getByRole('link', { name: 'AI Usage' })).toHaveCount(0);
+
+    const response = await page.goto('/admin');
+    expect(response?.status()).toBe(404);
+    await expect(page.getByRole('heading', { name: 'AI Usage' })).toHaveCount(
+      0,
+    );
+  });
+});

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -88,6 +88,29 @@ test.describe('Auth', () => {
     ).toBeVisible();
   });
 
+  test('OAuth callback without code redirects to login with error message', async ({
+    page,
+  }) => {
+    // Navigate directly to the callback route without an authorization code.
+    // This simulates a broken OAuth redirect (e.g., PKCE cookie lost on Safari).
+    await page.goto('/auth/callback');
+
+    // Should redirect to /login with an error parameter
+    await expect(page).toHaveURL(/\/login\?error=no_code/, { timeout: 10_000 });
+    await expect(page.locator('p[role="alert"]')).toBeVisible();
+  });
+
+  test('login page shows error message when redirected with session_exchange_failed error', async ({
+    page,
+  }) => {
+    await page.goto('/login?error=session_exchange_failed');
+
+    const alert = page.locator('p[role="alert"]');
+    await expect(alert).toBeVisible();
+    await expect(alert).toContainText(/sign-in failed/i);
+    await expect(alert).toContainText(/clearing your browser cookies/i);
+  });
+
   test('forgot password shows confirmation message', async ({ page }) => {
     await page.goto('/forgot-password');
 

--- a/specs/048-fix-ipad-google-auth/checklists/requirements.md
+++ b/specs/048-fix-ipad-google-auth/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Fix iPad Google OAuth Sign-In
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumption: "PKCE" and "Intelligent Tracking Prevention" are referenced as context for the bug's root cause, not as implementation prescriptions — the spec describes WHAT must work, not HOW to fix it.

--- a/specs/048-fix-ipad-google-auth/data-model.md
+++ b/specs/048-fix-ipad-google-auth/data-model.md
@@ -1,0 +1,50 @@
+# Data Model: Fix iPad Google OAuth Sign-In
+
+**Feature**: 048-fix-ipad-google-auth
+**Date**: 2026-05-27
+
+## Overview
+
+This is a client-side bug fix with no database schema changes. All relevant entities already exist.
+
+## Existing Entities (No Changes)
+
+### auth.users (Supabase managed)
+
+The user record created by Supabase Auth. Google OAuth populates `raw_user_meta_data` with `name`, `avatar_url`, and `email`.
+
+- `id` (UUID) — primary key
+- `email` (text) — from Google account
+- `raw_user_meta_data` (JSONB) — `{ name, avatar_url, email, ... }`
+- `app_metadata` (JSONB) — contains `provider: "google"` for OAuth users
+
+### profiles (public schema)
+
+Created by the `handle_new_user` database trigger when a new `auth.users` row is inserted.
+
+- `id` (UUID) — FK to `auth.users.id`
+- `name` (text) — extracted from `raw_user_meta_data.name`
+- `avatar_url` (text) — extracted from `raw_user_meta_data.avatar_url`
+
+### documents (public schema)
+
+User documents — keyed by `user_id`. When a new Google OAuth user is created, they have zero documents (empty workspace).
+
+## State Transitions
+
+```
+User taps "Sign up/in with Google"
+  → [Client] signInWithOAuth generates PKCE verifier + stores in cookie
+  → [Client] Browser redirects to Google OAuth consent screen
+  → [Google] User selects account, Google redirects to GoTrue
+  → [GoTrue] Exchanges Google token, redirects to /auth/callback?code=XXX
+  → [Server] /auth/callback reads PKCE cookie, calls exchangeCodeForSession
+  → [Server] Session established, redirect to /dashboard
+  → [Client] Dashboard loads with user's documents
+```
+
+**Failure mode (current bug)**: If the PKCE cookie is lost OR the redirect doesn't reach Google, the flow breaks at various points, leading to authentication failure or a new empty user being created.
+
+## No Migrations Required
+
+This fix is purely client-side (OAuth flow changes) and potentially Supabase config changes (`enable_manual_linking`). No new tables, columns, or database triggers are needed.

--- a/specs/048-fix-ipad-google-auth/plan.md
+++ b/specs/048-fix-ipad-google-auth/plan.md
@@ -1,0 +1,80 @@
+# Implementation Plan: Fix iPad Google OAuth Sign-In
+
+**Branch**: `048-fix-ipad-google-auth` | **Date**: 2026-05-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/048-fix-ipad-google-auth/spec.md`
+
+## Summary
+
+Fix Google OAuth sign-in/sign-up on iPad Safari. The current async `signInWithOAuth` call may not redirect reliably on Safari due to the redirect happening outside the synchronous user-gesture call stack. Additionally, if PKCE cookies are lost during the redirect chain, the callback fails silently. The fix uses `skipBrowserRedirect: true` to get the OAuth URL synchronously, then manually assigns `window.location.href` within the tap handler. The callback route error handling is also improved to prevent silent failures.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5 / Node.js 22+
+**Primary Dependencies**: Next.js 16 (App Router), React 19, @supabase/ssr, @supabase/supabase-js
+**Storage**: N/A — no schema changes, client-side only
+**Testing**: Vitest (unit), Playwright (E2E)
+**Target Platform**: Web — all browsers, with specific focus on iPad Safari (iPadOS 17+)
+**Project Type**: Web application (Next.js)
+**Performance Goals**: N/A — bug fix
+**Constraints**: Must work with Safari's default ITP privacy settings without requiring user configuration changes
+**Scale/Scope**: 4 files modified, ~50 lines changed
+
+## Constitution Check
+
+_GATE: Must pass before Phase 0 research. Re-check after Phase 1 design._
+
+| Principle                       | Status | Notes                                                                                                                                               |
+| ------------------------------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| I. Incremental Development      | PASS   | Bug fix on existing auth infrastructure. No new features being added before foundations.                                                            |
+| II. Test-Driven Quality         | PASS   | Will write a failing test first (callback error handling), then fix. Unit tests for both auth pages. E2E test for Google OAuth flow where possible. |
+| III. Protected Branches         | PASS   | Working on feature branch `048-fix-ipad-google-auth` off `dev`. Will PR to `dev`.                                                                   |
+| IV. Migrations as Code          | PASS   | No database changes needed.                                                                                                                         |
+| V. Interview-Ready Architecture | PASS   | OAuth PKCE flow, Safari ITP, and cross-browser compatibility are relevant interview topics.                                                         |
+
+**Post-Phase 1 Re-check**: All gates still pass. No new complexity introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/048-fix-ipad-google-auth/
+├── plan.md              # This file
+├── spec.md              # Feature specification
+├── research.md          # Root cause analysis and solutions
+├── data-model.md        # Entity documentation (no changes)
+├── quickstart.md        # Development setup guide
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Task breakdown (created by /speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── app/
+│   ├── (auth)/
+│   │   ├── login/
+│   │   │   ├── page.tsx          # Google login button — fix OAuth redirect
+│   │   │   └── page.test.tsx     # Update test for new redirect pattern
+│   │   └── signup/
+│   │       ├── page.tsx          # Google signup button — fix OAuth redirect
+│   │       └── page.test.tsx     # Update test for new redirect pattern
+│   └── auth/
+│       └── callback/
+│           ├── route.ts          # Improve PKCE error handling
+│           └── route.test.ts     # Add test for PKCE failure scenario
+└── lib/
+    └── supabase/
+        └── middleware.ts         # Verify OAuth error handling (read-only)
+
+e2e/
+└── google-auth-safari.spec.ts    # E2E tests (limited — can't test real Google OAuth)
+```
+
+**Structure Decision**: Existing Next.js App Router structure. All changes are in existing files except one potential new E2E test file.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/048-fix-ipad-google-auth/quickstart.md
+++ b/specs/048-fix-ipad-google-auth/quickstart.md
@@ -1,0 +1,55 @@
+# Quickstart: Fix iPad Google OAuth Sign-In
+
+**Feature**: 048-fix-ipad-google-auth
+**Date**: 2026-05-27
+
+## Prerequisites
+
+- Node.js 22+, pnpm
+- Supabase CLI with `supabase start` running
+- An iPad or iPad Simulator (Xcode) for testing Safari
+- Google OAuth credentials configured (see `.env.local`)
+
+## Local Development
+
+```bash
+# 1. Start local Supabase
+supabase start
+
+# 2. Start dev server
+pnpm dev
+
+# 3. Open in iPad Safari (or Safari simulator)
+# Navigate to http://<your-local-ip>:3000/signup
+```
+
+## Key Files to Modify
+
+| File                             | Change                                             |
+| -------------------------------- | -------------------------------------------------- |
+| `src/app/(auth)/signup/page.tsx` | Fix Google OAuth redirect for Safari compatibility |
+| `src/app/(auth)/login/page.tsx`  | Same Safari-compatible redirect fix                |
+| `src/app/auth/callback/route.ts` | Improve error handling for PKCE failures           |
+| `src/lib/supabase/middleware.ts` | Verify OAuth error redirect handling               |
+
+## Testing on iPad
+
+1. **Real iPad**: Connect to same network, use `http://<mac-ip>:3000`
+2. **Xcode Simulator**: Open Safari in iPad simulator, navigate to `http://localhost:3000`
+3. **Safari Remote Debugging**: Enable in iPad Settings → Safari → Advanced → Web Inspector, then use Safari DevTools on Mac to debug
+
+## Test Scenarios
+
+1. Tap "Sign up with Google" → Google account picker appears
+2. Select Google account → Redirected to dashboard with session
+3. Sign out → Sign in with Google on login page → Same behavior
+4. Cancel Google consent → Return to signup page without errors
+5. Test on desktop Chrome to ensure no regression
+
+## Running Tests
+
+```bash
+pnpm test          # Unit tests
+pnpm test:integration  # Integration tests
+pnpm test:e2e      # E2E browser tests
+```

--- a/specs/048-fix-ipad-google-auth/research.md
+++ b/specs/048-fix-ipad-google-auth/research.md
@@ -1,0 +1,76 @@
+# Research: Fix iPad Google OAuth Sign-In
+
+**Feature**: 048-fix-ipad-google-auth
+**Date**: 2026-05-27
+
+## Research Tasks
+
+### 1. Root Cause Analysis: iPad Safari OAuth Failure
+
+**Decision**: The issue has two likely root causes that must both be addressed:
+
+1. **Safari async redirect blocking**: The `handleGoogleSignup` / `handleGoogleLogin` functions are `async`. When `signInWithOAuth` is called, the Supabase JS SDK internally calls `window.location.assign()` after an `await` boundary. iPad Safari's popup/redirect blocker may treat this as "not user-initiated" because the redirect happens outside the synchronous call stack of the tap event. This can cause the redirect to silently fail or behave unpredictably.
+
+2. **PKCE code verifier loss on Safari**: `@supabase/ssr`'s `createBrowserClient` stores PKCE code verifiers in cookies via `document.cookie`. Safari's ITP (Intelligent Tracking Prevention) can interfere with cookie persistence during the OAuth redirect round-trip, especially when the redirect chain crosses domains (app → Google → Supabase GoTrue → app). If the code verifier cookie is lost, `exchangeCodeForSession` in the callback route fails, and the user gets redirected to `/login?error=auth_failed`.
+
+3. **"New user with no data" symptom**: This may indicate the user's existing account was created via email/password, and the Google OAuth creates a SEPARATE Supabase user (different `auth.users` row). Since `enable_manual_linking = false` in `config.toml`, accounts with different providers are not automatically linked. The user lands on the dashboard with an empty workspace because the new Google user has no documents.
+
+**Rationale**: All three factors must be investigated. The middleware already handles `bad_oauth_state` errors (line 43-51 of `middleware.ts`), suggesting OAuth state issues have been encountered before. The `skip_nonce_check = true` setting for Google in `config.toml` also suggests previous Safari/mobile compatibility work.
+
+**Alternatives considered**:
+
+- Switching to implicit flow instead of PKCE — rejected because PKCE is more secure and is the recommended flow for browser clients.
+- Using a popup instead of redirect — rejected because Safari blocks popups even more aggressively than redirects.
+
+### 2. Safari-Compatible OAuth Redirect Pattern
+
+**Decision**: Ensure the `signInWithOAuth` redirect happens synchronously within the user gesture's call stack, or use `window.location.href` assignment directly with the OAuth URL.
+
+**Rationale**: Safari's redirect blocker is strict about user-initiated navigation. The fix should either:
+
+- Use `skipBrowserRedirect: true` on `signInWithOAuth` to get the OAuth URL without redirecting, then assign `window.location.href` directly in the synchronous click handler
+- Or ensure no `await` happens before the redirect
+
+The `skipBrowserRedirect: true` approach is documented in Supabase's official docs for handling OAuth in environments where automatic redirects are unreliable (React Native, Safari on iOS/iPadOS, etc.).
+
+**Alternatives considered**:
+
+- Wrapping in `setTimeout` to defer redirect — rejected because it makes the timing issue worse.
+- Opening in a new tab via `window.open` — rejected because Safari blocks this even more aggressively.
+
+### 3. PKCE Cookie Persistence on Safari
+
+**Decision**: Verify PKCE cookies are set with `SameSite=Lax` (not `Strict` or `None`) and without third-party cookie restrictions that Safari might enforce.
+
+**Rationale**: `SameSite=Lax` cookies are sent on top-level navigations (redirects from Google back to the app), which is exactly what the OAuth flow needs. `SameSite=Strict` would block the cookie on the redirect back from Google. `SameSite=None` requires `Secure` and is treated as a third-party cookie by Safari ITP. The Supabase SSR library sets `SameSite=Lax` by default, but this should be verified.
+
+**Alternatives considered**:
+
+- Storing PKCE verifier in `localStorage` instead of cookies — rejected because the server-side callback route can't read `localStorage`.
+- Passing the verifier via URL parameters — rejected for security reasons (leaks in referrer headers and browser history).
+
+### 4. Account Linking / Duplicate User Prevention
+
+**Decision**: Investigate whether the "new user with no data" is a duplicate-account issue (email/password account exists separately from Google OAuth account) and recommend a clear UX path.
+
+**Rationale**: Supabase's `enable_manual_linking = false` means if a user signed up with email/password and then tries Google OAuth with the same email, Supabase may either:
+
+- Return an error ("User already registered")
+- Create a separate user (if the emails don't match)
+
+If the user's Google account email differs from their Typenote email/password account, Google OAuth WILL create a new, empty user. The fix should either show a clear message explaining this or support account linking.
+
+**Alternatives considered**:
+
+- Enabling automatic account linking (`enable_manual_linking = true`) — this requires careful security analysis and is a broader change that may warrant its own feature spec.
+- Forcing all users to migrate to Google-only auth — too disruptive for existing users.
+
+## Summary
+
+Three issues must be addressed:
+
+1. **Safari redirect reliability** — use `skipBrowserRedirect: true` + manual `window.location.href` assignment
+2. **PKCE cookie verification** — ensure `SameSite=Lax` cookies persist through the redirect chain on Safari
+3. **Duplicate user UX** — add clear error/guidance when Google OAuth creates a new user separate from an existing email/password account
+
+No NEEDS CLARIFICATION items remain.

--- a/specs/048-fix-ipad-google-auth/spec.md
+++ b/specs/048-fix-ipad-google-auth/spec.md
@@ -1,0 +1,88 @@
+# Feature Specification: Fix iPad Google OAuth Sign-In
+
+**Feature Branch**: `048-fix-ipad-google-auth`
+**Created**: 2026-05-27
+**Status**: Draft
+**Input**: User description: "the google sign up in ipad doesnt work, I press on google button and it just goes to a new user with no data, instead of letting me choose google account and get inside that user"
+
+## User Scenarios & Testing _(mandatory)_
+
+### User Story 1 - Google Sign-In Shows Account Picker on iPad (Priority: P1)
+
+A user opens Typenote on an iPad (Safari browser) and taps the "Sign up with Google" or "Sign in with Google" button. The Google account picker appears, allowing the user to select which Google account to use. After selecting an account, the user is redirected back to Typenote and lands on the dashboard with their existing data (if returning) or a fresh workspace (if new).
+
+**Why this priority**: This is the core bug — without the Google account picker appearing, iPad users cannot authenticate with Google at all. Google OAuth is the only sign-up method on the signup page, making the entire signup flow broken on iPad.
+
+**Independent Test**: Can be tested by opening the signup page on an iPad or iPad simulator in Safari, tapping the Google button, and verifying the Google OAuth consent/account-picker screen appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on iPad Safari on the signup page, **When** they tap "Sign up with Google", **Then** Safari navigates to Google's OAuth consent screen where they can select a Google account.
+2. **Given** a user on iPad Safari on the login page, **When** they tap the "Google" button, **Then** Safari navigates to Google's OAuth consent screen where they can select a Google account.
+3. **Given** a user who selected their Google account on the consent screen, **When** Google redirects back to Typenote, **Then** the user is authenticated and redirected to the dashboard with their data.
+4. **Given** a returning user who previously signed in with Google, **When** they sign in with the same Google account on iPad, **Then** they see their existing documents and data (not a blank workspace).
+
+---
+
+### User Story 2 - OAuth Callback Completes Successfully on Safari (Priority: P1)
+
+The OAuth callback route correctly exchanges the authorization code for a session on Safari/iPadOS. Safari's strict cookie policies (Intelligent Tracking Prevention) do not interfere with the PKCE code verifier or session cookies, ensuring the auth round-trip completes without silent failures.
+
+**Why this priority**: Even if the Google picker appears, a broken callback means the user never gets authenticated. This is equally critical and may be the root cause of the "new user with no data" symptom.
+
+**Independent Test**: Can be tested by initiating Google OAuth on iPad Safari, completing the Google consent flow, and verifying the `/auth/callback` route successfully exchanges the code for a session without errors.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on iPad Safari who completed the Google consent flow, **When** the callback route receives the authorization code, **Then** the code is exchanged for a valid session and the user is logged in.
+2. **Given** Safari's privacy restrictions are active, **When** the OAuth redirect round-trip completes, **Then** all required cookies/state survive the redirect and the callback succeeds.
+3. **Given** the code exchange fails for any reason, **When** the callback handles the error, **Then** the user sees a clear error message on the login page (not a blank workspace or a new empty account).
+
+---
+
+### User Story 3 - Consistent Google Auth Across All Devices (Priority: P2)
+
+Google sign-in/sign-up works identically on desktop browsers, iPad (Safari and Chrome), iPhone (Safari and Chrome), and Android devices. The user experience does not vary by device or browser.
+
+**Why this priority**: While the immediate bug is iPad-specific, the fix should ensure the auth flow is robust across all target platforms, not just patch one device.
+
+**Independent Test**: Can be tested by running the Google sign-in flow on desktop Chrome, iPad Safari, iPhone Safari, and Android Chrome, verifying all reach the Google picker and return authenticated.
+
+**Acceptance Scenarios**:
+
+1. **Given** a user on any supported device/browser, **When** they tap/click the Google sign-in button, **Then** Google's OAuth consent screen appears.
+2. **Given** a user who completed Google OAuth on any device, **When** they return to Typenote, **Then** they are authenticated and see the dashboard.
+
+---
+
+### Edge Cases
+
+- What happens if the user cancels the Google consent screen and returns to Typenote? They should remain on the login/signup page without errors or unexpected state changes.
+- What happens if the user's browser blocks all cookies? They should see a clear error message, not a silent failure or blank user state.
+- What happens if the required cookies/state are lost during the redirect? The callback should show an authentication error and redirect to the login page, not silently create a new empty user.
+- What happens if a user previously signed up with email/password and tries Google sign-in with the same email? The system should handle this gracefully (either link accounts or show a clear message), not create a duplicate user with no data.
+
+## Requirements _(mandatory)_
+
+### Functional Requirements
+
+- **FR-001**: System MUST display the Google OAuth consent/account-picker screen when the user taps the Google sign-in or sign-up button on iPad Safari.
+- **FR-002**: System MUST preserve all required authentication state (cookies, PKCE verifiers) across the full OAuth redirect round-trip on Safari/iPadOS, despite Intelligent Tracking Prevention restrictions.
+- **FR-003**: System MUST correctly authenticate the user and redirect to the dashboard after a successful Google OAuth flow on iPad.
+- **FR-004**: System MUST show a user-friendly error message if the OAuth flow fails (e.g., state lost, code exchange error), rather than silently creating a new empty user or showing a blank state.
+- **FR-005**: System MUST NOT create a new empty/duplicate user when the OAuth callback fails — failed auth attempts must redirect to the login page with an error indicator.
+- **FR-006**: System MUST work with Safari's default cookie and privacy policies without requiring the user to change browser settings.
+
+### Key Entities
+
+- **User Session**: The authenticated session created after successful OAuth, tied to the user's Google account identity.
+- **OAuth State**: Cryptographic values stored client-side before the OAuth redirect and validated server-side during code exchange. Must survive the redirect round-trip across all browsers.
+
+## Success Criteria _(mandatory)_
+
+### Measurable Outcomes
+
+- **SC-001**: Users on iPad Safari can complete Google sign-in/sign-up successfully on the first attempt, including seeing the Google account picker and landing on the dashboard with their data.
+- **SC-002**: The Google OAuth flow succeeds on iPad Safari without requiring the user to change any browser privacy or cookie settings.
+- **SC-003**: Zero instances of silent new-user creation when the OAuth flow encounters an error — all failures show a visible error message.
+- **SC-004**: Google sign-in works consistently across desktop Chrome, iPad Safari, iPhone Safari, and Android Chrome with no device-specific failures.

--- a/specs/048-fix-ipad-google-auth/tasks.md
+++ b/specs/048-fix-ipad-google-auth/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: Fix iPad Google OAuth Sign-In
+
+**Input**: Design documents from `/specs/048-fix-ipad-google-auth/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Included per CLAUDE.md testing requirements (unit tests with Vitest, E2E with Playwright).
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Verify development environment and understand current behavior
+
+- [x] T001 Verify local Supabase is running with Google OAuth enabled by checking `supabase/config.toml` `[auth.external.google]` section and running `supabase status`
+- [x] T002 Read and understand the current OAuth flow in `src/app/(auth)/signup/page.tsx`, `src/app/(auth)/login/page.tsx`, and `src/app/auth/callback/route.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Create shared OAuth redirect utility that both signup and login pages will use
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Create a shared Safari-compatible OAuth redirect helper function that uses `signInWithOAuth` with `skipBrowserRedirect: true` and manually assigns `window.location.href` — place in `src/lib/supabase/oauth.ts`
+- [x] T004 Write unit tests for the OAuth redirect helper in `src/lib/supabase/oauth.test.ts` — test that it calls `signInWithOAuth` with `skipBrowserRedirect: true` and assigns `window.location.href` to the returned URL
+
+**Checkpoint**: Foundation ready — shared OAuth helper exists and is tested
+
+---
+
+## Phase 3: User Story 1 — Google Sign-In Shows Account Picker on iPad (Priority: P1)
+
+**Goal**: Tapping the Google button on iPad Safari reliably navigates to Google's OAuth consent screen where the user can select a Google account.
+
+**Independent Test**: Open signup or login page on iPad Safari (or simulator), tap Google button, verify Google account picker appears.
+
+### Tests for User Story 1
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T005 [P] [US1] Update unit test in `src/app/(auth)/signup/page.test.tsx` — test that the Google button calls the new OAuth helper instead of directly calling `signInWithOAuth`
+- [x] T006 [P] [US1] Update unit test in `src/app/(auth)/login/page.test.tsx` — test that the Google button calls the new OAuth helper instead of directly calling `signInWithOAuth`
+
+### Implementation for User Story 1
+
+- [x] T007 [P] [US1] Refactor `handleGoogleSignup` in `src/app/(auth)/signup/page.tsx` to use the shared Safari-compatible OAuth redirect helper from `src/lib/supabase/oauth.ts`
+- [x] T008 [P] [US1] Refactor `handleGoogleLogin` in `src/app/(auth)/login/page.tsx` to use the shared Safari-compatible OAuth redirect helper from `src/lib/supabase/oauth.ts`
+- [x] T009 [US1] Run `pnpm test` to verify all unit tests pass for both signup and login pages
+
+**Checkpoint**: Google OAuth redirect works reliably on iPad Safari — account picker appears
+
+---
+
+## Phase 4: User Story 2 — OAuth Callback Completes Successfully on Safari (Priority: P1)
+
+**Goal**: The `/auth/callback` route handles PKCE failures gracefully — no silent new-user creation, clear error messaging on failure.
+
+**Independent Test**: Simulate a callback with an invalid/missing code and verify the user sees an error on the login page, not a blank workspace.
+
+### Tests for User Story 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation**
+
+- [x] T010 [US2] Add unit test in `src/app/auth/callback/route.test.ts` — test that when `exchangeCodeForSession` fails, the redirect includes a descriptive error parameter (not just `auth_failed`)
+- [x] T011 [US2] Add unit test in `src/app/auth/callback/route.test.ts` — test that when no `code` parameter is provided AND no error params exist, the redirect goes to `/login?error=no_code`
+
+### Implementation for User Story 2
+
+- [x] T012 [US2] Improve error handling in `src/app/auth/callback/route.ts` — log the specific error from `exchangeCodeForSession` and pass a more descriptive error type to the login page redirect (e.g., `session_exchange_failed` vs `no_code`)
+- [x] T013 [US2] Update the error display in `src/app/(auth)/login/page.tsx` to show a user-friendly message when redirected with `error=session_exchange_failed` (e.g., "Sign-in failed. Please try again. If this keeps happening, try clearing your browser cookies.")
+- [x] T014 [US2] Update the error display in `src/app/(auth)/signup/page.tsx` to handle the error query parameter from failed callbacks (redirect after failed Google OAuth should show an actionable message)
+- [x] T015 [US2] Run `pnpm test` to verify all unit tests pass
+
+**Checkpoint**: Callback route handles all failure modes gracefully — no silent failures
+
+---
+
+## Phase 5: User Story 3 — Consistent Google Auth Across All Devices (Priority: P2)
+
+**Goal**: Google sign-in works identically on desktop Chrome, iPad Safari, iPhone Safari, and Android Chrome with no regressions.
+
+**Independent Test**: Run the Google sign-in flow on desktop Chrome and verify no regressions from the Safari-specific fixes.
+
+### Tests for User Story 3
+
+- [x] T016 [US3] Update E2E test registry in `e2e/TEST_REGISTRY.md` with Google OAuth test scenarios (noting that real Google OAuth can't be fully E2E tested — test the redirect initiation and callback error handling)
+- [x] T017 [US3] Write E2E tests in `e2e/auth.spec.ts` — test callback error path (navigate to `/auth/callback` without code, verify error redirect) and login error display (navigate to `/login?error=session_exchange_failed`, verify error message)
+
+### Implementation for User Story 3
+
+- [x] T018 [US3] Verify the shared OAuth helper in `src/lib/supabase/oauth.ts` works correctly on desktop by running unit tests — no iPad-specific branches that break desktop flow
+- [x] T019 [US3] Run the full unit test suite to confirm no regressions (97/99 files pass, 2 pre-existing failures unrelated to this change)
+
+**Checkpoint**: All user stories work independently, no cross-device regressions
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final cleanup and verification
+
+- [x] T020 Run `pnpm lint && pnpm format:check` and fix any formatting/lint issues
+- [ ] T021 Run the full test suite one final time: `pnpm test && pnpm test:integration && pnpm test:e2e`
+- [ ] T022 Verify the fix manually on iPad Safari (if device available) — tap Google button, confirm account picker appears, complete sign-in, verify dashboard shows user data
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion — BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational (Phase 2) — can start immediately after
+- **User Story 2 (Phase 4)**: Depends on Foundational (Phase 2) — can run in parallel with US1
+- **User Story 3 (Phase 5)**: Depends on US1 and US2 completion — cross-device regression check
+- **Polish (Phase 6)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) — No dependencies on other stories
+- **User Story 2 (P1)**: Can start after Foundational (Phase 2) — Independent of US1, shares callback route
+- **User Story 3 (P2)**: Depends on US1 and US2 — regression testing requires both fixes to be in place
+
+### Within Each User Story
+
+- Tests MUST be written and FAIL before implementation
+- Implementation tasks marked [P] within a story can run in parallel
+- Run test suite at each checkpoint
+
+### Parallel Opportunities
+
+- T005 and T006 (US1 tests for signup and login pages) can run in parallel
+- T007 and T008 (US1 implementation for signup and login pages) can run in parallel
+- US1 (Phase 3) and US2 (Phase 4) can run in parallel after Foundational phase
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch signup and login test updates in parallel:
+Task: "Update unit test for signup page in src/app/(auth)/signup/page.test.tsx"
+Task: "Update unit test for login page in src/app/(auth)/login/page.test.tsx"
+
+# Launch signup and login implementation in parallel:
+Task: "Refactor handleGoogleSignup in src/app/(auth)/signup/page.tsx"
+Task: "Refactor handleGoogleLogin in src/app/(auth)/login/page.tsx"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (shared OAuth helper)
+3. Complete Phase 3: User Story 1 (fix redirect on both pages)
+4. **STOP and VALIDATE**: Test on iPad Safari — does the Google account picker appear?
+5. If yes, proceed to US2 for error handling hardening
+
+### Incremental Delivery
+
+1. Setup + Foundational → OAuth helper ready
+2. Add User Story 1 → Test on iPad → Google picker appears (MVP!)
+3. Add User Story 2 → Test callback errors → Clear error messages on failure
+4. Add User Story 3 → Cross-device regression check → No breakage
+5. Each story adds value without breaking previous stories
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Real Google OAuth cannot be fully E2E tested (requires Google credentials) — E2E tests cover redirect initiation and error paths only
+- The core fix is small (~50 lines) but touches auth-critical code — thorough testing is essential
+- Commit after each phase checkpoint

--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -1,0 +1,15 @@
+import { requireAdmin } from '@/lib/auth/require-admin';
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAdmin(); // 404s for non-admins; redirects handled by middleware
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold tracking-tight">AI Usage</h1>
+      {children}
+    </div>
+  );
+}

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,0 +1,139 @@
+import { getAdminUsage } from '@/lib/queries/admin-usage';
+import { MonthSelect } from '@/components/admin/month-select';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export const dynamic = 'force-dynamic';
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function usd(n: number): string {
+  return `$${n.toFixed(2)}`;
+}
+
+function tokensFor(
+  tokensByModel: Record<string, { input: number; output: number }>,
+  model: string,
+): number {
+  const t = tokensByModel[model];
+  return t ? t.input + t.output : 0;
+}
+
+export default async function AdminUsagePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ month?: string }>;
+}) {
+  const { month } = await searchParams;
+  const selectedMonth = month ?? currentMonth();
+  const { users, totals } = await getAdminUsage(selectedMonth);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          Source-of-truth usage from the token ledger. Cost is an estimate
+          (switchable via per-model price env vars).
+        </p>
+        <MonthSelect selected={selectedMonth} />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Chat queries
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {totals.chatCount}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              LaTeX queries
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {totals.latexCount}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total tokens
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {totals.totalTokens.toLocaleString()}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Est. cost
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-2xl font-bold">
+            {usd(totals.estimatedCostUsd)}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium">User</th>
+              <th className="px-3 py-2 font-medium">Tier</th>
+              <th className="px-3 py-2 text-right font-medium">Chat</th>
+              <th className="px-3 py-2 text-right font-medium">LaTeX</th>
+              <th className="px-3 py-2 text-right font-medium">Flash tok</th>
+              <th className="px-3 py-2 text-right font-medium">Pro tok</th>
+              <th className="px-3 py-2 text-right font-medium">Embed tok</th>
+              <th className="px-3 py-2 text-right font-medium">Est. cost</th>
+              <th className="px-3 py-2 text-right font-medium">Chat quota</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.map((u) => (
+              <tr key={u.userId} className="border-t">
+                <td className="px-3 py-2">{u.email}</td>
+                <td className="px-3 py-2">{u.tier}</td>
+                <td className="px-3 py-2 text-right">{u.chatCount}</td>
+                <td className="px-3 py-2 text-right">{u.latexCount}</td>
+                <td className="px-3 py-2 text-right">
+                  {tokensFor(u.tokensByModel, 'flash').toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {tokensFor(u.tokensByModel, 'pro').toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {tokensFor(u.tokensByModel, 'embedding').toLocaleString()}
+                </td>
+                <td className="px-3 py-2 text-right">
+                  {usd(u.estimatedCostUsd)}
+                </td>
+                <td
+                  className={
+                    'px-3 py-2 text-right ' +
+                    (u.chatQuotaPct >= 100
+                      ? 'font-semibold text-destructive'
+                      : u.chatQuotaPct >= 80
+                        ? 'font-medium text-amber-600'
+                        : '')
+                  }
+                >
+                  {u.chatQuotaPct}%
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(auth)/login/page.test.tsx
+++ b/src/app/(auth)/login/page.test.tsx
@@ -5,17 +5,20 @@ import LoginPage from './page';
 const mockPush = vi.fn();
 const mockRefresh = vi.fn();
 const mockSignInWithPassword = vi.fn();
-const mockSignInWithOAuth = vi.fn();
+const mockSignInWithGoogle = vi.fn();
 let mockSearchParams = new URLSearchParams();
 
 vi.mock('@/lib/supabase/client', () => ({
   createClient: () => ({
     auth: {
       signInWithPassword: mockSignInWithPassword,
-      signInWithOAuth: mockSignInWithOAuth,
       signUp: vi.fn(),
     },
   }),
+}));
+
+vi.mock('@/lib/supabase/oauth', () => ({
+  signInWithGoogle: (...args: unknown[]) => mockSignInWithGoogle(...args),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -106,17 +109,12 @@ describe('LoginPage', () => {
     });
   });
 
-  it('calls signInWithOAuth when Google button is clicked', () => {
+  it('calls signInWithGoogle helper when Google button is clicked', () => {
     render(<LoginPage />);
 
     fireEvent.click(screen.getByRole('button', { name: /google/i }));
 
-    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
-      provider: 'google',
-      options: {
-        redirectTo: expect.stringContaining('/auth/callback'),
-      },
-    });
+    expect(mockSignInWithGoogle).toHaveBeenCalled();
   });
 
   it('shows success banner when ?message=password-reset-success', () => {

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
+import { signInWithGoogle } from '@/lib/supabase/oauth';
 import { sanitizeAuthError } from '@/lib/auth-errors';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -36,6 +37,18 @@ function LoginForm() {
       ? nextParam
       : '/dashboard';
 
+  const oauthError = searchParams.get('error');
+  const oauthErrorMessage =
+    oauthError === 'session_exchange_failed'
+      ? 'Sign-in failed. Please try again. If this keeps happening, try clearing your browser cookies.'
+      : oauthError === 'no_code'
+        ? 'Sign-in was interrupted. Please try again.'
+        : oauthError === 'oauth_init_failed'
+          ? 'Could not start Google sign-in. Please try again.'
+          : oauthError === 'auth_failed'
+            ? 'Sign-in failed. Please try again.'
+            : null;
+
   async function handleEmailLogin(e: React.FormEvent) {
     e.preventDefault();
     setError('');
@@ -57,14 +70,8 @@ function LoginForm() {
     router.refresh();
   }
 
-  async function handleGoogleLogin() {
-    const supabase = createClient();
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
+  function handleGoogleLogin() {
+    signInWithGoogle();
   }
 
   return (
@@ -79,6 +86,14 @@ function LoginForm() {
         {showResetSuccess && (
           <p className="mb-4 rounded-md bg-green-50 p-3 text-sm text-green-800 dark:bg-green-950 dark:text-green-200">
             Password reset successfully. Please sign in with your new password.
+          </p>
+        )}
+        {oauthErrorMessage && (
+          <p
+            className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+            role="alert"
+          >
+            {oauthErrorMessage}
           </p>
         )}
         <form onSubmit={handleEmailLogin} className="space-y-4">

--- a/src/app/(auth)/signup/page.test.tsx
+++ b/src/app/(auth)/signup/page.test.tsx
@@ -2,14 +2,10 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import SignupPage from './page';
 
-const mockSignInWithOAuth = vi.fn();
+const mockSignInWithGoogle = vi.fn();
 
-vi.mock('@/lib/supabase/client', () => ({
-  createClient: () => ({
-    auth: {
-      signInWithOAuth: mockSignInWithOAuth,
-    },
-  }),
+vi.mock('@/lib/supabase/oauth', () => ({
+  signInWithGoogle: (...args: unknown[]) => mockSignInWithGoogle(...args),
 }));
 
 let mockSearchParams = new URLSearchParams();
@@ -24,8 +20,6 @@ describe('SignupPage', () => {
     vi.clearAllMocks();
     mockSearchParams = new URLSearchParams();
   });
-
-  // T001: Renders only Google button, no email/password form
   it('renders Google sign-up button', () => {
     render(<SignupPage />);
     expect(
@@ -68,18 +62,13 @@ describe('SignupPage', () => {
     expect(link).toHaveAttribute('href', '/login');
   });
 
-  it('calls signInWithOAuth when Google button is clicked', () => {
+  it('calls signInWithGoogle helper when Google button is clicked', () => {
     render(<SignupPage />);
 
     fireEvent.click(
       screen.getByRole('button', { name: /sign up with google/i }),
     );
 
-    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
-      provider: 'google',
-      options: {
-        redirectTo: expect.stringContaining('/auth/callback'),
-      },
-    });
+    expect(mockSignInWithGoogle).toHaveBeenCalled();
   });
 });

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -3,7 +3,7 @@
 import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { createClient } from '@/lib/supabase/client';
+import { signInWithGoogle } from '@/lib/supabase/oauth';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -18,14 +18,17 @@ function SignupForm() {
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
 
-  async function handleGoogleSignup() {
-    const supabase = createClient();
-    await supabase.auth.signInWithOAuth({
-      provider: 'google',
-      options: {
-        redirectTo: `${window.location.origin}/auth/callback`,
-      },
-    });
+  const errorMessage =
+    error === 'session_exchange_failed'
+      ? 'Sign-up failed. Please try again. If this keeps happening, try clearing your browser cookies.'
+      : error === 'oauth_init_failed'
+        ? 'Could not start Google sign-up. Please try again.'
+        : error
+          ? 'Sign-up failed. Please try again.'
+          : null;
+
+  function handleGoogleSignup() {
+    signInWithGoogle();
   }
 
   return (
@@ -35,12 +38,12 @@ function SignupForm() {
         <CardDescription>Sign up to start taking notes</CardDescription>
       </CardHeader>
       <CardContent>
-        {error && (
+        {errorMessage && (
           <p
             className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
             role="alert"
           >
-            Sign-up failed. Please try again.
+            {errorMessage}
           </p>
         )}
         <Button className="w-full" onClick={handleGoogleSignup} type="button">

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { signOut } from '@/lib/actions/auth';
@@ -5,7 +6,7 @@ import { SidebarFolderTree } from '@/components/dashboard/sidebar-folder-tree';
 import { SidebarLayout } from '@/components/dashboard/sidebar-layout';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
-import { LogOut } from 'lucide-react';
+import { Gauge, LogOut } from 'lucide-react';
 
 export default async function DashboardLayout({
   children,
@@ -21,6 +22,16 @@ export default async function DashboardLayout({
     redirect('/login');
   }
 
+  // Admin-only nav entry. Rendered server-side and only for admins, so the
+  // link never ships to non-admins. Access is still enforced by requireAdmin()
+  // on /admin (defense in depth) — the link is convenience, not the control.
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+  const isAdmin = profile?.is_admin ?? false;
+
   const sidebarContent = (
     <>
       <div className="flex h-14 items-center px-4">
@@ -33,6 +44,20 @@ export default async function DashboardLayout({
         <SidebarFolderTree />
       </div>
       <Separator />
+      {isAdmin && (
+        <div className="px-2 pt-2">
+          <Button
+            asChild
+            variant="ghost"
+            className="w-full justify-start min-h-[44px] hover:bg-primary/10 hover:text-primary"
+          >
+            <Link href="/admin">
+              <Gauge className="size-4" />
+              AI Usage
+            </Link>
+          </Button>
+        </div>
+      )}
       <div className="p-2">
         <form action={signOut}>
           <Button

--- a/src/app/api/ai/ask/route.ts
+++ b/src/app/api/ai/ask/route.ts
@@ -3,6 +3,7 @@ import { GoogleGenAI } from '@google/genai';
 
 import { buildAiContext, type QuestionParams } from '@/lib/actions/ai-context';
 import { checkAndIncrementUsage, recordTokenUsage } from '@/lib/ai/rate-limit';
+import { estimateTokens } from '@/lib/ai/tokens';
 import { createClient } from '@/lib/supabase/server';
 
 const isDebugMode = process.env.AI_RATE_LIMIT_DEBUG === 'true';
@@ -327,6 +328,8 @@ export async function POST(req: Request) {
     // Create a streaming response using SSE-like format
     const encoder = new TextEncoder();
     let fullResponse = '';
+    let usageInput = 0;
+    let usageOutput = 0;
     const stream = new ReadableStream({
       async start(controller) {
         try {
@@ -356,6 +359,11 @@ export async function POST(req: Request) {
                 ),
               );
             }
+            const usage = chunk.usageMetadata;
+            if (usage) {
+              usageInput = usage.promptTokenCount ?? usageInput;
+              usageOutput = usage.candidatesTokenCount ?? usageOutput;
+            }
           }
 
           controller.enqueue(
@@ -378,8 +386,18 @@ export async function POST(req: Request) {
               .update({ updated_at: new Date().toISOString() })
               .eq('id', activeConversationId);
           }
-          // Fire-and-forget token recording for admin observability
-          recordTokenUsage(user.id, 'chat', 0, 0).catch(() => {});
+          // Fire-and-forget token recording for cost observability.
+          // Prefer the model's reported usage; fall back to a char estimate so
+          // we never silently record zeros.
+          const inputTokens =
+            usageInput || estimateTokens(`${systemPrompt}\n${question}`);
+          const outputTokens = usageOutput || estimateTokens(fullResponse);
+          recordTokenUsage(
+            user.id,
+            modelLabel,
+            inputTokens,
+            outputTokens,
+          ).catch(() => {});
         } catch (err) {
           const message = err instanceof Error ? err.message : 'Stream error';
           controller.enqueue(

--- a/src/app/api/ai/latex/route.test.ts
+++ b/src/app/api/ai/latex/route.test.ts
@@ -50,7 +50,11 @@ describe('POST /api/ai/latex', () => {
   });
 
   it('should return 200 with latex for valid input', async () => {
-    vi.mocked(convertToLatex).mockResolvedValue('\\frac{1}{2} \\times 5');
+    vi.mocked(convertToLatex).mockResolvedValue({
+      latex: '\\frac{1}{2} \\times 5',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
 
     const res = await POST(createRequest({ text: 'one half times five' }));
     const data = await res.json();
@@ -60,7 +64,11 @@ describe('POST /api/ai/latex', () => {
   });
 
   it('should pass latex query type to rate limiter', async () => {
-    vi.mocked(convertToLatex).mockResolvedValue('x^2');
+    vi.mocked(convertToLatex).mockResolvedValue({
+      latex: 'x^2',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
 
     await POST(createRequest({ text: 'x squared' }));
 
@@ -68,7 +76,11 @@ describe('POST /api/ai/latex', () => {
   });
 
   it('should accept optional courseName', async () => {
-    vi.mocked(convertToLatex).mockResolvedValue('\\det(A)');
+    vi.mocked(convertToLatex).mockResolvedValue({
+      latex: '\\det(A)',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
 
     const res = await POST(
       createRequest({ text: 'determinant of A', courseName: 'Linear Algebra' }),
@@ -84,7 +96,11 @@ describe('POST /api/ai/latex', () => {
   });
 
   it('should work without courseName', async () => {
-    vi.mocked(convertToLatex).mockResolvedValue('x^2');
+    vi.mocked(convertToLatex).mockResolvedValue({
+      latex: 'x^2',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
 
     const res = await POST(createRequest({ text: 'x squared' }));
 
@@ -93,11 +109,15 @@ describe('POST /api/ai/latex', () => {
   });
 
   it('should call recordTokenUsage after conversion', async () => {
-    vi.mocked(convertToLatex).mockResolvedValue('x^2');
+    vi.mocked(convertToLatex).mockResolvedValue({
+      latex: 'x^2',
+      inputTokens: 12,
+      outputTokens: 7,
+    });
 
     await POST(createRequest({ text: 'x squared' }));
 
-    expect(recordTokenUsage).toHaveBeenCalledWith('u1', 'latex', 0, 0);
+    expect(recordTokenUsage).toHaveBeenCalledWith('u1', 'flash', 12, 7);
   });
 
   it('should return 400 when text is missing', async () => {

--- a/src/app/api/ai/latex/route.ts
+++ b/src/app/api/ai/latex/route.ts
@@ -80,12 +80,15 @@ export async function POST(req: Request) {
       );
     }
 
-    const latex = await convertToLatex(text.trim(), courseName || undefined);
+    const { latex, inputTokens, outputTokens } = await convertToLatex(
+      text.trim(),
+      courseName || undefined,
+    );
 
-    // Fire-and-forget token recording
-    // convertToLatex returns just the string for now; token recording
-    // will be enhanced when we update latex.ts to return usage in US3
-    recordTokenUsage(user.id, 'latex', 0, 0).catch(() => {});
+    // Fire-and-forget token recording (latex always runs on Flash).
+    recordTokenUsage(user.id, 'flash', inputTokens, outputTokens).catch(
+      () => {},
+    );
 
     return NextResponse.json({ latex });
   } catch (error) {

--- a/src/app/api/moodle/import-existing/route.test.ts
+++ b/src/app/api/moodle/import-existing/route.test.ts
@@ -151,6 +151,7 @@ describe('POST /api/moodle/import-existing', () => {
       type: 'moodle_file',
       fileId: 'file-1',
       courseId: 'tn-course-1',
+      triggeredByUserId: 'u1',
     });
   });
 
@@ -278,6 +279,7 @@ describe('POST /api/moodle/import-existing', () => {
       type: 'moodle_file',
       fileId: 'file-1',
       courseId: 'tn-course-1',
+      triggeredByUserId: 'u1',
     });
   });
 

--- a/src/app/api/moodle/import-existing/route.ts
+++ b/src/app/api/moodle/import-existing/route.ts
@@ -134,6 +134,7 @@ export async function POST(request: NextRequest) {
               type: 'moodle_file',
               fileId,
               courseId: appCourseId,
+              triggeredByUserId: userId,
             });
           } catch (err) {
             console.error('Background index failed:', err);

--- a/src/app/api/moodle/upload-finalize/route.ts
+++ b/src/app/api/moodle/upload-finalize/route.ts
@@ -140,6 +140,7 @@ export async function POST(request: NextRequest) {
               type: 'moodle_file',
               fileId,
               courseId: appCourseId,
+              triggeredByUserId: userId,
             });
           } catch (err) {
             console.error('Background index failed:', err);
@@ -193,6 +194,7 @@ export async function POST(request: NextRequest) {
             type: 'moodle_file',
             fileId,
             courseId: appCourseId,
+            triggeredByUserId: userId,
           });
         } catch (err) {
           console.error('Background index failed:', err);

--- a/src/app/api/moodle/upload/route.ts
+++ b/src/app/api/moodle/upload/route.ts
@@ -151,6 +151,7 @@ export async function POST(request: NextRequest) {
             type: 'moodle_file',
             fileId: fileRecord.id,
             courseId: appCourseId,
+            triggeredByUserId: userId ?? undefined,
           });
         } catch (err) {
           console.error('Index failed:', err);
@@ -203,6 +204,7 @@ export async function POST(request: NextRequest) {
           type: 'moodle_file',
           fileId: newRecord.id,
           courseId: appCourseId,
+          triggeredByUserId: userId ?? undefined,
         });
       } catch (err) {
         console.error('Index failed:', err);

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -81,17 +81,17 @@ describe('GET /auth/callback', () => {
     );
   });
 
-  it('redirects to /login with error when no code provided', async () => {
+  it('redirects to /login with no_code error when no code provided', async () => {
     const request = new Request('http://localhost:3000/auth/callback');
     const response = await GET(request);
 
     expect(response.status).toBe(307);
     const url = new URL(response.headers.get('location')!);
     expect(url.pathname).toBe('/login');
-    expect(url.searchParams.get('error')).toBe('auth_failed');
+    expect(url.searchParams.get('error')).toBe('no_code');
   });
 
-  it('redirects to /login with error when code exchange fails', async () => {
+  it('redirects to /login with session_exchange_failed when code exchange fails', async () => {
     mockExchangeCodeForSession.mockResolvedValueOnce({
       error: { message: 'Invalid code' },
     });
@@ -104,6 +104,6 @@ describe('GET /auth/callback', () => {
     expect(response.status).toBe(307);
     const url = new URL(response.headers.get('location')!);
     expect(url.pathname).toBe('/login');
-    expect(url.searchParams.get('error')).toBe('auth_failed');
+    expect(url.searchParams.get('error')).toBe('session_exchange_failed');
   });
 });

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -55,7 +55,14 @@ export async function GET(request: Request) {
       });
       return response;
     }
+
+    // Code was present but exchange failed (e.g. PKCE verifier lost on Safari)
+    console.error('[auth/callback] session exchange failed:', error.message);
+    return NextResponse.redirect(
+      `${origin}/login?error=session_exchange_failed`,
+    );
   }
 
-  return NextResponse.redirect(`${origin}/login?error=auth_failed`);
+  // No authorization code in the URL at all
+  return NextResponse.redirect(`${origin}/login?error=no_code`);
 }

--- a/src/components/admin/month-select.tsx
+++ b/src/components/admin/month-select.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+/** Last 12 months as 'YYYY-MM', most recent first, plus any current selection. */
+function recentMonths(selected: string): string[] {
+  const months = new Set<string>([selected]);
+  const now = new Date();
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1),
+    );
+    months.add(
+      `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}`,
+    );
+  }
+  return [...months].sort().reverse();
+}
+
+export function MonthSelect({ selected }: { selected: string }) {
+  const router = useRouter();
+  return (
+    <select
+      aria-label="Usage month"
+      className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+      value={selected}
+      onChange={(e) => router.push(`/admin?month=${e.target.value}`)}
+    >
+      {recentMonths(selected).map((m) => (
+        <option key={m} value={m}>
+          {m}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/ai/ai-chat-panel.tsx
+++ b/src/components/ai/ai-chat-panel.tsx
@@ -111,13 +111,17 @@ export function AiChatPanel({
   >(null);
   const [view, setView] = useState<'chat' | 'list'>('chat');
   const [loadingConversation, setLoadingConversation] = useState(false);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const abortRef = useRef<AbortController | null>(null);
   const initialLoadDone = useRef(false);
 
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
   }, [messages, streamingText]);
 
   useEffect(() => {
@@ -492,7 +496,7 @@ export function AiChatPanel({
   // - docked: becomes a static flex column on lg+ (must sit in a flex row).
   // - overlay: stays fixed and docks to the right edge on lg+ (works anywhere).
   const containerClassName = docked
-    ? 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:static lg:z-auto lg:w-[480px] lg:shrink-0 xl:w-[560px] 2xl:w-[640px]'
+    ? 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:static lg:z-auto lg:min-h-0 lg:overflow-hidden lg:w-[480px] lg:shrink-0 xl:w-[560px] 2xl:w-[640px]'
     : 'fixed inset-0 z-50 flex h-full w-full flex-col border-l border-border/30 bg-background/90 backdrop-blur-xl shadow-xl lg:inset-y-0 lg:left-auto lg:right-0 lg:w-[480px] xl:w-[560px] 2xl:w-[640px]';
 
   return (
@@ -594,7 +598,10 @@ export function AiChatPanel({
       ) : (
         <>
           {/* Chat Messages */}
-          <div className="flex-1 overflow-y-auto px-4 py-4">
+          <div
+            ref={messagesContainerRef}
+            className="flex-1 overflow-y-auto px-4 py-4"
+          >
             {loadingConversation ? (
               <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/components/canvas/canvas-page.tsx
+++ b/src/components/canvas/canvas-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createPortal } from 'react-dom';
 import { useRef, useEffect, useCallback, useState } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
@@ -768,7 +769,7 @@ export function CanvasPage({
       {/* Layer 4: Text content layer — only interactive in text mode */}
       <div
         ref={textLayerRef}
-        className="absolute inset-0 overflow-hidden"
+        className="absolute inset-0 overflow-visible"
         style={{
           pointerEvents:
             isInteractionMode ||
@@ -1027,46 +1028,50 @@ export function CanvasPage({
         </div>
       )}
 
-      {/* Layer 5.8: Floating action bar for Read mode text selection */}
-      {activeTool === 'read' && textSelectionRect && (
-        <div
-          className="fixed z-[100] flex items-center gap-1 rounded-full border bg-white px-2 py-1 shadow-lg"
-          style={{
-            left: textSelectionRect.left + textSelectionRect.width / 2,
-            top: textSelectionRect.top - 40,
-            transform: 'translateX(-50%)',
-            pointerEvents: 'auto',
-          }}
-        >
-          <button
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const text = selectedTextRef.current;
-              if (text && onAskAiWithText) {
-                onAskAiWithText(text);
-              }
+      {/* Layer 5.8: Floating action bar for Read mode text selection
+           Rendered via Portal to escape CSS transform container so position: fixed works correctly */}
+      {activeTool === 'read' &&
+        textSelectionRect &&
+        createPortal(
+          <div
+            className="fixed z-[100] flex items-center gap-1 rounded-full border bg-white px-2 py-1 shadow-lg"
+            style={{
+              left: textSelectionRect.left + textSelectionRect.width / 2,
+              top: textSelectionRect.top - 40,
+              transform: 'translateX(-50%)',
+              pointerEvents: 'auto',
             }}
-            className="flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium text-purple-700 transition-colors hover:bg-purple-50"
           >
-            <Sparkles className="h-3.5 w-3.5" />
-            Ask AI
-          </button>
-          <button
-            onMouseDown={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              selectedTextRef.current = '';
-              selectedRectRef.current = null;
-              setTextSelectionRect(null);
-            }}
-            className="flex items-center justify-center rounded-full p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
-            aria-label="Dismiss"
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      )}
+            <button
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const text = selectedTextRef.current;
+                if (text && onAskAiWithText) {
+                  onAskAiWithText(text);
+                }
+              }}
+              className="flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-medium text-purple-700 transition-colors hover:bg-purple-50"
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              Ask AI
+            </button>
+            <button
+              onMouseDown={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                selectedTextRef.current = '';
+                selectedRectRef.current = null;
+                setTextSelectionRect(null);
+              }}
+              className="flex items-center justify-center rounded-full p-1 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
+              aria-label="Dismiss"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>,
+          document.body,
+        )}
 
       {/* Layer 6: Interaction layer — ALWAYS present
           In draw/erase mode: captures all events (pointer-events: auto, touch-action: none)

--- a/src/components/editor/math-node-view.tsx
+++ b/src/components/editor/math-node-view.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { createPortal } from 'react-dom';
 import { NodeViewWrapper } from '@tiptap/react';
 import type { NodeViewProps } from '@tiptap/react';
 import type { EditorView } from '@tiptap/pm/view';
@@ -24,9 +25,14 @@ export function MathNodeView({
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [menuPos, setMenuPos] = useState<{
+    left: number;
+    top: number;
+  } | null>(null);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
 
   const html = useMemo(() => {
     if (!latex) return '';
@@ -39,6 +45,16 @@ export function MathNodeView({
       return `<span style="color: red;">${latex}</span>`;
     }
   }, [latex]);
+
+  // Compute menu position when selected or editing
+  useEffect(() => {
+    if ((selected || isEditing) && wrapperRef.current) {
+      const rect = wrapperRef.current.getBoundingClientRect();
+      setMenuPos({ left: rect.left, top: rect.bottom + 4 });
+    } else {
+      setMenuPos(null);
+    }
+  }, [selected, isEditing]);
 
   const openEditor = useCallback(() => {
     setIsEditing(true);
@@ -218,98 +234,103 @@ export function MathNodeView({
           : {}),
       }}
     >
-      <span dangerouslySetInnerHTML={{ __html: html }} />
-      {selected && !isEditing && (
-        <div
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: '100%',
-            zIndex: 50,
-            marginTop: '4px',
-          }}
-          className="flex gap-1 rounded-lg border border-zinc-300 bg-white p-1 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
-        >
-          {/* preventDefault on mouseDown keeps ProseMirror NodeSelection active */}
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={openEditor}
-            className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
+      <span ref={wrapperRef} dangerouslySetInnerHTML={{ __html: html }} />
+      {selected &&
+        !isEditing &&
+        menuPos &&
+        createPortal(
+          <div
+            style={{
+              position: 'fixed',
+              left: menuPos.left,
+              top: menuPos.top,
+              zIndex: 9999,
+            }}
+            className="flex gap-1 rounded-lg border border-zinc-300 bg-white p-1 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
           >
-            Edit
-          </button>
-          <button
-            type="button"
-            onMouseDown={(e) => e.preventDefault()}
-            onClick={handleCopy}
-            className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
-          >
-            {copied ? 'Copied!' : 'Copy'}
-          </button>
-        </div>
-      )}
-      {isEditing && (
-        <div
-          ref={panelRef}
-          style={{
-            position: 'absolute',
-            left: 0,
-            top: '100%',
-            zIndex: 50,
-            marginTop: '4px',
-          }}
-          className="flex flex-col gap-2 rounded-lg border border-zinc-300 bg-white p-2 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
-        >
-          {/* Mode selector */}
-          <div className="flex gap-1">
+            {/* preventDefault on mouseDown keeps ProseMirror NodeSelection active */}
             <button
               type="button"
-              onClick={() => switchMode('expression')}
-              className={`rounded px-2 py-0.5 text-xs font-medium ${
-                editMode === 'expression'
-                  ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
-                  : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-              }`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={openEditor}
+              className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
-              Edit Expression
+              Edit
             </button>
             <button
               type="button"
-              onClick={() => switchMode('latex')}
-              className={`rounded px-2 py-0.5 text-xs font-medium ${
-                editMode === 'latex'
-                  ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
-                  : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
-              }`}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleCopy}
+              className="rounded px-2 py-1 text-xs font-medium text-zinc-700 hover:bg-zinc-100 dark:text-zinc-300 dark:hover:bg-zinc-800"
             >
-              Edit LaTeX
+              {copied ? 'Copied!' : 'Copy'}
             </button>
-          </div>
-          {/* Input */}
-          <div className="flex items-center gap-2">
-            <textarea
-              ref={inputRef}
-              rows={1}
-              value={editValue}
-              onChange={(e) => setEditValue(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={
-                editMode === 'expression'
-                  ? 'Describe math in plain English...'
-                  : 'Enter LaTeX code...'
-              }
-              disabled={isLoading}
-              className="min-w-[220px] max-h-[200px] resize-none overflow-y-auto border-none bg-transparent text-sm outline-none placeholder:text-zinc-400 disabled:opacity-50"
-            />
-            {isLoading && (
-              <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-violet-500" />
-            )}
-          </div>
-          {/* Error message */}
-          {error && <span className="text-xs text-red-500">{error}</span>}
-        </div>
-      )}
+          </div>,
+          document.body,
+        )}
+      {isEditing &&
+        menuPos &&
+        createPortal(
+          <div
+            ref={panelRef}
+            style={{
+              position: 'fixed',
+              left: menuPos.left,
+              top: menuPos.top,
+              zIndex: 9999,
+            }}
+            className="flex flex-col gap-2 rounded-lg border border-zinc-300 bg-white p-2 shadow-lg dark:border-zinc-600 dark:bg-zinc-900"
+          >
+            {/* Mode selector */}
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => switchMode('expression')}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  editMode === 'expression'
+                    ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
+                    : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                }`}
+              >
+                Edit Expression
+              </button>
+              <button
+                type="button"
+                onClick={() => switchMode('latex')}
+                className={`rounded px-2 py-0.5 text-xs font-medium ${
+                  editMode === 'latex'
+                    ? 'bg-violet-100 text-violet-700 dark:bg-violet-900 dark:text-violet-300'
+                    : 'text-zinc-500 hover:bg-zinc-100 dark:hover:bg-zinc-800'
+                }`}
+              >
+                Edit LaTeX
+              </button>
+            </div>
+            {/* Input */}
+            <div className="flex items-center gap-2">
+              <textarea
+                ref={inputRef}
+                rows={1}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={
+                  editMode === 'expression'
+                    ? 'Describe math in plain English...'
+                    : 'Enter LaTeX code...'
+                }
+                disabled={isLoading}
+                className="min-w-[220px] max-h-[200px] resize-none overflow-y-auto border-none bg-transparent text-sm outline-none placeholder:text-zinc-400 disabled:opacity-50"
+              />
+              {isLoading && (
+                <div className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-violet-500" />
+              )}
+            </div>
+            {/* Error message */}
+            {error && <span className="text-xs text-red-500">{error}</span>}
+          </div>,
+          document.body,
+        )}
     </NodeViewWrapper>
   );
 }

--- a/src/lib/actions/__tests__/ai-context.test.ts
+++ b/src/lib/actions/__tests__/ai-context.test.ts
@@ -12,8 +12,14 @@ vi.mock('@/lib/ai/embeddings', () => ({
   chunkFlatText: vi.fn((text: string) => [
     { text, chunkIndex: 0, pageStart: null, pageEnd: null },
   ]),
-  embedText: vi.fn(async () => Array.from({ length: 1536 }, () => 0.1)),
-  embedQuery: vi.fn(async () => Array.from({ length: 1536 }, () => 0.1)),
+  embedText: vi.fn(async () => ({
+    values: Array.from({ length: 1536 }, () => 0.1),
+    tokens: 1,
+  })),
+  embedQuery: vi.fn(async () => ({
+    values: Array.from({ length: 1536 }, () => 0.1),
+    tokens: 1,
+  })),
 }));
 
 vi.mock('@/lib/ai/extraction/docx', () => ({
@@ -211,6 +217,10 @@ vi.mock('@/lib/ai/prompts', () => ({
   buildSystemPrompt: vi.fn(() => 'You are a test tutor.'),
 }));
 
+vi.mock('@/lib/ai/rate-limit', () => ({
+  recordTokenUsage: vi.fn(async () => {}),
+}));
+
 vi.mock('@/lib/actions/context-files', () => ({
   listContextFiles: vi.fn(async () => []),
 }));
@@ -222,6 +232,7 @@ vi.mock('@/lib/ai/context-files', () => ({
 }));
 
 import { embedText } from '@/lib/ai/embeddings';
+import { recordTokenUsage } from '@/lib/ai/rate-limit';
 import { extractPdfPages } from '@/lib/ai/extraction/pdf';
 import { listContextFiles } from '@/lib/actions/context-files';
 import { resolveContextFileName } from '@/lib/ai/context-files';
@@ -274,7 +285,9 @@ describe('indexContent', () => {
     // Both pages' embeddings come back empty (malformed API response). The file
     // has chunks, so this is an embedding failure, not a blank file — it must
     // surface as success:false, never a silent skip that hides the outage.
-    vi.mocked(embedText).mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    vi.mocked(embedText)
+      .mockResolvedValueOnce({ values: [], tokens: 0 })
+      .mockResolvedValueOnce({ values: [], tokens: 0 });
 
     const result = await indexContent({
       type: 'course_material',
@@ -299,6 +312,48 @@ describe('indexContent', () => {
 
     expect(result.success).toBe(true);
     expect(getContentHash).toHaveBeenCalledWith('course_material', 'mat-1');
+  });
+
+  it('attributes embedding token cost to the authed user (course_material)', async () => {
+    await indexContent({
+      type: 'course_material',
+      materialId: 'mat-1',
+      courseId: 'course-1',
+    });
+
+    // 2 PDF pages -> 2 chunks -> embedText mock returns tokens:1 each = 2.
+    expect(recordTokenUsage).toHaveBeenCalledWith(
+      'test-user-id',
+      'embedding',
+      2,
+      0,
+    );
+  });
+
+  it('attributes moodle embedding cost to triggeredByUserId (row user stays null)', async () => {
+    await indexContent({
+      type: 'moodle_file',
+      fileId: 'file-1',
+      courseId: 'callers-typenote-course',
+      triggeredByUserId: 'triggering-user',
+    });
+
+    expect(recordTokenUsage).toHaveBeenCalledWith(
+      'triggering-user',
+      'embedding',
+      2,
+      0,
+    );
+  });
+
+  it('does not record embedding cost for moodle when no triggering user', async () => {
+    await indexContent({
+      type: 'moodle_file',
+      fileId: 'file-1',
+      courseId: 'callers-typenote-course',
+    });
+
+    expect(recordTokenUsage).not.toHaveBeenCalled();
   });
 
   it('embeds moodle_file with canonical moodle_courses.id (not caller course_id)', async () => {

--- a/src/lib/actions/__tests__/page-indexing.integration.test.ts
+++ b/src/lib/actions/__tests__/page-indexing.integration.test.ts
@@ -34,9 +34,24 @@ vi.mock('@/lib/ai/embeddings', async (orig) => {
   const actual = await orig<typeof import('@/lib/ai/embeddings')>();
   return {
     ...actual, // real chunkPages / chunkFlatText
-    embedText: vi.fn(async () => Array.from({ length: 1536 }, () => 0.05)),
-    embedQuery: vi.fn(async () => Array.from({ length: 1536 }, () => 0.05)),
+    embedText: vi.fn(async () => ({
+      values: Array.from({ length: 1536 }, () => 0.05),
+      tokens: 1,
+    })),
+    embedQuery: vi.fn(async () => ({
+      values: Array.from({ length: 1536 }, () => 0.05),
+      tokens: 1,
+    })),
   };
+});
+
+// recordTokenUsage (the embedding cost attribution) goes through the cookie-based
+// server client, which can't run in this plain node env. Point it at the admin
+// client so the record_token_usage RPC actually writes to Postgres and the
+// embedding-cost assertion below can read it back.
+vi.mock('@/lib/supabase/server', async () => {
+  const { createAdminClient } = await import('@/test/supabase-client');
+  return { createClient: vi.fn(async () => createAdminClient()) };
 });
 
 // ---------------------------------------------------------------------------
@@ -44,8 +59,13 @@ vi.mock('@/lib/ai/embeddings', async (orig) => {
 // ---------------------------------------------------------------------------
 
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { createAdminClient } from '@/test/supabase-client';
+import { createAdminClient, TEST_USER_ID } from '@/test/supabase-client';
 import { indexContent } from '@/lib/actions/ai-context';
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
 
 // ---------------------------------------------------------------------------
 // Fixed UUIDs for this test — chosen to be collision-free with seeded data
@@ -139,6 +159,14 @@ async function cleanup() {
   await admin.from('moodle_courses').delete().eq('id', MOODLE_COURSE_ID);
   await admin.from('moodle_instances').delete().eq('id', INSTANCE_ID);
   await admin.storage.from('moodle-materials').remove([STORAGE_PATH]);
+  // Clear this user's embedding-cost rows for the current month so the
+  // attribution assertion isn't polluted by a prior run.
+  await admin
+    .from('ai_token_usage')
+    .delete()
+    .eq('user_id', TEST_USER_ID)
+    .eq('usage_month', currentMonth())
+    .eq('model', 'embedding');
 }
 
 // ---------------------------------------------------------------------------
@@ -160,6 +188,7 @@ describe('indexContent (moodle_file path) — per-page indexing', () => {
       type: 'moodle_file',
       fileId: MOODLE_FILE_ID,
       courseId: MOODLE_COURSE_ID,
+      triggeredByUserId: TEST_USER_ID,
     });
 
     expect(r1.success).toBe(true);
@@ -210,5 +239,21 @@ describe('indexContent (moodle_file path) — per-page indexing', () => {
       .eq('source_id', MOODLE_FILE_ID);
 
     expect(data).toHaveLength(2);
+  });
+
+  it('records embedding token cost for the triggering user', async () => {
+    // The first index ran 2 chunks through embedText (tokens:1 each), and the
+    // Moodle vector itself is shared (user_id=null) — but the COST is attributed
+    // to triggeredByUserId via record_token_usage.
+    const admin = createAdminClient();
+    const { data } = await admin
+      .from('ai_token_usage')
+      .select('input_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('model', 'embedding')
+      .eq('usage_month', currentMonth())
+      .maybeSingle();
+
+    expect(data?.input_tokens ?? 0).toBeGreaterThan(0);
   });
 });

--- a/src/lib/actions/ai-context.ts
+++ b/src/lib/actions/ai-context.ts
@@ -12,6 +12,7 @@ import {
 import { extractDocxText } from '@/lib/ai/extraction/docx';
 import { extractPdfPages } from '@/lib/ai/extraction/pdf';
 import { buildSystemPrompt } from '@/lib/ai/prompts';
+import { recordTokenUsage } from '@/lib/ai/rate-limit';
 import { listContextFiles } from '@/lib/actions/context-files';
 import { resolveContextFileName } from '@/lib/ai/context-files';
 import {
@@ -35,7 +36,13 @@ const MAX_CHUNKS_PER_SOURCE = 3;
 // ---------------------------------------------------------------------------
 
 export type IndexSource =
-  | { type: 'moodle_file'; fileId: string; courseId: string }
+  | {
+      type: 'moodle_file';
+      fileId: string;
+      courseId: string;
+      /** User who triggered the one-time shared embed (for cost attribution). */
+      triggeredByUserId?: string;
+    }
   | { type: 'course_material'; materialId: string; courseId: string }
   | { type: 'personal_file'; fileId: string; courseId: string };
 
@@ -122,6 +129,7 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
     let sourceType = '';
     let sourceId = '';
     let userId: string | null = null;
+    let costUserId: string | null = null; // who pays for the embed (may differ from row owner)
     let courseId: string | null = null;
     let mimeType = 'application/octet-stream';
     let storageBucket = '';
@@ -132,6 +140,7 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
       sourceId = source.fileId;
       courseId = source.courseId;
       userId = null;
+      costUserId = source.triggeredByUserId ?? null;
 
       const { data: fileRow, error: fileErr } = await admin
         .from('moodle_files')
@@ -188,6 +197,7 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
     } else if (source.type === 'course_material') {
       const supabase = await createClient();
       userId = await getAuthUserId();
+      costUserId = userId;
       sourceType = 'course_material';
       sourceId = source.materialId;
       courseId = source.courseId;
@@ -220,6 +230,7 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
     } else {
       const supabase = await createClient();
       userId = await getAuthUserId();
+      costUserId = userId;
       sourceType = 'personal_file';
       sourceId = source.fileId;
       courseId = source.courseId;
@@ -292,8 +303,10 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
     }
 
     const rows: EmbeddingRow[] = [];
+    let embedTokens = 0;
     for (const chunk of chunks) {
-      const embedding = await embedText(chunk.text);
+      const { values: embedding, tokens } = await embedText(chunk.text);
+      embedTokens += tokens;
       // embedText returns [] only on a malformed embeddings API response.
       if (!embedding.length) continue;
 
@@ -333,6 +346,12 @@ export async function indexContent(source: IndexSource): Promise<IndexResult> {
 
     await upsertEmbeddings(rows);
 
+    // Fire-and-forget embedding cost attribution. The vector is shared
+    // (user_id may be null for Moodle); the COST belongs to whoever triggered it.
+    if (costUserId && embedTokens > 0) {
+      recordTokenUsage(costUserId, 'embedding', embedTokens, 0).catch(() => {});
+    }
+
     return { success: true, segmentsIndexed: rows.length, skipped: false };
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
@@ -355,7 +374,12 @@ export async function searchContext(
 ): Promise<SearchResult[]> {
   const userId = await getAuthUserId();
   const supabase = await createClient();
-  const queryEmbedding = await embedQuery(params.query);
+  const { values: queryEmbedding, tokens: queryTokens } = await embedQuery(
+    params.query,
+  );
+  if (queryTokens > 0) {
+    recordTokenUsage(userId, 'embedding', queryTokens, 0).catch(() => {});
+  }
 
   // Resolve Typenote course -> canonical moodle_courses.id (if synced).
   // Uses course_moodle_view RPC so members see the OWNER's Moodle imports,

--- a/src/lib/ai/__tests__/embeddings.test.ts
+++ b/src/lib/ai/__tests__/embeddings.test.ts
@@ -20,13 +20,15 @@ afterEach(() => {
 });
 
 describe('embedText', () => {
-  it('sends text with RETRIEVAL_DOCUMENT task type', async () => {
+  it('sends text with RETRIEVAL_DOCUMENT task type and returns values + token estimate', async () => {
     const mockValues = Array.from({ length: 1536 }, () => 0.2);
     mockEmbedContent.mockResolvedValueOnce({
       embeddings: [{ values: mockValues }],
     });
 
-    const result = await embedText('Some document text');
+    const result = await embedText('Some document text'); // 18 chars -> ceil(18/4)=5
+    expect(result.values).toEqual(mockValues);
+    expect(result.tokens).toBe(5);
 
     expect(mockEmbedContent).toHaveBeenCalledWith({
       model: 'gemini-embedding-2-preview',
@@ -36,7 +38,7 @@ describe('embedText', () => {
         taskType: 'RETRIEVAL_DOCUMENT',
       },
     });
-    expect(result).toHaveLength(1536);
+    expect(result.values).toHaveLength(1536);
   });
 });
 
@@ -57,13 +59,13 @@ describe('embedQuery', () => {
         taskType: 'RETRIEVAL_QUERY',
       },
     });
-    expect(result).toHaveLength(1536);
+    expect(result.values).toHaveLength(1536);
   });
 
   it('returns empty array when no embeddings returned', async () => {
     mockEmbedContent.mockResolvedValueOnce({ embeddings: [] });
     const result = await embedQuery('test');
-    expect(result).toEqual([]);
+    expect(result.values).toEqual([]);
   });
 });
 

--- a/src/lib/ai/__tests__/pricing.test.ts
+++ b/src/lib/ai/__tests__/pricing.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { estimateCostUsd, getModelPrices } from '../pricing';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('estimateCostUsd', () => {
+  it('prices flash input + output per 1M tokens using defaults', () => {
+    // defaults: flash input 0.30, output 2.50 per 1M
+    const cost = estimateCostUsd('flash', 1_000_000, 1_000_000);
+    expect(cost).toBeCloseTo(0.3 + 2.5, 6);
+  });
+
+  it('prices embedding as input-only', () => {
+    // default embedding input 0.20 per 1M (Gemini Embedding 2), output unused
+    const cost = estimateCostUsd('embedding', 2_000_000, 0);
+    expect(cost).toBeCloseTo(0.4, 6);
+  });
+
+  it('returns 0 for an unknown model', () => {
+    expect(estimateCostUsd('mystery', 1_000_000, 1_000_000)).toBe(0);
+  });
+
+  it('honours env overrides so prices are switchable without a deploy', () => {
+    vi.stubEnv('AI_PRICE_FLASH_INPUT', '1.00');
+    vi.stubEnv('AI_PRICE_FLASH_OUTPUT', '3.00');
+    expect(getModelPrices().flash).toEqual({ input: 1.0, output: 3.0 });
+    expect(estimateCostUsd('flash', 1_000_000, 1_000_000)).toBeCloseTo(4.0, 6);
+  });
+
+  it('ignores invalid env values and falls back to default', () => {
+    vi.stubEnv('AI_PRICE_FLASH_INPUT', 'not-a-number');
+    expect(getModelPrices().flash.input).toBe(0.3);
+  });
+});

--- a/src/lib/ai/__tests__/rate-limit.test.ts
+++ b/src/lib/ai/__tests__/rate-limit.test.ts
@@ -407,25 +407,24 @@ describe('getQuota', () => {
 // ---------------------------------------------------------------------------
 
 describe('recordTokenUsage', () => {
-  it('calls record_token_usage RPC with correct params', async () => {
+  it('calls record_token_usage RPC keyed by model', async () => {
     mockRpc.mockResolvedValueOnce({ data: null, error: null });
 
-    await recordTokenUsage('user-123', 'chat', 5000, 400);
+    await recordTokenUsage('user-1', 'pro', 123, 45);
 
     expect(mockRpc).toHaveBeenCalledWith('record_token_usage', {
-      p_user_id: 'user-123',
-      p_query_type: 'chat',
-      p_input_tokens: 5000,
-      p_output_tokens: 400,
+      p_user_id: 'user-1',
+      p_model: 'pro',
+      p_input_tokens: 123,
+      p_output_tokens: 45,
     });
   });
 
-  it('does not throw when RPC fails (fire-and-forget)', async () => {
-    mockRpc.mockRejectedValueOnce(new Error('DB down'));
+  it('never throws if the RPC errors (fire-and-forget)', async () => {
+    mockRpc.mockRejectedValueOnce(new Error('db down'));
 
-    // Should not throw
     await expect(
-      recordTokenUsage('user-123', 'latex', 100, 30),
+      recordTokenUsage('user-1', 'flash', 1, 1),
     ).resolves.toBeUndefined();
   });
 });

--- a/src/lib/ai/__tests__/tokens.test.ts
+++ b/src/lib/ai/__tests__/tokens.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { estimateTokens } from '../tokens';
+
+describe('estimateTokens', () => {
+  it('approximates ~1 token per 4 characters, rounding up', () => {
+    expect(estimateTokens('12345678')).toBe(2); // 8 / 4
+    expect(estimateTokens('123456789')).toBe(3); // ceil(9 / 4)
+  });
+
+  it('returns 0 for empty or whitespace-only text', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens('   ')).toBe(0);
+  });
+
+  it('handles undefined/null defensively', () => {
+    expect(estimateTokens(undefined as unknown as string)).toBe(0);
+  });
+});

--- a/src/lib/ai/embeddings.ts
+++ b/src/lib/ai/embeddings.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI } from '@google/genai';
 import type { PageText } from '@/lib/ai/extraction/pdf';
+import { estimateTokens } from '@/lib/ai/tokens';
 
 const EMBEDDING_MODEL = 'gemini-embedding-2-preview';
 const EMBEDDING_DIMENSIONS = 1536;
@@ -10,10 +11,16 @@ function getGenAI() {
   });
 }
 
+export interface EmbedResult {
+  values: number[];
+  /** Estimated token count (Developer API returns none for embeddings). */
+  tokens: number;
+}
+
 /**
  * Embed a text string for storage (document side of asymmetric retrieval).
  */
-export async function embedText(text: string): Promise<number[]> {
+export async function embedText(text: string): Promise<EmbedResult> {
   const genai = getGenAI();
 
   const response = await genai.models.embedContent({
@@ -25,13 +32,16 @@ export async function embedText(text: string): Promise<number[]> {
     },
   });
 
-  return response.embeddings?.[0]?.values ?? [];
+  return {
+    values: response.embeddings?.[0]?.values ?? [],
+    tokens: estimateTokens(text),
+  };
 }
 
 /**
  * Embed a search query (query side of asymmetric retrieval).
  */
-export async function embedQuery(text: string): Promise<number[]> {
+export async function embedQuery(text: string): Promise<EmbedResult> {
   const genai = getGenAI();
 
   const response = await genai.models.embedContent({
@@ -43,7 +53,10 @@ export async function embedQuery(text: string): Promise<number[]> {
     },
   });
 
-  return response.embeddings?.[0]?.values ?? [];
+  return {
+    values: response.embeddings?.[0]?.values ?? [],
+    tokens: estimateTokens(text),
+  };
 }
 
 export interface PageChunk {

--- a/src/lib/ai/latex.test.ts
+++ b/src/lib/ai/latex.test.ts
@@ -18,29 +18,34 @@ describe('convertToLatex', () => {
     vi.clearAllMocks();
   });
 
-  it('should return LaTeX from the AI model', async () => {
+  it('should return LaTeX and token usage from the AI model', async () => {
     vi.mocked(generateText).mockResolvedValue({
-      text: '\\frac{1}{2} \\times 5',
+      text: '<latex>',
+      usage: { inputTokens: 12, outputTokens: 7 },
     } as unknown as Awaited<ReturnType<typeof generateText>>);
 
     const result = await convertToLatex('one half times five');
 
-    expect(result).toBe('\\frac{1}{2} \\times 5');
+    expect(result.latex).toBe('<latex>');
+    expect(result.inputTokens).toBe(12);
+    expect(result.outputTokens).toBe(7);
   });
 
   it('should trim whitespace from the response', async () => {
     vi.mocked(generateText).mockResolvedValue({
       text: '  \\frac{1}{2}  \n',
+      usage: { inputTokens: 12, outputTokens: 7 },
     } as unknown as Awaited<ReturnType<typeof generateText>>);
 
     const result = await convertToLatex('one half');
 
-    expect(result).toBe('\\frac{1}{2}');
+    expect(result.latex).toBe('\\frac{1}{2}');
   });
 
   it('should call generateText with the correct parameters', async () => {
     vi.mocked(generateText).mockResolvedValue({
       text: '\\frac{1}{2}',
+      usage: { inputTokens: 12, outputTokens: 7 },
     } as unknown as Awaited<ReturnType<typeof generateText>>);
 
     await convertToLatex('one half');

--- a/src/lib/ai/latex.ts
+++ b/src/lib/ai/latex.ts
@@ -1,17 +1,43 @@
 import { generateText } from 'ai';
 import { getModel } from './provider';
 import { buildLatexPrompt } from './prompts';
+import { estimateTokens } from './tokens';
+
+export interface LatexResult {
+  latex: string;
+  inputTokens: number;
+  outputTokens: number;
+}
 
 export async function convertToLatex(
   text: string,
   courseName?: string,
-): Promise<string> {
-  const { text: latex } = await generateText({
+): Promise<LatexResult> {
+  const system = buildLatexPrompt(courseName);
+  const result = await generateText({
     model: getModel(),
-    system: buildLatexPrompt(courseName),
+    system,
     prompt: text,
     temperature: 0,
   });
 
-  return latex.trim();
+  const latex = result.text.trim();
+  // AI SDK usage field naming has varied across versions; read both, then
+  // fall back to a char estimate so we never record zeros.
+  const usage = result.usage as
+    | {
+        inputTokens?: number;
+        promptTokens?: number;
+        outputTokens?: number;
+        completionTokens?: number;
+      }
+    | undefined;
+  const inputTokens =
+    usage?.inputTokens ??
+    usage?.promptTokens ??
+    estimateTokens(`${system}\n${text}`);
+  const outputTokens =
+    usage?.outputTokens ?? usage?.completionTokens ?? estimateTokens(latex);
+
+  return { latex, inputTokens, outputTokens };
 }

--- a/src/lib/ai/pricing.ts
+++ b/src/lib/ai/pricing.ts
@@ -1,0 +1,56 @@
+/**
+ * Per-model AI token prices, in USD per 1,000,000 tokens.
+ *
+ * Prices are ENV-OVERRIDABLE so cost-per-token can be switched without a code
+ * deploy (mirrors the AI_LIMIT_* rate-limit override pattern). Defaults are
+ * approximate published Gemini prices and are safe to adjust.
+ *
+ * Tokens are the primary, accurate metric. The dollar figure is a derived,
+ * switchable estimate and is labeled as such in the UI.
+ */
+
+export interface ModelPrice {
+  input: number; // USD per 1M input tokens
+  output: number; // USD per 1M output tokens
+}
+
+function envPrice(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (raw !== undefined) {
+    const n = Number(raw);
+    if (!Number.isNaN(n) && n >= 0) return n;
+  }
+  return fallback;
+}
+
+export function getModelPrices(): Record<string, ModelPrice> {
+  return {
+    flash: {
+      input: envPrice('AI_PRICE_FLASH_INPUT', 0.3),
+      output: envPrice('AI_PRICE_FLASH_OUTPUT', 2.5),
+    },
+    pro: {
+      input: envPrice('AI_PRICE_PRO_INPUT', 1.25),
+      output: envPrice('AI_PRICE_PRO_OUTPUT', 10.0),
+    },
+    embedding: {
+      // Default = Gemini Embedding 2 text input ($0.20/1M); the app embeds with
+      // gemini-embedding-2-preview. Override via AI_PRICE_EMBEDDING.
+      input: envPrice('AI_PRICE_EMBEDDING', 0.2),
+      output: 0,
+    },
+  };
+}
+
+export function estimateCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const price = getModelPrices()[model];
+  if (!price) return 0;
+  return (
+    (inputTokens / 1_000_000) * price.input +
+    (outputTokens / 1_000_000) * price.output
+  );
+}

--- a/src/lib/ai/rate-limit.ts
+++ b/src/lib/ai/rate-limit.ts
@@ -191,32 +191,27 @@ export async function getQuota(userId: string): Promise<QuotaInfo> {
 // ---------------------------------------------------------------------------
 
 /**
- * Record token counts for admin observability. Called AFTER the AI response.
+ * Record token counts for cost observability. Called AFTER the AI response.
  *
- * This is a fire-and-forget update — it never throws. If the DB update fails,
- * we log and move on. The user's query is not affected.
- *
- * Why not in the atomic RPC? Because token counts are unknown before the AI call,
- * and the RPC runs before the call for fail-closed rate limiting.
+ * Keyed by MODEL ('flash' | 'pro' | 'embedding') so mixed-model usage is priced
+ * correctly. Fire-and-forget — never throws; a metrics-write failure must never
+ * fail the user's AI response.
  */
 export async function recordTokenUsage(
   userId: string,
-  queryType: QueryType,
+  model: string,
   inputTokens: number,
   outputTokens: number,
 ): Promise<void> {
   try {
     const supabase = await createClient();
-
-    // Atomic increment via RPC — can't use .update() because it replaces, not adds.
     await supabase.rpc('record_token_usage', {
       p_user_id: userId,
-      p_query_type: queryType,
+      p_model: model,
       p_input_tokens: inputTokens,
       p_output_tokens: outputTokens,
     });
   } catch (err) {
-    // Fire-and-forget: log but never throw
     console.error('[rate-limit] Failed to record token usage:', err);
   }
 }

--- a/src/lib/ai/tokens.ts
+++ b/src/lib/ai/tokens.ts
@@ -1,0 +1,13 @@
+/**
+ * Rough token estimate from text length. The Gemini Developer API does not
+ * return token counts for embeddings, and generation usage can be absent, so
+ * this is the fallback. ~4 characters per token is the standard heuristic for
+ * Latin-script text. Estimates are accepted — tokens are the metric we report;
+ * the dollar figure derived from them is labeled an estimate.
+ */
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return Math.ceil(trimmed.length / 4);
+}

--- a/src/lib/auth/__tests__/require-admin.test.ts
+++ b/src/lib/auth/__tests__/require-admin.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { notFound, getUser, from } = vi.hoisted(() => ({
+  notFound: vi.fn(() => {
+    throw new Error('NEXT_NOT_FOUND');
+  }),
+  getUser: vi.fn(),
+  from: vi.fn(),
+}));
+vi.mock('next/navigation', () => ({ notFound }));
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(async () => ({ auth: { getUser }, from })),
+}));
+
+import { requireAdmin } from '../require-admin';
+
+function mockProfile(is_admin: boolean | null) {
+  from.mockReturnValue({
+    select: () => ({
+      eq: () => ({
+        single: async () => ({
+          data: is_admin === null ? null : { is_admin },
+          error: null,
+        }),
+      }),
+    }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('requireAdmin', () => {
+  it('returns the user id for an admin', async () => {
+    getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } } });
+    mockProfile(true);
+    await expect(requireAdmin()).resolves.toBe('admin-1');
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it('calls notFound for a logged-in non-admin', async () => {
+    getUser.mockResolvedValue({ data: { user: { id: 'user-1' } } });
+    mockProfile(false);
+    await expect(requireAdmin()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+
+  it('calls notFound when unauthenticated', async () => {
+    getUser.mockResolvedValue({ data: { user: null } });
+    await expect(requireAdmin()).rejects.toThrow('NEXT_NOT_FOUND');
+    expect(notFound).toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth/require-admin.ts
+++ b/src/lib/auth/require-admin.ts
@@ -1,0 +1,33 @@
+import { notFound } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+
+/**
+ * Server-only authorization gate for the /admin area.
+ *
+ * Authentication is handled upstream by middleware (an unauthenticated /admin
+ * hit is redirected to /login before any layout runs). This enforces
+ * AUTHORIZATION: only an is_admin profile may proceed. Non-admins get a 404 so
+ * the admin area is not discoverable. Returns the admin user id.
+ */
+export async function requireAdmin(): Promise<string> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    notFound();
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('is_admin')
+    .eq('id', user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    notFound();
+  }
+
+  return user.id;
+}

--- a/src/lib/queries/admin-usage.integration.test.ts
+++ b/src/lib/queries/admin-usage.integration.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Integration test: getAdminUsage aggregates per-user usage + token cost for a
+ * given month against the seeded deterministic rows (month 2099-01).
+ */
+import { describe, it, expect } from 'vitest';
+import { getAdminUsage } from './admin-usage';
+
+const TEST_USER_ID = 'ac3be77d-4566-406c-9ac0-7c410634ad41';
+
+describe('getAdminUsage (2099-01 seed)', () => {
+  it('returns the seeded user with correct counts and a positive cost', async () => {
+    const { users, totals } = await getAdminUsage('2099-01');
+    const row = users.find((u) => u.userId === TEST_USER_ID);
+
+    expect(row).toBeDefined();
+    expect(row!.chatCount).toBe(12);
+    expect(row!.latexCount).toBe(30);
+    expect(row!.tokensByModel.flash).toEqual({
+      input: 1000000,
+      output: 500000,
+    });
+    expect(row!.tokensByModel.embedding.input).toBe(2000000);
+    // flash 1M in*0.30 + 0.5M out*2.50 + embedding 2M*0.20 = 0.30 + 1.25 + 0.40
+    expect(row!.estimatedCostUsd).toBeCloseTo(1.95, 4);
+    expect(totals.estimatedCostUsd).toBeGreaterThanOrEqual(1.95);
+  });
+
+  it('returns no rows for a month with no activity', async () => {
+    const { users } = await getAdminUsage('1999-01');
+    expect(users).toHaveLength(0);
+  });
+});

--- a/src/lib/queries/admin-usage.ts
+++ b/src/lib/queries/admin-usage.ts
@@ -1,0 +1,127 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+import { estimateCostUsd } from '@/lib/ai/pricing';
+import { resolveLimitForTier } from '@/lib/ai/rate-limit';
+
+export interface ModelTokens {
+  input: number;
+  output: number;
+}
+
+export interface AdminUserUsage {
+  userId: string;
+  email: string;
+  displayName: string | null;
+  tier: string;
+  chatCount: number;
+  latexCount: number;
+  tokensByModel: Record<string, ModelTokens>;
+  estimatedCostUsd: number;
+  /** Chat queries used as a percentage of the tier's chat limit (0-100+). */
+  chatQuotaPct: number;
+}
+
+export interface AdminUsageTotals {
+  chatCount: number;
+  latexCount: number;
+  totalTokens: number;
+  embeddingTokens: number;
+  estimatedCostUsd: number;
+}
+
+export interface AdminUsage {
+  users: AdminUserUsage[];
+  totals: AdminUsageTotals;
+}
+
+/**
+ * Aggregate per-user AI usage + cost for one month. Reads via the service-role
+ * client (bypasses RLS) — call ONLY after requireAdmin() in a Server Component.
+ */
+export async function getAdminUsage(month: string): Promise<AdminUsage> {
+  const admin = createAdminClient();
+
+  const [{ data: profiles }, { data: usage }, { data: tokens }] =
+    await Promise.all([
+      admin
+        .from('profiles')
+        .select('id, email, display_name, subscription_tier'),
+      admin
+        .from('ai_usage')
+        .select('user_id, query_type, query_count')
+        .eq('usage_month', month),
+      admin
+        .from('ai_token_usage')
+        .select('user_id, model, input_tokens, output_tokens')
+        .eq('usage_month', month),
+    ]);
+
+  const byUser = new Map<string, AdminUserUsage>();
+  for (const p of profiles ?? []) {
+    byUser.set(p.id, {
+      userId: p.id,
+      email: p.email,
+      displayName: p.display_name ?? null,
+      tier: p.subscription_tier ?? 'free',
+      chatCount: 0,
+      latexCount: 0,
+      tokensByModel: {},
+      estimatedCostUsd: 0,
+      chatQuotaPct: 0,
+    });
+  }
+
+  for (const u of usage ?? []) {
+    const row = byUser.get(u.user_id);
+    if (!row) continue;
+    if (u.query_type === 'chat') row.chatCount = u.query_count;
+    else if (u.query_type === 'latex') row.latexCount = u.query_count;
+  }
+
+  for (const t of tokens ?? []) {
+    const row = byUser.get(t.user_id);
+    if (!row) continue;
+    row.tokensByModel[t.model] = {
+      input: t.input_tokens,
+      output: t.output_tokens,
+    };
+  }
+
+  const totals: AdminUsageTotals = {
+    chatCount: 0,
+    latexCount: 0,
+    totalTokens: 0,
+    embeddingTokens: 0,
+    estimatedCostUsd: 0,
+  };
+
+  for (const row of byUser.values()) {
+    let cost = 0;
+    for (const [model, tk] of Object.entries(row.tokensByModel)) {
+      cost += estimateCostUsd(model, tk.input, tk.output);
+      totals.totalTokens += tk.input + tk.output;
+      if (model === 'embedding') totals.embeddingTokens += tk.input;
+    }
+    row.estimatedCostUsd = cost;
+    const chatLimit = resolveLimitForTier(row.tier, 'chat');
+    row.chatQuotaPct =
+      chatLimit > 0 ? Math.round((row.chatCount / chatLimit) * 100) : 0;
+
+    totals.chatCount += row.chatCount;
+    totals.latexCount += row.latexCount;
+    totals.estimatedCostUsd += cost;
+  }
+
+  // Only surface users with activity this month (sorted by cost desc — top
+  // spenders first). Zero-activity users add noise; totals already exclude them
+  // since their contribution is zero.
+  const users = [...byUser.values()]
+    .filter(
+      (u) =>
+        u.chatCount > 0 ||
+        u.latexCount > 0 ||
+        Object.keys(u.tokensByModel).length > 0,
+    )
+    .sort((a, b) => b.estimatedCostUsd - a.estimatedCostUsd);
+
+  return { users, totals };
+}

--- a/src/lib/queries/ai-token-usage.integration.test.ts
+++ b/src/lib/queries/ai-token-usage.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration test: record_token_usage upserts into ai_token_usage,
+ * keyed by (user, month, model), accumulating on repeat calls.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createAdminClient, TEST_USER_ID } from '@/test/supabase-client';
+
+let supabase: SupabaseClient;
+
+function currentMonth(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+async function cleanup() {
+  await supabase
+    .from('ai_token_usage')
+    .delete()
+    .eq('user_id', TEST_USER_ID)
+    .eq('usage_month', currentMonth());
+}
+
+beforeAll(async () => {
+  supabase = createAdminClient();
+  await cleanup();
+});
+
+afterAll(cleanup);
+
+describe('record_token_usage', () => {
+  it('inserts a new row for a model on first call', async () => {
+    const { error } = await supabase.rpc('record_token_usage', {
+      p_user_id: TEST_USER_ID,
+      p_model: 'flash',
+      p_input_tokens: 100,
+      p_output_tokens: 40,
+    });
+    expect(error).toBeNull();
+
+    const { data } = await supabase
+      .from('ai_token_usage')
+      .select('input_tokens, output_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('usage_month', currentMonth())
+      .eq('model', 'flash')
+      .single();
+
+    expect(data?.input_tokens).toBe(100);
+    expect(data?.output_tokens).toBe(40);
+  });
+
+  it('accumulates on repeat calls for the same model', async () => {
+    await supabase.rpc('record_token_usage', {
+      p_user_id: TEST_USER_ID,
+      p_model: 'flash',
+      p_input_tokens: 10,
+      p_output_tokens: 5,
+    });
+
+    const { data } = await supabase
+      .from('ai_token_usage')
+      .select('input_tokens, output_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('usage_month', currentMonth())
+      .eq('model', 'flash')
+      .single();
+
+    expect(data?.input_tokens).toBe(110);
+    expect(data?.output_tokens).toBe(45);
+  });
+
+  it('keeps separate models in separate rows', async () => {
+    await supabase.rpc('record_token_usage', {
+      p_user_id: TEST_USER_ID,
+      p_model: 'embedding',
+      p_input_tokens: 999,
+      p_output_tokens: 0,
+    });
+
+    const { data } = await supabase
+      .from('ai_token_usage')
+      .select('model, input_tokens')
+      .eq('user_id', TEST_USER_ID)
+      .eq('usage_month', currentMonth());
+
+    const embedding = data?.find((r) => r.model === 'embedding');
+    expect(embedding?.input_tokens).toBe(999);
+    expect(data?.length).toBe(2); // flash + embedding
+  });
+});

--- a/src/lib/supabase/oauth.test.ts
+++ b/src/lib/supabase/oauth.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSignInWithOAuth = vi.fn();
+
+vi.mock('./client', () => ({
+  createClient: () => ({
+    auth: {
+      signInWithOAuth: mockSignInWithOAuth,
+    },
+  }),
+}));
+
+describe('signInWithGoogle', () => {
+  let originalLocation: Location;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Save and replace window.location (jsdom doesn't allow direct assignment)
+    originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: {
+        ...originalLocation,
+        origin: 'http://localhost:3000',
+        href: 'http://localhost:3000/signup',
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+  });
+
+  it('calls signInWithOAuth with skipBrowserRedirect: true', async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({
+      data: { url: 'https://accounts.google.com/o/oauth2/v2/auth?...' },
+      error: null,
+    });
+
+    const { signInWithGoogle } = await import('./oauth');
+    await signInWithGoogle();
+
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: {
+        redirectTo: 'http://localhost:3000/auth/callback',
+        skipBrowserRedirect: true,
+      },
+    });
+  });
+
+  it('sets window.location.href to the OAuth URL on success', async () => {
+    const oauthUrl =
+      'https://accounts.google.com/o/oauth2/v2/auth?client_id=abc';
+    mockSignInWithOAuth.mockResolvedValueOnce({
+      data: { url: oauthUrl },
+      error: null,
+    });
+
+    const { signInWithGoogle } = await import('./oauth');
+    await signInWithGoogle();
+
+    expect(window.location.href).toBe(oauthUrl);
+  });
+
+  it('redirects to login with error when signInWithOAuth fails', async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({
+      data: { url: null },
+      error: { message: 'Something went wrong' },
+    });
+
+    const { signInWithGoogle } = await import('./oauth');
+    await signInWithGoogle();
+
+    expect(window.location.href).toBe('/login?error=oauth_init_failed');
+  });
+
+  it('redirects to login with error when no URL is returned', async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({
+      data: { url: null },
+      error: null,
+    });
+
+    const { signInWithGoogle } = await import('./oauth');
+    await signInWithGoogle();
+
+    expect(window.location.href).toBe('/login?error=oauth_init_failed');
+  });
+});

--- a/src/lib/supabase/oauth.ts
+++ b/src/lib/supabase/oauth.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import { createClient } from './client';
+
+/**
+ * Initiates Google OAuth sign-in using a Safari-compatible redirect pattern.
+ *
+ * Safari (especially on iPad/iOS) may block programmatic redirects that happen
+ * after an `await` boundary — the browser no longer considers them user-initiated.
+ * Using `skipBrowserRedirect: true` lets us get the OAuth URL from Supabase and
+ * assign `window.location.href` ourselves, keeping the redirect in the same
+ * synchronous-ish call stack as the user gesture.
+ */
+export async function signInWithGoogle() {
+  const supabase = createClient();
+  const { data, error } = await supabase.auth.signInWithOAuth({
+    provider: 'google',
+    options: {
+      redirectTo: `${window.location.origin}/auth/callback`,
+      skipBrowserRedirect: true,
+    },
+  });
+
+  if (error || !data.url) {
+    // Fall back to the login page with an error indicator
+    window.location.href = '/login?error=oauth_init_failed';
+    return;
+  }
+
+  // Navigate directly — stays within user-gesture context for Safari
+  window.location.href = data.url;
+}

--- a/supabase/migrations/20260604120000_ai_token_usage.sql
+++ b/supabase/migrations/20260604120000_ai_token_usage.sql
@@ -1,0 +1,88 @@
+-- AI usage admin dashboard: accurate per-model token cost ledger.
+--
+-- Why a new table instead of more columns on ai_usage?
+-- ai_usage is the RATE-LIMIT ledger (query_count per query_type, drives the
+-- atomic quota RPC). Token COST has a different grain — it must be split by
+-- model (flash/pro/embedding) so a user who mixes Flash + Pro is priced
+-- correctly. Single-responsibility tables: ai_usage counts queries,
+-- ai_token_usage accounts tokens.
+
+-- 1. Cost ledger table
+CREATE TABLE public.ai_token_usage (
+  id            bigserial PRIMARY KEY,
+  user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  usage_month   text NOT NULL DEFAULT to_char(CURRENT_DATE, 'YYYY-MM'),
+  model         text NOT NULL,            -- 'flash' | 'pro' | 'embedding'
+  input_tokens  bigint NOT NULL DEFAULT 0,
+  output_tokens bigint NOT NULL DEFAULT 0,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX ai_token_usage_user_month_model_idx
+  ON public.ai_token_usage (user_id, usage_month, model);
+
+CREATE TRIGGER ai_token_usage_updated_at
+  BEFORE UPDATE ON public.ai_token_usage
+  FOR EACH ROW EXECUTE FUNCTION public.handle_updated_at();
+
+ALTER TABLE public.ai_token_usage ENABLE ROW LEVEL SECURITY;
+
+-- Users may read their own token rows; admin reads bypass RLS via service role.
+CREATE POLICY "Users can view their own token usage"
+  ON public.ai_token_usage FOR SELECT
+  USING (auth.uid() = user_id);
+
+-- 2. Replace record_token_usage: key by MODEL, and UPSERT (embedding rows never
+-- pass through increment_ai_usage, so the row may not exist yet).
+-- Param names change (p_query_type -> p_model), so DROP then CREATE.
+DROP FUNCTION IF EXISTS public.record_token_usage(uuid, text, integer, integer);
+
+CREATE FUNCTION public.record_token_usage(
+  p_user_id uuid,
+  p_model text,
+  p_input_tokens integer,
+  p_output_tokens integer
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  INSERT INTO public.ai_token_usage (user_id, usage_month, model, input_tokens, output_tokens)
+    VALUES (p_user_id, to_char(CURRENT_DATE, 'YYYY-MM'), p_model, p_input_tokens, p_output_tokens)
+    ON CONFLICT (user_id, usage_month, model)
+    DO UPDATE SET
+      input_tokens  = public.ai_token_usage.input_tokens  + p_input_tokens,
+      output_tokens = public.ai_token_usage.output_tokens + p_output_tokens,
+      updated_at    = now();
+END;
+$$;
+
+-- 3. Security fix + cleanup of the old zeroed columns.
+-- The admin_user_ai_usage VIEW referenced these columns, so drop the view first.
+-- It was created without security_invoker (RLS-bypass leak) and joined every
+-- user's email — recreate it security_invoker and REVOKE from public roles.
+DROP VIEW IF EXISTS public.admin_user_ai_usage;
+
+ALTER TABLE public.ai_usage
+  DROP COLUMN IF EXISTS total_input_tokens,
+  DROP COLUMN IF EXISTS total_output_tokens;
+
+CREATE VIEW public.admin_user_ai_usage
+  WITH (security_invoker = true) AS
+SELECT
+  p.id AS user_id,
+  p.display_name,
+  p.email,
+  p.subscription_tier,
+  au.usage_month,
+  au.query_type,
+  au.query_count,
+  au.updated_at
+FROM public.profiles p
+LEFT JOIN public.ai_usage au ON au.user_id = p.id
+ORDER BY au.usage_month DESC, p.display_name;
+
+REVOKE ALL ON public.admin_user_ai_usage FROM anon, authenticated;

--- a/supabase/migrations/20260604120100_profiles_is_admin.sql
+++ b/supabase/migrations/20260604120100_profiles_is_admin.sql
@@ -1,0 +1,5 @@
+-- Admin authorization flag. Authentication stays Supabase Auth (single identity);
+-- this flag is the authorization gate for the /admin area. Default false so no
+-- existing user becomes an admin implicitly.
+ALTER TABLE public.profiles
+  ADD COLUMN is_admin boolean NOT NULL DEFAULT false;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -130,6 +130,73 @@ INSERT INTO auth.identities (
 
 UPDATE public.profiles SET subscription_tier = 'free' WHERE id = 'bd4ce88e-5677-507d-ad1d-8d4275a45b52';
 
+-- ============================================
+-- ADMIN USER (for /admin dashboard authorization)
+-- Email: admin@typenote.dev | Password: Admin1234
+-- ============================================
+
+INSERT INTO auth.users (
+  id,
+  instance_id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  confirmation_token,
+  recovery_token,
+  email_change,
+  email_change_token_new,
+  email_change_token_current,
+  email_change_confirm_status
+) VALUES (
+  '00000000-0000-4000-a000-000000000001',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated',
+  'authenticated',
+  'admin@typenote.dev',
+  crypt('Admin1234', gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}',
+  '{"email":"admin@typenote.dev","email_verified":true,"full_name":"Admin User"}',
+  now(),
+  now(),
+  '',
+  '',
+  '',
+  '',
+  '',
+  0
+) ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.identities (
+  id,
+  user_id,
+  identity_data,
+  provider,
+  provider_id,
+  last_sign_in_at,
+  created_at,
+  updated_at
+) VALUES (
+  '00000000-0000-4000-a000-000000000001',
+  '00000000-0000-4000-a000-000000000001',
+  '{"sub":"00000000-0000-4000-a000-000000000001","email":"admin@typenote.dev","email_verified":true}',
+  'email',
+  '00000000-0000-4000-a000-000000000001',
+  now(),
+  now(),
+  now()
+) ON CONFLICT (provider_id, provider) DO NOTHING;
+
+-- The profile is auto-created by handle_new_user(); flip the authorization flag.
+UPDATE public.profiles SET is_admin = true
+  WHERE id = '00000000-0000-4000-a000-000000000001';
+
 -- Sample AI usage data for testing the quota display
 INSERT INTO public.ai_usage (user_id, usage_month, query_type, query_count, last_model)
 VALUES ('ac3be77d-4566-406c-9ac0-7c410634ad41', to_char(CURRENT_DATE, 'YYYY-MM'), 'chat', 3, 'flash')
@@ -615,3 +682,20 @@ VALUES (
   'close',
   '2026-04-10 14:30:00+00'
 ) ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- DETERMINISTIC AI-USAGE ROWS (admin dashboard E2E, month 2099-01)
+-- ============================================
+
+-- Deterministic AI-usage rows for the admin dashboard E2E (month 2099-01).
+INSERT INTO public.ai_usage (user_id, usage_month, query_type, query_count, last_model)
+VALUES
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'chat', 12, 'flash'),
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'latex', 30, 'flash')
+ON CONFLICT (user_id, usage_month, query_type) DO NOTHING;
+
+INSERT INTO public.ai_token_usage (user_id, usage_month, model, input_tokens, output_tokens)
+VALUES
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'flash', 1000000, 500000),
+  ('ac3be77d-4566-406c-9ac0-7c410634ad41', '2099-01', 'embedding', 2000000, 0)
+ON CONFLICT (user_id, usage_month, model) DO NOTHING;


### PR DESCRIPTION
Clean replacement for #218-era `dev → main` promotion. Supersedes #219 (which was unmergeable due to evil-twin commit divergence under this repo's rebase-merge-only setting).

## What this is
A single promote commit whose **parent is `main`** and whose **tree is exactly `dev`'s tree** — so it rebase-merges onto `main` with **zero conflicts**. Verified: `git diff <commit> origin/dev` is empty (content identical to `dev`).

## Why this approach
`dev` and `main` drifted apart with duplicated ("evil-twin") commits from the earlier "promote dev to main" merge. Diagnosis confirmed **`dev` is a content-superset of `main`** — every file/symbol on `main` (incl. the serverless-await hardening, `concurrency.ts`, `storage-path.ts`, `after-response.ts`, refactored `embeddings.ts`/`ai-context.ts`) is present on `dev`, with the admin work layered additively on top. **Zero files deleted**; 4264 insertions / 320 deletions are line-level evolution within modified files.

## Brings to production
- **AI usage admin dashboard + per-model token cost ledger** — `is_admin`-gated, 404 for non-admins, read-only.
- **Two new migrations:** `20260604120000_ai_token_usage`, `20260604120100_profiles_is_admin`.
- **Dev-only fixes `main` lacked:** LaTeX/Ask-AI overflow clipping; iPad/Safari Google OAuth redirect.

## ⚠️ POST-DEPLOY checklist (manual — CI does NOT run migrations)
1. Apply both migrations to the prod DB.
2. Set Vercel prod env: `AI_PRICE_FLASH_INPUT=0.30`, `AI_PRICE_FLASH_OUTPUT=2.50`, `AI_PRICE_PRO_INPUT=1.25`, `AI_PRICE_PRO_OUTPUT=10.00`, `AI_PRICE_EMBEDDING=0.20`.
3. `UPDATE public.profiles SET is_admin = true WHERE email = 'nadavbarak14@gmail.com';` (account must exist in prod first).

## Test Plan
- [ ] CI green on combined code.
- [ ] After deploy + migrations: `/admin` loads for the promoted admin, 404s for everyone else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)