### PR TITLE
feat(admin): richer usage dashboard — day scoping, sortable roster, daily trend

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -236,13 +236,16 @@ Test lives in `src/__tests__/integration/storage-rls.integration.test.ts`. Verif
 
 ## Admin AI Usage Dashboard (`e2e/admin-dashboard.spec.ts`) — IMPLEMENTED
 
-Covers the admin-only `/admin` AI usage dashboard (token-ledger aggregation + cost estimate). The route is in the `(admin)` group whose layout calls `requireAdmin()`, which `notFound()`s for non-admins. Uses the seeded admin user (`admin@typenote.dev`) and the deterministic month `2099-01` (test user: chat=12, latex=30, flash 1M/0.5M tokens, embedding 2M tokens → estimated cost `$1.95`). The dashboard lists the **full user roster** (every profile), not just active users — zero-activity users appear with zeroed columns, sorted below active ones.
+Covers the admin-only `/admin` AI usage dashboard (event-ledger aggregation + cost estimate). The route is in the `(admin)` group whose layout calls `requireAdmin()`, which `notFound()`s for non-admins. Uses the seeded admin user (`admin@typenote.dev`) and the deterministic month `2099-01` (test user usage on `2099-01-05` and `2099-01-06` → full-month estimated cost `$1.95`; the `2099-01-06` slice is `$1.02`). The dashboard lists the **full user roster** (from `auth.users`), not just active users — zero-activity users appear with zeroed columns. It also shows richer KPIs (active users, total queries, chat/latex/embedding counts, tokens, cost), a **month-wide daily-totals trend**, an optional **day picker** that scopes the roster to a single UTC day, and a **client-side sortable + filterable** per-user table.
 
 - [x] Admin logs in and views the dashboard for `/admin?month=2099-01` — asserts the "AI Usage" heading, the seeded test user's email row, the zero-activity admin user's email row (full-roster behavior), the "Chat queries"/"LaTeX queries" summary cards, and the seeded `$1.95` cost
 - [x] Admin sees the "AI Usage" sidebar nav link and reaches the dashboard by clicking it
 - [x] Non-admin (`test@typenote.dev`) is blocked from `/admin` — HTTP 404, and the admin-only "AI Usage" nav link does not render
 - [x] Admin user drill-down — roster email link → `/admin/users/<id>` heading; by-month row `2099-01` drills to `?month=2099-01`; by-day row `2099-01-06` (2 events) drills to `?day=2099-01-06`; per-query table shows the `embedding` type row; "Questions by document" section is present
 - [x] Non-admin receives HTTP 404 when navigating directly to `/admin/users/<id>`
+- [x] Richer KPIs + daily trend — asserts the new "Active users", "Total queries", "Embeddings" KPI cards, the "Daily totals — 2099-01" section heading, and month-wide trend links for both seeded days (`2099-01-05`, `2099-01-06`)
+- [x] Day scoping — clicking the `2099-01-06` daily-trend link sets `?day=2099-01-06`; the test user's roster row switches from the full-month `$1.95` to that day's `$1.02` slice; the day picker (`Usage day`) reflects the selection
+- [x] Roster sorting + filter — default sort is cost-desc (active test user on top); clicking the "Est. cost" header toggles `aria-sort="ascending"` and surfaces a `$0.00` user; the "Filter users" box narrows the roster to the matching user
 
 ---
 
@@ -266,7 +269,7 @@ Covers the admin-only `/admin` AI usage dashboard (token-ledger aggregation + co
 | Extension Real Load   | Implemented | `e2e/extension-real.spec.ts`             | 3/3         |
 | Version History       | Planned     | `e2e/version-history.spec.ts`            | 0/5         |
 | PDF Visual Regression | Implemented | `e2e/pdf-visual-regression.spec.ts`      | 8/8         |
-| Admin AI Usage        | Implemented | `e2e/admin-dashboard.spec.ts`            | 5/5         |
+| Admin AI Usage        | Implemented | `e2e/admin-dashboard.spec.ts`            | 8/8         |
 | **Total**             |             |                                          | **104/114** |
 
 ---

--- a/e2e/admin-dashboard.spec.ts
+++ b/e2e/admin-dashboard.spec.ts
@@ -99,4 +99,74 @@ test.describe('Admin AI Usage Dashboard', () => {
     );
     expect(res?.status()).toBe(404);
   });
+
+  test('shows richer KPIs and a month-wide daily-totals trend', async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await page.goto('/admin?month=2099-01');
+
+    // New KPI cards beyond chat/latex.
+    await expect(page.getByText('Active users')).toBeVisible();
+    await expect(page.getByText('Total queries')).toBeVisible();
+    await expect(page.getByText('Embeddings')).toBeVisible();
+
+    // Daily trend section lists both seeded days (06 has 2 events, 05 has 1).
+    await expect(
+      page.getByRole('heading', { name: 'Daily totals — 2099-01' }),
+    ).toBeVisible();
+    await expect(page.getByRole('link', { name: '2099-01-06' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '2099-01-05' })).toBeVisible();
+  });
+
+  test('day picker / trend link scopes the roster to a single day', async ({
+    page,
+  }) => {
+    await loginAs(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await page.goto('/admin?month=2099-01');
+
+    const roster = page.getByTestId('usage-roster');
+    const testRow = roster
+      .getByRole('row')
+      .filter({ has: page.getByRole('link', { name: 'test@typenote.dev' }) });
+
+    // Month view: test user's full-month cost is $1.95.
+    await expect(testRow).toContainText('$1.95');
+
+    // Scope to 2099-01-06 via the daily-trend link.
+    await page.getByRole('link', { name: '2099-01-06' }).click();
+    await expect(page).toHaveURL(/day=2099-01-06/);
+
+    // That day's slice for the test user is $1.02 (chat $0.62 + embedding $0.40).
+    await expect(testRow).toContainText('$1.02');
+    await expect(testRow).not.toContainText('$1.95');
+
+    // The day picker reflects the selection.
+    await expect(page.getByLabel('Usage day')).toHaveValue('2099-01-06');
+  });
+
+  test('roster columns sort on header click', async ({ page }) => {
+    await loginAs(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+    await page.goto('/admin?month=2099-01');
+
+    const roster = page.getByTestId('usage-roster');
+    const firstRow = roster.locator('tbody tr').first();
+
+    // Default sort is cost desc → the only active user (test@) is on top.
+    await expect(firstRow).toContainText('test@typenote.dev');
+
+    // Click "Est. cost" header → toggles to ascending → a $0.00 user surfaces.
+    await roster.getByRole('button', { name: /Est\. cost/ }).click();
+    const costHeader = roster.getByRole('columnheader', { name: /Est\. cost/ });
+    await expect(costHeader).toHaveAttribute('aria-sort', 'ascending');
+    await expect(firstRow).toContainText('$0.00');
+    await expect(firstRow).not.toContainText('test@typenote.dev');
+
+    // Filter box narrows the roster to the matching user.
+    await page.getByLabel('Filter users').fill('test@typenote');
+    await expect(roster.locator('tbody tr')).toHaveCount(1);
+    await expect(roster.locator('tbody tr').first()).toContainText(
+      'test@typenote.dev',
+    );
+  });
 });

--- a/src/app/(admin)/admin/page.tsx
+++ b/src/app/(admin)/admin/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import { getAdminUsage } from '@/lib/queries/admin-usage';
 import { MonthSelect } from '@/components/admin/month-select';
+import { DaySelect } from '@/components/admin/day-select';
+import { UsageRoster } from '@/components/admin/usage-roster';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 export const dynamic = 'force-dynamic';
@@ -14,134 +16,143 @@ function usd(n: number): string {
   return `$${n.toFixed(2)}`;
 }
 
-function tokensFor(
-  tokensByModel: Record<string, { input: number; output: number }>,
-  model: string,
-): number {
-  const t = tokensByModel[model];
-  return t ? t.input + t.output : 0;
+function Kpi({ label, value }: { label: string; value: string }) {
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="text-2xl font-bold">{value}</CardContent>
+    </Card>
+  );
 }
 
 export default async function AdminUsagePage({
   searchParams,
 }: {
-  searchParams: Promise<{ month?: string }>;
+  searchParams: Promise<{ month?: string; day?: string }>;
 }) {
-  const { month } = await searchParams;
+  const { month, day } = await searchParams;
   const selectedMonth = month ?? currentMonth();
-  const { users, totals } = await getAdminUsage(selectedMonth);
+  // Only honour a day that belongs to the selected month.
+  const selectedDay = day?.startsWith(selectedMonth) ? day : undefined;
+
+  const { users, totals, dailyTotals } = await getAdminUsage(
+    selectedMonth,
+    selectedDay,
+  );
+  const maxDayCost = Math.max(0, ...dailyTotals.map((d) => d.estimatedCostUsd));
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <p className="text-sm text-muted-foreground">
-          Source-of-truth usage from the token ledger. Cost is an estimate
-          (switchable via per-model price env vars).
+          Source-of-truth usage from the event ledger
+          {selectedDay ? ` — ${selectedDay}` : ` — ${selectedMonth}`}. Cost is
+          an estimate (switchable via per-model price env vars).
         </p>
-        <MonthSelect selected={selectedMonth} />
+        <div className="flex items-center gap-2">
+          <MonthSelect selected={selectedMonth} />
+          <DaySelect month={selectedMonth} selected={selectedDay} />
+        </div>
       </div>
 
-      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Chat queries
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-2xl font-bold">
-            {totals.chatCount}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              LaTeX queries
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-2xl font-bold">
-            {totals.latexCount}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Total tokens
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-2xl font-bold">
-            {totals.totalTokens.toLocaleString()}
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardTitle className="text-sm font-medium text-muted-foreground">
-              Est. cost
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="text-2xl font-bold">
-            {usd(totals.estimatedCostUsd)}
-          </CardContent>
-        </Card>
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4 lg:grid-cols-7">
+        <Kpi
+          label="Active users"
+          value={`${totals.activeUsers} / ${totals.totalUsers}`}
+        />
+        <Kpi
+          label="Total queries"
+          value={totals.totalQueries.toLocaleString()}
+        />
+        <Kpi label="Chat queries" value={totals.chatCount.toLocaleString()} />
+        <Kpi label="LaTeX queries" value={totals.latexCount.toLocaleString()} />
+        <Kpi
+          label="Embeddings"
+          value={totals.embeddingCount.toLocaleString()}
+        />
+        <Kpi label="Total tokens" value={totals.totalTokens.toLocaleString()} />
+        <Kpi label="Est. cost" value={usd(totals.estimatedCostUsd)} />
       </div>
 
-      <div className="overflow-x-auto rounded-lg border">
-        <table className="w-full text-sm">
-          <thead className="bg-muted/50 text-left">
-            <tr>
-              <th className="px-3 py-2 font-medium">User</th>
-              <th className="px-3 py-2 font-medium">Tier</th>
-              <th className="px-3 py-2 text-right font-medium">Chat</th>
-              <th className="px-3 py-2 text-right font-medium">LaTeX</th>
-              <th className="px-3 py-2 text-right font-medium">Flash tok</th>
-              <th className="px-3 py-2 text-right font-medium">Pro tok</th>
-              <th className="px-3 py-2 text-right font-medium">Embed tok</th>
-              <th className="px-3 py-2 text-right font-medium">Est. cost</th>
-              <th className="px-3 py-2 text-right font-medium">Chat quota</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.map((u) => (
-              <tr key={u.userId} className="border-t">
-                <td className="px-3 py-2">
-                  <Link
-                    href={`/admin/users/${u.userId}`}
-                    className="text-primary underline-offset-2 hover:underline"
-                  >
-                    {u.email}
-                  </Link>
-                </td>
-                <td className="px-3 py-2">{u.tier}</td>
-                <td className="px-3 py-2 text-right">{u.chatCount}</td>
-                <td className="px-3 py-2 text-right">{u.latexCount}</td>
-                <td className="px-3 py-2 text-right">
-                  {tokensFor(u.tokensByModel, 'flash').toLocaleString()}
-                </td>
-                <td className="px-3 py-2 text-right">
-                  {tokensFor(u.tokensByModel, 'pro').toLocaleString()}
-                </td>
-                <td className="px-3 py-2 text-right">
-                  {tokensFor(u.tokensByModel, 'embedding').toLocaleString()}
-                </td>
-                <td className="px-3 py-2 text-right">
-                  {usd(u.estimatedCostUsd)}
-                </td>
-                <td
-                  className={
-                    'px-3 py-2 text-right ' +
-                    (u.chatQuotaPct >= 100
-                      ? 'font-semibold text-destructive'
-                      : u.chatQuotaPct >= 80
-                        ? 'font-medium text-amber-600'
-                        : '')
-                  }
-                >
-                  {u.chatQuotaPct}%
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <section className="space-y-2">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Daily totals — {selectedMonth}
+        </h2>
+        {dailyTotals.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No usage recorded this month.
+          </p>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Day</th>
+                  <th className="px-3 py-2 text-right font-medium">Queries</th>
+                  <th className="px-3 py-2 text-right font-medium">Tokens</th>
+                  <th className="px-3 py-2 text-right font-medium">
+                    Est. cost
+                  </th>
+                  <th className="w-1/3 px-3 py-2 font-medium">Cost share</th>
+                </tr>
+              </thead>
+              <tbody>
+                {dailyTotals.map((d) => (
+                  <tr key={d.day} className="border-t">
+                    <td className="px-3 py-2">
+                      <Link
+                        href={`/admin?month=${selectedMonth}&day=${d.day}`}
+                        className={
+                          'text-primary hover:underline ' +
+                          (d.day === selectedDay ? 'font-semibold' : '')
+                        }
+                      >
+                        {d.day}
+                      </Link>
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {d.queryCount.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {d.totalTokens.toLocaleString()}
+                    </td>
+                    <td className="px-3 py-2 text-right">
+                      {usd(d.estimatedCostUsd)}
+                    </td>
+                    <td className="px-3 py-2">
+                      <div
+                        className="h-2 rounded bg-primary/70"
+                        style={{
+                          width: `${
+                            maxDayCost > 0
+                              ? Math.max(
+                                  2,
+                                  (d.estimatedCostUsd / maxDayCost) * 100,
+                                )
+                              : 0
+                          }%`,
+                        }}
+                      />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="text-sm font-medium text-muted-foreground">
+          Per-user{selectedDay ? ` — ${selectedDay}` : ''} (click a column to
+          sort)
+        </h2>
+        <UsageRoster users={users} />
+      </section>
     </div>
   );
 }

--- a/src/components/admin/day-select.tsx
+++ b/src/components/admin/day-select.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+/** Every 'YYYY-MM-DD' in the given 'YYYY-MM' month, ascending. */
+function daysInMonth(month: string): string[] {
+  const [y, m] = month.split('-').map(Number);
+  const count = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  return Array.from(
+    { length: count },
+    (_, i) => `${month}-${String(i + 1).padStart(2, '0')}`,
+  );
+}
+
+const ALL = 'all';
+
+export function DaySelect({
+  month,
+  selected,
+}: {
+  month: string;
+  selected?: string;
+}) {
+  const router = useRouter();
+  return (
+    <select
+      aria-label="Usage day"
+      className="rounded-md border border-input bg-background px-3 py-2 text-sm"
+      value={selected ?? ALL}
+      onChange={(e) => {
+        const v = e.target.value;
+        router.push(
+          v === ALL
+            ? `/admin?month=${month}`
+            : `/admin?month=${month}&day=${v}`,
+        );
+      }}
+    >
+      <option value={ALL}>All days</option>
+      {daysInMonth(month).map((d) => (
+        <option key={d} value={d}>
+          {d.slice(8)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/components/admin/usage-roster.tsx
+++ b/src/components/admin/usage-roster.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import type { AdminUserUsage } from '@/lib/queries/admin-usage';
+import { sortUsers, type SortKey, type SortDir } from '@/lib/admin/roster-sort';
+
+function usd(n: number) {
+  return `$${n.toFixed(2)}`;
+}
+function tokensFor(u: AdminUserUsage, model: string): number {
+  const t = u.tokensByModel[model];
+  return t ? t.input + t.output : 0;
+}
+
+interface Column {
+  key: SortKey;
+  label: string;
+  numeric: boolean;
+  render: (u: AdminUserUsage) => React.ReactNode;
+}
+
+const COLUMNS: Column[] = [
+  {
+    key: 'email',
+    label: 'User',
+    numeric: false,
+    render: (u) => (
+      <Link
+        href={`/admin/users/${u.userId}`}
+        className="text-primary underline-offset-2 hover:underline"
+      >
+        {u.email}
+      </Link>
+    ),
+  },
+  { key: 'tier', label: 'Tier', numeric: false, render: (u) => u.tier },
+  { key: 'chat', label: 'Chat', numeric: true, render: (u) => u.chatCount },
+  { key: 'latex', label: 'LaTeX', numeric: true, render: (u) => u.latexCount },
+  {
+    key: 'embedding',
+    label: 'Embed',
+    numeric: true,
+    render: (u) => u.embeddingCount,
+  },
+  {
+    key: 'flash',
+    label: 'Flash tok',
+    numeric: true,
+    render: (u) => tokensFor(u, 'flash').toLocaleString(),
+  },
+  {
+    key: 'pro',
+    label: 'Pro tok',
+    numeric: true,
+    render: (u) => tokensFor(u, 'pro').toLocaleString(),
+  },
+  {
+    key: 'embedTokens',
+    label: 'Embed tok',
+    numeric: true,
+    render: (u) => tokensFor(u, 'embedding').toLocaleString(),
+  },
+  {
+    key: 'tokens',
+    label: 'Tokens',
+    numeric: true,
+    render: (u) => u.totalTokens.toLocaleString(),
+  },
+  {
+    key: 'cost',
+    label: 'Est. cost',
+    numeric: true,
+    render: (u) => usd(u.estimatedCostUsd),
+  },
+  {
+    key: 'quota',
+    label: 'Chat quota',
+    numeric: true,
+    render: (u) => (
+      <span
+        className={
+          u.chatQuotaPct >= 100
+            ? 'font-semibold text-destructive'
+            : u.chatQuotaPct >= 80
+              ? 'font-medium text-amber-600'
+              : ''
+        }
+      >
+        {u.chatQuotaPct}%
+      </span>
+    ),
+  },
+];
+
+export function UsageRoster({ users }: { users: AdminUserUsage[] }) {
+  const [query, setQuery] = useState('');
+  const [sortKey, setSortKey] = useState<SortKey>('cost');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? users.filter(
+          (u) =>
+            u.email.toLowerCase().includes(q) ||
+            (u.displayName?.toLowerCase().includes(q) ?? false),
+        )
+      : users;
+    return sortUsers(filtered, sortKey, sortDir);
+  }, [users, query, sortKey, sortDir]);
+
+  function toggleSort(col: Column) {
+    if (col.key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(col.key);
+      setSortDir(col.numeric ? 'desc' : 'asc');
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <input
+          type="search"
+          aria-label="Filter users"
+          placeholder="Filter by email…"
+          className="w-64 rounded-md border border-input bg-background px-3 py-2 text-sm"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">
+          {rows.length} {rows.length === 1 ? 'user' : 'users'}
+        </p>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <table data-testid="usage-roster" className="w-full text-sm">
+          <thead className="bg-muted/50 text-left">
+            <tr>
+              {COLUMNS.map((col) => {
+                const active = col.key === sortKey;
+                return (
+                  <th
+                    key={col.key}
+                    aria-sort={
+                      active
+                        ? sortDir === 'asc'
+                          ? 'ascending'
+                          : 'descending'
+                        : 'none'
+                    }
+                    className={
+                      'px-3 py-2 font-medium' +
+                      (col.numeric ? ' text-right' : '')
+                    }
+                  >
+                    <button
+                      type="button"
+                      onClick={() => toggleSort(col)}
+                      className={
+                        'inline-flex items-center gap-1 hover:text-foreground ' +
+                        (active ? 'text-foreground' : 'text-muted-foreground')
+                      }
+                    >
+                      {col.label}
+                      <span aria-hidden className="text-xs">
+                        {active ? (sortDir === 'asc' ? '▲' : '▼') : '↕'}
+                      </span>
+                    </button>
+                  </th>
+                );
+              })}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((u) => (
+              <tr key={u.userId} className="border-t">
+                {COLUMNS.map((col) => (
+                  <td
+                    key={col.key}
+                    className={'px-3 py-2' + (col.numeric ? ' text-right' : '')}
+                  >
+                    {col.render(u)}
+                  </td>
+                ))}
+              </tr>
+            ))}
+            {rows.length === 0 && (
+              <tr>
+                <td
+                  colSpan={COLUMNS.length}
+                  className="px-3 py-6 text-center text-muted-foreground"
+                >
+                  No users match “{query}”.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/admin/__tests__/roster-sort.test.ts
+++ b/src/lib/admin/__tests__/roster-sort.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { sortUsers, sortValue } from '@/lib/admin/roster-sort';
+import type { AdminUserUsage } from '@/lib/queries/admin-usage';
+
+function u(partial: Partial<AdminUserUsage>): AdminUserUsage {
+  return {
+    userId: partial.userId ?? partial.email ?? 'id',
+    email: partial.email ?? 'x@x.dev',
+    displayName: partial.displayName ?? null,
+    tier: partial.tier ?? 'free',
+    chatCount: partial.chatCount ?? 0,
+    latexCount: partial.latexCount ?? 0,
+    embeddingCount: partial.embeddingCount ?? 0,
+    totalTokens: partial.totalTokens ?? 0,
+    tokensByModel: partial.tokensByModel ?? {},
+    estimatedCostUsd: partial.estimatedCostUsd ?? 0,
+    chatQuotaPct: partial.chatQuotaPct ?? 0,
+  };
+}
+
+const ROSTER = [
+  u({ email: 'carol@x.dev', estimatedCostUsd: 0.5, chatCount: 2 }),
+  u({ email: 'alice@x.dev', estimatedCostUsd: 2.0, chatCount: 1 }),
+  u({ email: 'bob@x.dev', estimatedCostUsd: 0.5, chatCount: 9 }),
+];
+
+describe('sortValue', () => {
+  it('lowercases string keys and reads model token totals', () => {
+    expect(sortValue(u({ email: 'A@B.dev' }), 'email')).toBe('a@b.dev');
+    expect(
+      sortValue(
+        u({ tokensByModel: { flash: { input: 10, output: 5 } } }),
+        'flash',
+      ),
+    ).toBe(15);
+    expect(
+      sortValue(
+        u({ tokensByModel: { embedding: { input: 7, output: 0 } } }),
+        'embedTokens',
+      ),
+    ).toBe(7);
+  });
+});
+
+describe('sortUsers', () => {
+  it('sorts by cost descending', () => {
+    const r = sortUsers(ROSTER, 'cost', 'desc');
+    expect(r.map((x) => x.email)).toEqual([
+      'alice@x.dev', // 2.0
+      'bob@x.dev', // 0.5, tiebreak by email (bob < carol)
+      'carol@x.dev', // 0.5
+    ]);
+  });
+
+  it('sorts by cost ascending', () => {
+    const r = sortUsers(ROSTER, 'cost', 'asc');
+    expect(r.map((x) => x.email)).toEqual([
+      'bob@x.dev',
+      'carol@x.dev',
+      'alice@x.dev',
+    ]);
+  });
+
+  it('sorts by email ascending (case-insensitive)', () => {
+    const r = sortUsers(ROSTER, 'email', 'asc');
+    expect(r.map((x) => x.email)).toEqual([
+      'alice@x.dev',
+      'bob@x.dev',
+      'carol@x.dev',
+    ]);
+  });
+
+  it('sorts by a numeric column with email tiebreak', () => {
+    const r = sortUsers(ROSTER, 'chat', 'desc');
+    expect(r.map((x) => x.email)).toEqual([
+      'bob@x.dev', // 9
+      'carol@x.dev', // 2
+      'alice@x.dev', // 1
+    ]);
+  });
+
+  it('does not mutate the input array', () => {
+    const before = ROSTER.map((x) => x.email);
+    sortUsers(ROSTER, 'cost', 'asc');
+    expect(ROSTER.map((x) => x.email)).toEqual(before);
+  });
+});

--- a/src/lib/admin/roster-sort.ts
+++ b/src/lib/admin/roster-sort.ts
@@ -1,0 +1,73 @@
+import type { AdminUserUsage } from '@/lib/queries/admin-usage';
+
+export type SortKey =
+  | 'email'
+  | 'tier'
+  | 'chat'
+  | 'latex'
+  | 'embedding'
+  | 'flash'
+  | 'pro'
+  | 'embedTokens'
+  | 'tokens'
+  | 'cost'
+  | 'quota';
+export type SortDir = 'asc' | 'desc';
+
+function tokensFor(u: AdminUserUsage, model: string): number {
+  const t = u.tokensByModel[model];
+  return t ? t.input + t.output : 0;
+}
+
+/** Numeric/string value a column sorts on. */
+export function sortValue(u: AdminUserUsage, key: SortKey): number | string {
+  switch (key) {
+    case 'email':
+      return u.email.toLowerCase();
+    case 'tier':
+      return u.tier.toLowerCase();
+    case 'chat':
+      return u.chatCount;
+    case 'latex':
+      return u.latexCount;
+    case 'embedding':
+      return u.embeddingCount;
+    case 'flash':
+      return tokensFor(u, 'flash');
+    case 'pro':
+      return tokensFor(u, 'pro');
+    case 'embedTokens':
+      return tokensFor(u, 'embedding');
+    case 'tokens':
+      return u.totalTokens;
+    case 'cost':
+      return u.estimatedCostUsd;
+    case 'quota':
+      return u.chatQuotaPct;
+  }
+}
+
+/**
+ * Stable sort of a roster by a column. Pure — no DB, no React. Returns a new
+ * array; email is the deterministic tiebreaker so ordering is reproducible.
+ */
+export function sortUsers(
+  users: AdminUserUsage[],
+  key: SortKey,
+  dir: SortDir,
+): AdminUserUsage[] {
+  const factor = dir === 'asc' ? 1 : -1;
+  return [...users].sort((a, b) => {
+    const av = sortValue(a, key);
+    const bv = sortValue(b, key);
+    let cmp: number;
+    if (typeof av === 'string' || typeof bv === 'string') {
+      cmp = String(av).localeCompare(String(bv));
+    } else {
+      cmp = av - bv;
+    }
+    return cmp !== 0
+      ? cmp * factor
+      : a.email.toLowerCase().localeCompare(b.email.toLowerCase());
+  });
+}

--- a/src/lib/queries/__tests__/admin-usage.test.ts
+++ b/src/lib/queries/__tests__/admin-usage.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { monthRange, aggregateRoster } from '@/lib/queries/admin-usage';
+import {
+  monthRange,
+  dayRange,
+  aggregateRoster,
+  aggregateDailyTotals,
+} from '@/lib/queries/admin-usage';
 
 describe('monthRange', () => {
   it('returns UTC start (inclusive) and next-month start (exclusive)', () => {
@@ -14,8 +19,23 @@ describe('monthRange', () => {
   });
 });
 
+describe('dayRange', () => {
+  it('returns UTC start (inclusive) and next-day start (exclusive)', () => {
+    expect(dayRange('2099-01-06')).toEqual({
+      start: '2099-01-06T00:00:00.000Z',
+      end: '2099-01-07T00:00:00.000Z',
+    });
+  });
+  it('rolls over month boundaries', () => {
+    expect(dayRange('2099-01-31')).toEqual({
+      start: '2099-01-31T00:00:00.000Z',
+      end: '2099-02-01T00:00:00.000Z',
+    });
+  });
+});
+
 describe('aggregateRoster', () => {
-  it('builds full roster incl. zero-usage users, sorted by cost desc', () => {
+  it('builds full roster incl. zero-usage users, sorted by cost desc, with rich totals', () => {
     const authUsers = [
       { id: 'u1', email: 'a@x.dev' },
       { id: 'u2', email: 'b@x.dev' }, // no profile, no usage
@@ -35,6 +55,7 @@ describe('aggregateRoster', () => {
         model: 'flash',
         input_tokens: 1_000_000,
         output_tokens: 500_000,
+        created_at: '2099-01-05T10:00:00.000Z',
       },
       {
         user_id: 'u1',
@@ -42,6 +63,7 @@ describe('aggregateRoster', () => {
         model: 'embedding',
         input_tokens: 2_000_000,
         output_tokens: 0,
+        created_at: '2099-01-06T10:00:00.000Z',
       },
     ];
     const { users, totals } = aggregateRoster(authUsers, profiles, events);
@@ -49,16 +71,74 @@ describe('aggregateRoster', () => {
     expect(users).toHaveLength(2);
     const u1 = users.find((u) => u.userId === 'u1')!;
     expect(u1.chatCount).toBe(1);
+    expect(u1.embeddingCount).toBe(1);
+    expect(u1.totalTokens).toBe(3_500_000);
     expect(u1.tokensByModel.flash).toEqual({
       input: 1_000_000,
       output: 500_000,
     });
     expect(u1.estimatedCostUsd).toBeCloseTo(1.95, 2);
+
     const u2 = users.find((u) => u.userId === 'u2')!;
     expect(u2.email).toBe('b@x.dev');
     expect(u2.tier).toBe('free');
     expect(u2.estimatedCostUsd).toBe(0);
-    expect(users[0].userId).toBe('u1');
+
+    expect(users[0].userId).toBe('u1'); // cost desc
+
+    // Rich totals.
+    expect(totals.totalUsers).toBe(2);
+    expect(totals.activeUsers).toBe(1); // only u1 had events
+    expect(totals.chatCount).toBe(1);
+    expect(totals.embeddingCount).toBe(1);
+    expect(totals.totalQueries).toBe(2); // chat + embedding
+    expect(totals.totalTokens).toBe(3_500_000);
     expect(totals.estimatedCostUsd).toBeCloseTo(1.95, 2);
+  });
+});
+
+describe('aggregateDailyTotals', () => {
+  it('groups events by UTC day, newest first, summing tokens and cost', () => {
+    const events = [
+      {
+        user_id: 'u1',
+        query_type: 'chat',
+        model: 'flash',
+        input_tokens: 1_000_000, // $0.30
+        output_tokens: 0,
+        created_at: '2099-01-05T23:00:00.000Z',
+      },
+      {
+        user_id: 'u2',
+        query_type: 'chat',
+        model: 'flash',
+        input_tokens: 1_000_000, // $0.30
+        output_tokens: 0,
+        created_at: '2099-01-06T01:00:00.000Z',
+      },
+      {
+        user_id: 'u1',
+        query_type: 'embedding',
+        model: 'embedding',
+        input_tokens: 1_000_000, // $0.20
+        output_tokens: 0,
+        created_at: '2099-01-06T02:00:00.000Z',
+      },
+    ];
+    const days = aggregateDailyTotals(events);
+    expect(days.map((d) => d.day)).toEqual(['2099-01-06', '2099-01-05']);
+
+    const d06 = days.find((d) => d.day === '2099-01-06')!;
+    expect(d06.queryCount).toBe(2);
+    expect(d06.totalTokens).toBe(2_000_000);
+    expect(d06.estimatedCostUsd).toBeCloseTo(0.5, 2); // 0.30 + 0.20
+
+    const d05 = days.find((d) => d.day === '2099-01-05')!;
+    expect(d05.queryCount).toBe(1);
+    expect(d05.estimatedCostUsd).toBeCloseTo(0.3, 2);
+  });
+
+  it('returns [] for no events', () => {
+    expect(aggregateDailyTotals([])).toEqual([]);
   });
 });

--- a/src/lib/queries/admin-usage.integration.test.ts
+++ b/src/lib/queries/admin-usage.integration.test.ts
@@ -1,17 +1,53 @@
 import { describe, it, expect } from 'vitest';
 import { getAdminUsage } from '@/lib/queries/admin-usage';
 
+const TEST_USER = 'test@typenote.dev';
+
 describe('getAdminUsage (full roster from auth.users)', () => {
   it('lists every auth user, including ones with no usage this month', async () => {
     // 2099-07 is a month with no seeded events → all users have zero usage,
     // but the full roster must still be returned (the "missing users" fix).
-    const { users } = await getAdminUsage('2099-07');
+    const { users, totals } = await getAdminUsage('2099-07');
     const admin = users.find((u) => u.email === 'admin@typenote.dev');
-    const tester = users.find((u) => u.email === 'test@typenote.dev');
+    const tester = users.find((u) => u.email === TEST_USER);
     expect(admin).toBeDefined();
     expect(tester).toBeDefined();
     // Zero-usage users still appear with $0 cost.
     expect(admin!.estimatedCostUsd).toBe(0);
     expect(users.length).toBeGreaterThanOrEqual(2);
+    // Roster total reflects everyone; nobody active this empty month.
+    expect(totals.totalUsers).toBe(users.length);
+    expect(totals.activeUsers).toBe(0);
+  });
+
+  it('returns a month-wide daily trend for the seeded month', async () => {
+    // Seed (2099-01): 2099-01-05 has 1 event, 2099-01-06 has 2 events.
+    const { dailyTotals } = await getAdminUsage('2099-01');
+    const days = dailyTotals.map((d) => d.day);
+    expect(days).toContain('2099-01-05');
+    expect(days).toContain('2099-01-06');
+    // Newest first.
+    expect(days.indexOf('2099-01-06')).toBeLessThan(days.indexOf('2099-01-05'));
+    const d06 = dailyTotals.find((d) => d.day === '2099-01-06')!;
+    expect(d06.queryCount).toBe(2); // chat + embedding on the 6th
+  });
+
+  it('scopes the roster to a single day, while keeping the month-wide trend', async () => {
+    // Day 2099-01-06 for the test user: chat flash 400k/200k ($0.62) +
+    // embedding 2M ($0.40) = $1.02.
+    const { users, totals, dailyTotals } = await getAdminUsage(
+      '2099-01',
+      '2099-01-06',
+    );
+    const tester = users.find((u) => u.email === TEST_USER)!;
+    expect(tester.estimatedCostUsd).toBeCloseTo(1.02, 2);
+    expect(tester.chatCount).toBe(1); // only the 06th chat
+    expect(tester.embeddingCount).toBe(1);
+    expect(totals.activeUsers).toBe(1);
+    expect(totals.estimatedCostUsd).toBeCloseTo(1.02, 2);
+    // Trend is still month-wide (both seeded days present) despite day scope.
+    expect(dailyTotals.map((d) => d.day)).toEqual(
+      expect.arrayContaining(['2099-01-05', '2099-01-06']),
+    );
   });
 });

--- a/src/lib/queries/admin-usage.ts
+++ b/src/lib/queries/admin-usage.ts
@@ -13,20 +13,34 @@ export interface AdminUserUsage {
   tier: string;
   chatCount: number;
   latexCount: number;
+  embeddingCount: number;
+  totalTokens: number;
   tokensByModel: Record<string, ModelTokens>;
   estimatedCostUsd: number;
   chatQuotaPct: number;
 }
 export interface AdminUsageTotals {
+  activeUsers: number;
+  totalUsers: number;
+  totalQueries: number;
   chatCount: number;
   latexCount: number;
+  embeddingCount: number;
   totalTokens: number;
   embeddingTokens: number;
+  estimatedCostUsd: number;
+}
+export interface DailyTotalRow {
+  day: string;
+  queryCount: number;
+  totalTokens: number;
   estimatedCostUsd: number;
 }
 export interface AdminUsage {
   users: AdminUserUsage[];
   totals: AdminUsageTotals;
+  /** Per-day totals across all users for the whole month (trend), newest first. */
+  dailyTotals: DailyTotalRow[];
 }
 
 interface AuthUserLite {
@@ -39,12 +53,13 @@ interface ProfileLite {
   display_name: string | null;
   subscription_tier: string | null;
 }
-interface EventLite {
+export interface EventLite {
   user_id: string;
   query_type: string;
   model: string;
   input_tokens: number;
   output_tokens: number;
+  created_at: string;
 }
 
 /** UTC [start, end) ISO bounds for a 'YYYY-MM' month. */
@@ -53,6 +68,35 @@ export function monthRange(month: string): { start: string; end: string } {
   const start = new Date(Date.UTC(y, m - 1, 1));
   const end = new Date(Date.UTC(y, m, 1));
   return { start: start.toISOString(), end: end.toISOString() };
+}
+
+/** UTC [start, end) ISO bounds for a single 'YYYY-MM-DD' day. */
+export function dayRange(day: string): { start: string; end: string } {
+  const [y, m, d] = day.split('-').map(Number);
+  const start = new Date(Date.UTC(y, m - 1, d));
+  const end = new Date(Date.UTC(y, m - 1, d + 1));
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+/** Per-day totals (across all users), newest day first. Pure. */
+export function aggregateDailyTotals(events: EventLite[]): DailyTotalRow[] {
+  const byDay = new Map<string, DailyTotalRow>();
+  for (const e of events) {
+    const day = e.created_at.slice(0, 10);
+    let r = byDay.get(day);
+    if (!r) {
+      r = { day, queryCount: 0, totalTokens: 0, estimatedCostUsd: 0 };
+      byDay.set(day, r);
+    }
+    r.queryCount += 1;
+    r.totalTokens += e.input_tokens + e.output_tokens;
+    r.estimatedCostUsd += estimateCostUsd(
+      e.model,
+      e.input_tokens,
+      e.output_tokens,
+    );
+  }
+  return [...byDay.values()].sort((a, b) => b.day.localeCompare(a.day));
 }
 
 /** Pure aggregation — unit-tested without a DB. */
@@ -73,25 +117,34 @@ export function aggregateRoster(
       tier: p?.subscription_tier ?? 'free',
       chatCount: 0,
       latexCount: 0,
+      embeddingCount: 0,
+      totalTokens: 0,
       tokensByModel: {},
       estimatedCostUsd: 0,
       chatQuotaPct: 0,
     });
   }
 
+  const activeUserIds = new Set<string>();
   for (const e of events) {
     const row = byUser.get(e.user_id);
     if (!row) continue;
+    activeUserIds.add(e.user_id);
     if (e.query_type === 'chat') row.chatCount += 1;
     else if (e.query_type === 'latex') row.latexCount += 1;
+    else if (e.query_type === 'embedding') row.embeddingCount += 1;
     const tk = (row.tokensByModel[e.model] ??= { input: 0, output: 0 });
     tk.input += e.input_tokens;
     tk.output += e.output_tokens;
   }
 
   const totals: AdminUsageTotals = {
+    activeUsers: activeUserIds.size,
+    totalUsers: byUser.size,
+    totalQueries: 0,
     chatCount: 0,
     latexCount: 0,
+    embeddingCount: 0,
     totalTokens: 0,
     embeddingTokens: 0,
     estimatedCostUsd: 0,
@@ -100,17 +153,22 @@ export function aggregateRoster(
     let cost = 0;
     for (const [model, tk] of Object.entries(row.tokensByModel)) {
       cost += estimateCostUsd(model, tk.input, tk.output);
-      totals.totalTokens += tk.input + tk.output;
+      row.totalTokens += tk.input + tk.output;
       if (model === 'embedding') totals.embeddingTokens += tk.input;
     }
     row.estimatedCostUsd = cost;
     const chatLimit = resolveLimitForTier(row.tier, 'chat');
     row.chatQuotaPct =
       chatLimit > 0 ? Math.round((row.chatCount / chatLimit) * 100) : 0;
+
     totals.chatCount += row.chatCount;
     totals.latexCount += row.latexCount;
+    totals.embeddingCount += row.embeddingCount;
+    totals.totalTokens += row.totalTokens;
     totals.estimatedCostUsd += cost;
   }
+  totals.totalQueries =
+    totals.chatCount + totals.latexCount + totals.embeddingCount;
 
   const users = [...byUser.values()].sort(
     (a, b) =>
@@ -118,7 +176,7 @@ export function aggregateRoster(
       b.chatCount + b.latexCount - (a.chatCount + a.latexCount) ||
       a.email.localeCompare(b.email),
   );
-  return { users, totals };
+  return { users, totals, dailyTotals: [] };
 }
 
 /** Enumerate every auth user (paged) so zero-profile users still appear. */
@@ -137,10 +195,18 @@ async function listAllAuthUsers(
 }
 
 /**
- * Aggregate per-user AI usage + cost for one month from the event log.
+ * Aggregate per-user AI usage + cost from the event log.
+ *
+ * Always fetches the whole month (one query) so the daily-trend is month-wide.
+ * When `day` ('YYYY-MM-DD') is given, the roster + totals are scoped to that
+ * single UTC day; the trend still covers the full month.
+ *
  * Service-role reads — call ONLY after requireAdmin() in a Server Component.
  */
-export async function getAdminUsage(month: string): Promise<AdminUsage> {
+export async function getAdminUsage(
+  month: string,
+  day?: string,
+): Promise<AdminUsage> {
   const admin = createAdminClient();
   const { start, end } = monthRange(month);
 
@@ -149,16 +215,26 @@ export async function getAdminUsage(month: string): Promise<AdminUsage> {
     admin.from('profiles').select('id, email, display_name, subscription_tier'),
     admin
       .from('ai_usage_events')
-      .select('user_id, query_type, model, input_tokens, output_tokens')
+      .select(
+        'user_id, query_type, model, input_tokens, output_tokens, created_at',
+      )
       .gte('created_at', start)
       .lt('created_at', end),
   ]);
   if (profilesRes.error) throw profilesRes.error;
   if (eventsRes.error) throw eventsRes.error;
 
-  return aggregateRoster(
+  const monthEvents = (eventsRes.data ?? []) as EventLite[];
+  const dailyTotals = aggregateDailyTotals(monthEvents);
+
+  const scopedEvents = day
+    ? monthEvents.filter((e) => e.created_at.slice(0, 10) === day)
+    : monthEvents;
+
+  const roster = aggregateRoster(
     authUsers,
     profilesRes.data ?? [],
-    eventsRes.data ?? [],
+    scopedEvents,
   );
+  return { ...roster, dailyTotals };
 }


### PR DESCRIPTION
## Summary
Makes the admin AI-usage dashboard surface a lot more info (follow-up to the analytics ledger).

- **Day scoping** — a day picker beside the month selector; the per-user roster + totals can be scoped to a single UTC day (not just a whole month). The daily-trend rows are also click-to-scope.
- **Sortable + filterable roster** — the per-user table is now a client component: click any column to sort (default cost-desc, `aria-sort` for a11y) and filter by email. The pure `sortUsers`/`sortValue` comparator lives in a client-safe module (type-only import) and is unit-tested.
- **More info** — richer KPI cards (active users, total queries, chat/latex/embedding counts, tokens, cost) and a **month-wide daily-totals** table with inline cost-share bars.
- **Data layer** — `getAdminUsage(month, day?)` fetches the month once, computes the month-wide trend and the (optionally day-scoped) roster. New pure helpers `dayRange` + `aggregateDailyTotals`; totals enriched with active/total users, total queries, embedding count.

The user drill-down page is unchanged.

## Test Plan
- [x] Unit (1032): `dayRange`, `aggregateDailyTotals`, richer `aggregateRoster` totals, `sortUsers`/`sortValue`
- [x] Integration (200): day-scoped `getAdminUsage` ($1.02 for 2099-01-06), month-wide trend present, full roster
- [x] E2E admin-dashboard 8/8: richer KPIs + trend, day-scope via trend link ($1.95 → $1.02), sort toggle + `aria-sort` + filter
- [x] `pnpm format:check` clean; lint clean; new files typecheck clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)