### PR TITLE
feat(admin): show full user roster in AI usage dashboard

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -236,9 +236,9 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 
 ## Admin AI Usage Dashboard (`e2e/admin-dashboard.spec.ts`) — IMPLEMENTED
 
-Covers the admin-only `/admin` AI usage dashboard (token-ledger aggregation + cost estimate). The route is in the `(admin)` group whose layout calls `requireAdmin()`, which `notFound()`s for non-admins. Uses the seeded admin user (`admin@typenote.dev`) and the deterministic month `2099-01` (test user: chat=12, latex=30, flash 1M/0.5M tokens, embedding 2M tokens → estimated cost `$1.85`).
+Covers the admin-only `/admin` AI usage dashboard (token-ledger aggregation + cost estimate). The route is in the `(admin)` group whose layout calls `requireAdmin()`, which `notFound()`s for non-admins. Uses the seeded admin user (`admin@typenote.dev`) and the deterministic month `2099-01` (test user: chat=12, latex=30, flash 1M/0.5M tokens, embedding 2M tokens → estimated cost `$1.95`). The dashboard lists the **full user roster** (every profile), not just active users — zero-activity users appear with zeroed columns, sorted below active ones.
 
-- [x] Admin logs in and views the dashboard for `/admin?month=2099-01` — asserts the "AI Usage" heading, the seeded test user's email row, the "Chat queries"/"LaTeX queries" summary cards, and the seeded `$1.85` cost
+- [x] Admin logs in and views the dashboard for `/admin?month=2099-01` — asserts the "AI Usage" heading, the seeded test user's email row, the zero-activity admin user's email row (full-roster behavior), the "Chat queries"/"LaTeX queries" summary cards, and the seeded `$1.95` cost
 - [x] Admin sees the "AI Usage" sidebar nav link and reaches the dashboard by clicking it
 - [x] Non-admin (`test@typenote.dev`) is blocked from `/admin` — HTTP 404, and the admin-only "AI Usage" nav link does not render
 

--- a/e2e/admin-dashboard.spec.ts
+++ b/e2e/admin-dashboard.spec.ts
@@ -16,6 +16,10 @@ test.describe('Admin AI Usage Dashboard', () => {
     // Seeded test user row is present with its email.
     await expect(page.getByText('test@typenote.dev')).toBeVisible();
 
+    // Full roster: zero-activity users appear too. The admin account has no
+    // usage in 2099-01 but must still be listed (sorted below active users).
+    await expect(page.getByRole('cell', { name: ADMIN_EMAIL })).toBeVisible();
+
     // Summary cards present.
     await expect(page.getByText('Chat queries')).toBeVisible();
     await expect(page.getByText('LaTeX queries')).toBeVisible();

--- a/src/lib/queries/admin-usage.integration.test.ts
+++ b/src/lib/queries/admin-usage.integration.test.ts
@@ -6,6 +6,9 @@ import { describe, it, expect } from 'vitest';
 import { getAdminUsage } from './admin-usage';
 
 const TEST_USER_ID = 'ac3be77d-4566-406c-9ac0-7c410634ad41';
+// admin@typenote.dev — seeded but has NO ai_usage/token rows in any test month,
+// so it's our canary for the "show every user, even zero-activity" behavior.
+const ADMIN_USER_ID = '00000000-0000-4000-a000-000000000001';
 
 describe('getAdminUsage (2099-01 seed)', () => {
   it('returns the seeded user with correct counts and a positive cost', async () => {
@@ -25,8 +28,37 @@ describe('getAdminUsage (2099-01 seed)', () => {
     expect(totals.estimatedCostUsd).toBeGreaterThanOrEqual(1.95);
   });
 
-  it('returns no rows for a month with no activity', async () => {
-    const { users } = await getAdminUsage('1999-01');
-    expect(users).toHaveLength(0);
+  it('also lists zero-activity users (full roster), with zeroed columns', async () => {
+    const { users } = await getAdminUsage('2099-01');
+    const admin = users.find((u) => u.userId === ADMIN_USER_ID);
+
+    expect(admin).toBeDefined();
+    expect(admin!.chatCount).toBe(0);
+    expect(admin!.latexCount).toBe(0);
+    expect(admin!.tokensByModel).toEqual({});
+    expect(admin!.estimatedCostUsd).toBe(0);
+    // Active users sort ahead of zero-activity ones (cost desc).
+    const activeIdx = users.findIndex((u) => u.userId === TEST_USER_ID);
+    const adminIdx = users.findIndex((u) => u.userId === ADMIN_USER_ID);
+    expect(activeIdx).toBeLessThan(adminIdx);
+  });
+
+  it('still lists every user for a month with no activity (all zeroed)', async () => {
+    const { users, totals } = await getAdminUsage('1999-01');
+
+    // The roster is the full set of profiles, independent of the month.
+    expect(users.length).toBeGreaterThanOrEqual(2);
+    expect(users.some((u) => u.userId === TEST_USER_ID)).toBe(true);
+    expect(users.some((u) => u.userId === ADMIN_USER_ID)).toBe(true);
+    expect(
+      users.every(
+        (u) =>
+          u.chatCount === 0 &&
+          u.latexCount === 0 &&
+          Object.keys(u.tokensByModel).length === 0 &&
+          u.estimatedCostUsd === 0,
+      ),
+    ).toBe(true);
+    expect(totals.estimatedCostUsd).toBe(0);
   });
 });

--- a/src/lib/queries/admin-usage.ts
+++ b/src/lib/queries/admin-usage.ts
@@ -111,17 +111,16 @@ export async function getAdminUsage(month: string): Promise<AdminUsage> {
     totals.estimatedCostUsd += cost;
   }
 
-  // Only surface users with activity this month (sorted by cost desc — top
-  // spenders first). Zero-activity users add noise; totals already exclude them
-  // since their contribution is zero.
-  const users = [...byUser.values()]
-    .filter(
-      (u) =>
-        u.chatCount > 0 ||
-        u.latexCount > 0 ||
-        Object.keys(u.tokensByModel).length > 0,
-    )
-    .sort((a, b) => b.estimatedCostUsd - a.estimatedCostUsd);
+  // Surface every registered user (full roster), not just those active this
+  // month — admins want complete visibility, including who has never used AI.
+  // Sort top spenders first (cost desc), then by query volume, then email so the
+  // ordering is stable; zero-activity users naturally sink to the bottom.
+  const users = [...byUser.values()].sort(
+    (a, b) =>
+      b.estimatedCostUsd - a.estimatedCostUsd ||
+      b.chatCount + b.latexCount - (a.chatCount + a.latexCount) ||
+      a.email.localeCompare(b.email),
+  );
 
   return { users, totals };
 }


### PR DESCRIPTION
## Summary
The admin AI-usage dashboard was filtering to users **with activity in the selected month**, so on a fresh prod (empty token ledger) it showed only the handful of users with historical query counts — and all their token/cost columns read `$0`.

This changes the dashboard to list the **full user roster** (every registered profile), with zero-activity users sorted below active ones (cost desc → query volume → email for stable ordering).

## Why tokens/cost were `$0` (not a bug)
`ai_token_usage` is a brand-new ledger that only fills from AI queries made **after** the token-recording code deployed (prod's last AI query predates the deploy). Verified the `record_token_usage` RPC + UPSERT works end-to-end in prod via a rolled-back probe. So the `$0`s are simply "no data yet" — this PR just stops hiding the idle users so the roster is complete in the meantime.

## Changes
- `admin-usage.ts`: drop the active-only filter; sort all profiles (cost desc, then query volume, then email)
- `admin-usage.integration.test.ts`: assert zero-activity users appear (full roster); a no-activity month still returns every profile, all zeroed
- `admin-dashboard.spec.ts` (E2E): assert the zero-activity admin row renders
- `TEST_REGISTRY.md`: document full-roster behavior; fix stale `$1.85` → `$1.95`

## Test Plan
- [x] `pnpm test` — 991 passed
- [x] `pnpm test:integration` — 198 passed (incl. updated admin-usage)
- [x] `pnpm test:e2e admin-dashboard.spec.ts` — 3/3 passed
- [x] `eslint` + `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)