### PR TITLE
feat(ux): loading indicators for create/open/upload flows

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -29,6 +29,8 @@ When adding or modifying a feature, update this registry and write the correspon
 ## Documents (`e2e/documents.spec.ts`) — IMPLEMENTED
 
 - [x] Create new document from dashboard
+- [x] Create dialog stays open with disabled "Creating..." button until the editor renders (feature 051)
+- [x] Document card shows a loading spinner while the editor route is loading (feature 051)
 - [x] Open existing document navigates to editor
 - [x] Rename document from editor title input (auto-saves on blur)
 - [x] Delete document with confirmation dialog
@@ -117,6 +119,7 @@ Follow-up to issue #118. Guards against cursor jumps when a multi-page overflow 
 ## File Upload (`e2e/file-upload.spec.ts`) — IMPLEMENTED
 
 - [x] Import file into course (PDF upload)
+- [x] Upload shows "Uploading..." then "Processing file..." phases before completing (feature 051)
 - [x] Open imported file (creates document)
 - [x] Delete imported file
 
@@ -254,12 +257,12 @@ Covers the admin-only `/admin` AI usage dashboard (event-ledger aggregation + co
 | Feature               | Status      | Spec File                                | Tests       |
 | --------------------- | ----------- | ---------------------------------------- | ----------- |
 | Auth                  | Implemented | `e2e/auth.spec.ts`                       | 9/9         |
-| Documents             | Implemented | `e2e/documents.spec.ts`                  | 6/6         |
+| Documents             | Implemented | `e2e/documents.spec.ts`                  | 8/8         |
 | Canvas Editor         | Implemented | `e2e/canvas-editor.spec.ts`              | 15/15       |
 | Text Editor Toolbar   | Implemented | `e2e/editor-toolbar.spec.ts`             | 12/12       |
 | LaTeX Math            | Implemented | `e2e/latex-math.spec.ts`                 | 5/5         |
 | Courses               | Implemented | `e2e/courses.spec.ts`                    | 5/6         |
-| File Upload           | Implemented | `e2e/file-upload.spec.ts`                | 3/4         |
+| File Upload           | Implemented | `e2e/file-upload.spec.ts`                | 4/5         |
 | AI Chat               | Implemented | `e2e/ai-chat.spec.ts`                    | 6/6         |
 | AI Chat — Per-user    | Planned     | `e2e/ai-chat-per-user-materials.spec.ts` | 0/2         |
 | PDF Export            | Implemented | `e2e/export-pdf-*.spec.ts`               | 6/7         |

--- a/e2e/documents.spec.ts
+++ b/e2e/documents.spec.ts
@@ -50,6 +50,62 @@ test.describe('Documents', () => {
     });
   });
 
+  test('create dialog stays open with a disabled Creating button until the editor renders', async ({
+    page,
+  }) => {
+    // Delay server-action POSTs so the pending state is reliably observable
+    // (locally the create action + navigation can finish in milliseconds).
+    await page.route('**/*', async (route) => {
+      const req = route.request();
+      if (req.method() === 'POST' && req.headers()['next-action']) {
+        await new Promise((r) => setTimeout(r, 800));
+      }
+      await route.continue();
+    });
+
+    await page.getByRole('button', { name: 'New Document' }).click();
+    await expect(page.getByText('Create New Document')).toBeVisible();
+    const titleInput = page.getByLabel('Title');
+    await titleInput.clear();
+    await titleInput.fill(`Loading State ${Date.now()}`);
+    await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+    // While the document is being created, the dialog must stay open and the
+    // submit button must show the in-progress state.
+    const creating = page.getByRole('button', { name: 'Creating...' });
+    await expect(creating).toBeVisible();
+    await expect(creating).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    await expect(page.getByText('Create New Document')).toBeVisible();
+
+    // The dialog disappears only because navigation lands in the editor.
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 15_000,
+    });
+  });
+
+  test('document card shows a spinner while the editor is loading', async ({
+    page,
+  }) => {
+    // Delay the editor route fetch so the card's pending spinner is visible.
+    await page.route('**/dashboard/documents/**', async (route) => {
+      await new Promise((r) => setTimeout(r, 800));
+      await route.continue();
+    });
+
+    const firstDoc = page.locator('[data-testid="document-card"]').first();
+    await expect(firstDoc).toBeVisible({ timeout: 10_000 });
+    await firstDoc.click();
+
+    await expect(
+      page.getByTestId('document-card-loading').first(),
+    ).toBeVisible();
+
+    await expect(page).toHaveURL(/\/dashboard\/documents\//, {
+      timeout: 15_000,
+    });
+  });
+
   test('open existing document navigates to editor', async ({ page }) => {
     // Click the first document card on the dashboard
     const firstDoc = page.locator('[data-testid="document-card"]').first();

--- a/e2e/file-upload.spec.ts
+++ b/e2e/file-upload.spec.ts
@@ -30,6 +30,51 @@ test.describe('File Upload', () => {
     });
   });
 
+  test('upload shows Uploading then Processing phases before completing', async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+    await goToSeededCourse(page);
+    await expect(page.getByRole('button', { name: 'Import File' })).toBeVisible(
+      { timeout: 15_000 },
+    );
+
+    // Delay the storage upload and the server-action POST so both loading
+    // phases are reliably observable (tiny fixture files finish in ms).
+    await page.route('**/*', async (route) => {
+      const req = route.request();
+      const isAction =
+        req.method() === 'POST' && !!req.headers()['next-action'];
+      const isStorageUpload =
+        req.method() === 'POST' && req.url().includes('/storage/v1/object/');
+      if (isAction || isStorageUpload) {
+        await new Promise((r) => setTimeout(r, 800));
+      }
+      await route.continue();
+    });
+
+    const fileInput = page.locator('input[type="file"]').first();
+    await fileInput.setInputFiles({
+      name: `test-phases-${Date.now()}.pdf`,
+      mimeType: 'application/pdf',
+      buffer: Buffer.from('%PDF-1.4 fake pdf content for testing'),
+    });
+
+    // Phase 1: storage upload
+    await expect(page.getByText('Uploading...')).toBeVisible();
+    // Phase 2: server-side extraction + indexing (previously silent)
+    await expect(page.getByText('Processing file...')).toBeVisible({
+      timeout: 15_000,
+    });
+    // Completion: toast + button restored
+    await expect(page.getByText('File imported')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByRole('button', { name: 'Import File' }),
+    ).toBeVisible();
+  });
+
   test('open imported file creates a document', async ({ page }) => {
     // File conversion (PDF → document) is a complex server-side operation
     // that's unreliable in CI's local Supabase environment.

--- a/specs/051-loading-indicators/spec.md
+++ b/specs/051-loading-indicators/spec.md
@@ -48,7 +48,7 @@ async flow with a single boolean, instead of modeling the full flow.
   - `processing` — `createPersonalFile()` (extraction + embedding) in
     progress: spinner + "Processing file…"
 - Phase state lives in `PersonalFileUpload` (`idle → uploading → processing →
-  idle`); `useFileUpload` keeps validation/upload but drops the dead
+idle`); `useFileUpload` keeps validation/upload but drops the dead
   `progress` number.
 - The upload button remains replaced by the indicator until the flow finishes;
   errors at either phase show the existing toast and restore the button.

--- a/specs/051-loading-indicators/spec.md
+++ b/specs/051-loading-indicators/spec.md
@@ -1,0 +1,72 @@
+# Feature 051: Loading Indicators (create / open / upload)
+
+**Date:** 2026-06-07
+**Status:** Approved
+
+## Problem
+
+Three user flows have dead time with no visual feedback:
+
+1. **Create document** — `CreateDocumentDialog` shows "Creating…" while the
+   `createDocument` server action runs, but closes the dialog and resets the
+   button as soon as the action returns, while navigation to the new editor
+   page is still in flight. The user stares at the dashboard with no feedback.
+2. **Open document** — `DocumentCard` fires a bare `router.push()` on click.
+   No prefetch, no pending state: nothing happens visually until the server
+   responds and the route-level `loading.tsx` takes over.
+3. **Upload material** — `PersonalFileUpload` shows a fake progress bar
+   (supabase-js standard upload has no progress callback; the bar sits at 0%
+   and jumps to 100), and the indicator disappears as soon as the storage
+   upload finishes — while `createPersonalFile()` (text extraction, chunking,
+   embedding: 10–30 s for large PDFs) is still running. The longest phase is
+   completely silent, ending in a surprise "File imported" toast.
+
+The root pattern in (1) and (3): the client tracked only part of a multi-step
+async flow with a single boolean, instead of modeling the full flow.
+
+## Design
+
+### 1. Create document — `src/components/dashboard/create-document-dialog.tsx`
+
+- On success, wrap `router.push()` in `useTransition`'s `startTransition`.
+- Do **not** close the dialog or reset `isSubmitting` on success; the dialog
+  stays open with the disabled "Creating…" button until the destination route
+  renders and the dialog unmounts with the navigation.
+- On error, reset `isSubmitting` and show the error (existing behavior).
+
+### 2. Open document — `src/components/dashboard/document-card.tsx`
+
+- Wrap the card click's `router.push()` in `useTransition`.
+- While `isPending`, show a `Loader2` spinner on the card (same idiom the card
+  already uses for PDF export) and ignore further clicks.
+
+### 3. Upload material — `src/components/dashboard/personal-file-upload.tsx`, `src/hooks/use-file-upload.ts`
+
+- Replace the fake percent bar with an honest two-phase indicator spanning the
+  whole operation:
+  - `uploading` — storage upload in progress: spinner + "Uploading…"
+  - `processing` — `createPersonalFile()` (extraction + embedding) in
+    progress: spinner + "Processing file…"
+- Phase state lives in `PersonalFileUpload` (`idle → uploading → processing →
+  idle`); `useFileUpload` keeps validation/upload but drops the dead
+  `progress` number.
+- The upload button remains replaced by the indicator until the flow finishes;
+  errors at either phase show the existing toast and restore the button.
+
+## Out of scope
+
+- Granular byte-level upload progress (requires TUS resumable uploads — not
+  worth it at the 50 MB cap).
+- PDF viewer/editor changes; math subscript paste handling (dropped).
+
+## Testing
+
+- Unit (Vitest + RTL): dialog stays open and disabled after successful create;
+  card fires navigation once and shows spinner while pending; upload component
+  walks idle → uploading → processing → idle and shows phase labels; errors
+  restore the button.
+- E2E (Playwright, real flows): create-document flow lands in the editor with
+  the creating indicator shown during the transition; opening a document from
+  a card shows the pending spinner; uploading a fixture PDF shows
+  "Processing file…" before the file appears in the list.
+- `e2e/TEST_REGISTRY.md` updated accordingly.

--- a/src/components/dashboard/create-document-dialog.test.tsx
+++ b/src/components/dashboard/create-document-dialog.test.tsx
@@ -1,9 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CreateDocumentDialog } from './create-document-dialog';
+import { createDocument } from '@/lib/actions/documents';
+
+const mockPush = vi.fn();
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 vi.mock('@/lib/actions/documents', () => ({
@@ -53,5 +57,50 @@ describe('CreateDocumentDialog', () => {
   it('does not show custom subject input by default', () => {
     renderDialog();
     expect(screen.queryByLabelText(/custom subject/i)).not.toBeInTheDocument();
+  });
+
+  describe('loading state during create + navigation', () => {
+    beforeEach(() => {
+      mockPush.mockClear();
+      vi.mocked(createDocument).mockResolvedValue({
+        id: 'new-doc-1',
+      } as Awaited<ReturnType<typeof createDocument>>);
+    });
+
+    it('keeps the dialog open with a disabled "Creating..." button after a successful create, until navigation unmounts it', async () => {
+      renderDialog();
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/documents/new-doc-1');
+      // Dialog must still be visible — navigation to the editor is in flight
+      expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+      const submit = screen.getByRole('button', { name: /creating/i });
+      expect(submit).toBeDisabled();
+    });
+
+    it('disables Cancel while the document is being created', async () => {
+      let resolveCreate: (v: { id: string }) => void;
+      vi.mocked(createDocument).mockImplementation(
+        () =>
+          new Promise((res) => {
+            resolveCreate = res;
+          }) as ReturnType<typeof createDocument>,
+      );
+      renderDialog();
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(screen.getByRole('button', { name: /cancel/i })).toBeDisabled();
+      resolveCreate!({ id: 'new-doc-1' });
+    });
+
+    it('re-enables the form and shows the error when creation fails', async () => {
+      vi.mocked(createDocument).mockRejectedValue(new Error('boom'));
+      renderDialog();
+      await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+
+      expect(screen.getByRole('alert')).toHaveTextContent('boom');
+      expect(screen.getByRole('button', { name: /^create$/i })).toBeEnabled();
+      expect(mockPush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/dashboard/create-document-dialog.tsx
+++ b/src/components/dashboard/create-document-dialog.tsx
@@ -60,14 +60,15 @@ export function CreateDocumentDialog({
         document_type: canvasType,
         purpose: null,
       });
-      setOpen(false);
-      resetForm();
+      // Keep the dialog open and the button in its "Creating..." state while
+      // navigation to the new editor page is in flight — the dialog unmounts
+      // together with this page when the route renders. Closing it here would
+      // leave the user staring at the dashboard with no feedback.
       router.push(`/dashboard/documents/${doc.id}`);
     } catch (err) {
       setError(
         err instanceof Error ? err.message : 'Failed to create document',
       );
-    } finally {
       setIsSubmitting(false);
     }
   }
@@ -82,6 +83,9 @@ export function CreateDocumentDialog({
     <Dialog
       open={open}
       onOpenChange={(value) => {
+        // Ignore close attempts while creating — the document is already
+        // being created server-side and navigation is about to happen.
+        if (!value && isSubmitting) return;
         setOpen(value);
         if (!value) resetForm();
       }}
@@ -139,6 +143,7 @@ export function CreateDocumentDialog({
             <Button
               type="button"
               variant="outline"
+              disabled={isSubmitting}
               onClick={() => setOpen(false)}
             >
               Cancel

--- a/src/components/dashboard/document-card.test.tsx
+++ b/src/components/dashboard/document-card.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { DocumentCard } from './document-card';
 import type { Document } from '@/types/database';
 
@@ -9,6 +9,19 @@ const mockPush = vi.fn();
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
 }));
+
+// Controls React's useTransition so tests can render the pending state
+// deterministically (jsdom has no real App Router navigation to track).
+const transitionState = vi.hoisted(() => ({ isPending: false }));
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>();
+  return {
+    ...actual,
+    useTransition: () =>
+      [transitionState.isPending, (cb: () => void) => cb()] as const,
+  };
+});
 
 const mockDocument: Document = {
   id: 'doc-1',
@@ -101,5 +114,42 @@ describe('DocumentCard', () => {
     await user.click(screen.getByText('Delete'));
 
     expect(onDelete).toHaveBeenCalledWith('doc-1');
+  });
+
+  describe('navigation loading state', () => {
+    beforeEach(() => {
+      mockPush.mockClear();
+      transitionState.isPending = false;
+    });
+
+    it('navigates to the document page when the card is clicked', async () => {
+      const user = userEvent.setup();
+      render(<DocumentCard document={mockDocument} />);
+
+      await user.click(screen.getByTestId('document-card'));
+
+      expect(mockPush).toHaveBeenCalledWith('/dashboard/documents/doc-1');
+    });
+
+    it('shows a loading spinner on the card while navigation is pending', () => {
+      transitionState.isPending = true;
+      render(<DocumentCard document={mockDocument} />);
+
+      expect(screen.getByTestId('document-card-loading')).toBeInTheDocument();
+      expect(screen.getByTestId('document-card')).toHaveAttribute(
+        'aria-busy',
+        'true',
+      );
+    });
+
+    it('ignores clicks while navigation is already pending', async () => {
+      transitionState.isPending = true;
+      const user = userEvent.setup();
+      render(<DocumentCard document={mockDocument} />);
+
+      await user.click(screen.getByTestId('document-card'));
+
+      expect(mockPush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/dashboard/document-card.tsx
+++ b/src/components/dashboard/document-card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useTransition } from 'react';
 import { useRouter } from 'next/navigation';
 import {
   MoreHorizontal,
@@ -86,7 +87,18 @@ export function DocumentCard({
   onDelete,
 }: DocumentCardProps) {
   const router = useRouter();
+  // Tracks the App Router navigation after a click — isPending stays true
+  // until the document route actually renders, so the card can show feedback
+  // during the otherwise-silent server fetch.
+  const [isNavigating, startNavigation] = useTransition();
   const { exportPdf, isExporting } = useExportPdf();
+
+  function handleOpen() {
+    if (isNavigating) return;
+    startNavigation(() => {
+      router.push(`/dashboard/documents/${document.id}`);
+    });
+  }
 
   const subjectLabel =
     document.subject === 'other' && document.subject_custom
@@ -110,12 +122,21 @@ export function DocumentCard({
   return (
     <Card
       className={cn(
-        'cursor-pointer overflow-hidden border-t-4 transition-shadow hover:shadow-md',
+        'relative cursor-pointer overflow-hidden border-t-4 transition-shadow hover:shadow-md',
         subjectBorderColor,
       )}
-      onClick={() => router.push(`/dashboard/documents/${document.id}`)}
+      onClick={handleOpen}
+      aria-busy={isNavigating}
       data-testid="document-card"
     >
+      {isNavigating && (
+        <div
+          data-testid="document-card-loading"
+          className="absolute inset-0 z-10 flex items-center justify-center bg-background/60"
+        >
+          <Loader2 className="size-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
       <CardHeader>
         <CardTitle className="truncate text-base">{document.title}</CardTitle>
         <CardAction>

--- a/src/components/dashboard/personal-file-upload.test.tsx
+++ b/src/components/dashboard/personal-file-upload.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PersonalFileUpload } from './personal-file-upload';
+import { createPersonalFile } from '@/lib/actions/personal-files';
+import { toast } from 'sonner';
+
+const uploadMock = vi.fn();
+
+vi.mock('@/lib/supabase/client', () => ({
+  createClient: () => ({
+    storage: {
+      from: () => ({ upload: uploadMock }),
+    },
+  }),
+}));
+
+vi.mock('@/lib/actions/personal-files', () => ({
+  createPersonalFile: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@/lib/analytics/events', () => ({
+  trackEvent: vi.fn(),
+}));
+
+/** A promise whose resolution the test controls. */
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function selectPdf(container: HTMLElement) {
+  const input = container.querySelector('input[type="file"]')!;
+  const file = new File(['%PDF-1.4'], 'notes.pdf', {
+    type: 'application/pdf',
+  });
+  fireEvent.change(input, { target: { files: [file] } });
+}
+
+describe('PersonalFileUpload', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the import button when idle', () => {
+    render(
+      <PersonalFileUpload courseId="c1" userId="u1" category="material" />,
+    );
+    expect(
+      screen.getByRole('button', { name: /import file/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows "Uploading..." while the storage upload is in progress', async () => {
+    const upload = deferred<{ error: null }>();
+    uploadMock.mockReturnValue(upload.promise);
+
+    const { container } = render(
+      <PersonalFileUpload courseId="c1" userId="u1" category="material" />,
+    );
+    selectPdf(container);
+
+    expect(await screen.findByText(/uploading/i)).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /import file/i }),
+    ).not.toBeInTheDocument();
+
+    upload.resolve({ error: null });
+  });
+
+  it('shows "Processing file..." while indexing runs after the upload completes', async () => {
+    uploadMock.mockResolvedValue({ error: null });
+    const processing = deferred<unknown>();
+    vi.mocked(createPersonalFile).mockReturnValue(
+      processing.promise as ReturnType<typeof createPersonalFile>,
+    );
+
+    const { container } = render(
+      <PersonalFileUpload courseId="c1" userId="u1" category="material" />,
+    );
+    selectPdf(container);
+
+    expect(await screen.findByText(/processing file/i)).toBeInTheDocument();
+    expect(screen.queryByText(/uploading/i)).not.toBeInTheDocument();
+    // Button stays hidden through the processing phase
+    expect(
+      screen.queryByRole('button', { name: /import file/i }),
+    ).not.toBeInTheDocument();
+
+    processing.resolve({});
+  });
+
+  it('restores the button and shows a success toast when the whole flow completes', async () => {
+    uploadMock.mockResolvedValue({ error: null });
+    vi.mocked(createPersonalFile).mockResolvedValue(
+      {} as Awaited<ReturnType<typeof createPersonalFile>>,
+    );
+
+    const { container } = render(
+      <PersonalFileUpload courseId="c1" userId="u1" category="material" />,
+    );
+    selectPdf(container);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /import file/i }),
+      ).toBeInTheDocument(),
+    );
+    expect(toast.success).toHaveBeenCalledWith('File imported');
+  });
+
+  it('restores the button and shows an error toast when the upload fails', async () => {
+    uploadMock.mockResolvedValue({ error: new Error('storage down') });
+
+    const { container } = render(
+      <PersonalFileUpload courseId="c1" userId="u1" category="material" />,
+    );
+    selectPdf(container);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(
+      screen.getByRole('button', { name: /import file/i }),
+    ).toBeInTheDocument();
+    expect(createPersonalFile).not.toHaveBeenCalled();
+  });
+
+  it('restores the button and shows an error toast when processing fails', async () => {
+    uploadMock.mockResolvedValue({ error: null });
+    vi.mocked(createPersonalFile).mockRejectedValue(new Error('index failed'));
+
+    const { container } = render(
+      <PersonalFileUpload courseId="c1" userId="u1" category="material" />,
+    );
+    selectPdf(container);
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith('index failed'),
+    );
+    expect(
+      screen.getByRole('button', { name: /import file/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/personal-file-upload.tsx
+++ b/src/components/dashboard/personal-file-upload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useRef } from 'react';
-import { Upload } from 'lucide-react';
+import { useRef, useState } from 'react';
+import { Loader2, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useFileUpload } from '@/hooks/use-file-upload';
 import { createPersonalFile } from '@/lib/actions/personal-files';
@@ -15,6 +15,19 @@ interface PersonalFileUploadProps {
   label?: string;
 }
 
+/**
+ * The import flow has two long-running steps the user must see:
+ * storage upload, then server-side processing (text extraction + embedding,
+ * which can take 10-30s for large PDFs). A single boolean hid the second
+ * phase entirely — model the flow as explicit phases instead.
+ */
+type UploadPhase = 'idle' | 'uploading' | 'processing';
+
+const PHASE_LABELS: Record<Exclude<UploadPhase, 'idle'>, string> = {
+  uploading: 'Uploading...',
+  processing: 'Processing file...',
+};
+
 export function PersonalFileUpload({
   courseId,
   userId,
@@ -22,19 +35,20 @@ export function PersonalFileUpload({
   label,
 }: PersonalFileUploadProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { uploading, progress, error, upload, reset } = useFileUpload(
-    'personal-files',
-    [
-      'application/pdf',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    ],
-  );
+  const [phase, setPhase] = useState<UploadPhase>('idle');
+  const { error, upload } = useFileUpload('personal-files', [
+    'application/pdf',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  ]);
 
   async function handleFile(file: File) {
     const path = `${userId}/${courseId}/${file.name}`;
 
     try {
+      setPhase('uploading');
       await upload(file, path);
+
+      setPhase('processing');
       await createPersonalFile({
         courseId,
         category,
@@ -43,7 +57,7 @@ export function PersonalFileUpload({
         fileSize: file.size,
         storagePath: path,
       });
-      reset();
+
       trackEvent('personal_file_uploaded', {
         file_size: file.size,
         mime_type: file.type,
@@ -52,6 +66,8 @@ export function PersonalFileUpload({
       toast.success('File imported');
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setPhase('idle');
     }
   }
 
@@ -66,15 +82,13 @@ export function PersonalFileUpload({
 
   return (
     <div>
-      {uploading ? (
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <div className="h-1.5 w-24 overflow-hidden rounded-full bg-muted">
-            <div
-              className="h-full rounded-full bg-primary transition-all"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-          Uploading...
+      {phase !== 'idle' ? (
+        <div
+          className="flex h-8 items-center gap-2 px-3 text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          <Loader2 className="size-4 animate-spin" />
+          {PHASE_LABELS[phase]}
         </div>
       ) : (
         <Button

--- a/src/hooks/__tests__/use-file-upload.test.ts
+++ b/src/hooks/__tests__/use-file-upload.test.ts
@@ -6,7 +6,7 @@
  *   - validateFile rejects files >50 MB
  *   - validateFile accepts allowed types under the cap
  *   - upload short-circuits when validation fails (no network, error state set)
- *   - upload sets uploading state, then sets progress=100 on success
+ *   - upload sets uploading state, then clears it on success
  *   - upload exposes Supabase errors to callers and updates state
  *   - reset clears state
  */
@@ -117,7 +117,7 @@ describe('useFileUpload — upload flow', () => {
     expect(String(result.current.error)).toMatch(/Accepted file types/i);
   });
 
-  it('calls storage.upload and sets progress=100 on success', async () => {
+  it('calls storage.upload and clears uploading state on success', async () => {
     mockUpload.mockResolvedValue({ error: null });
 
     const { result } = renderHook(() => useFileUpload('test-bucket'));
@@ -135,7 +135,6 @@ describe('useFileUpload — upload flow', () => {
     expect(mockUpload).toHaveBeenCalledTimes(1);
     expect(mockUpload.mock.calls[0][0]).toBe('docs/ok.pdf');
     expect(returnedPath).toBe('docs/ok.pdf');
-    expect(result.current.progress).toBe(100);
     expect(result.current.uploading).toBe(false);
     expect(result.current.error).toBeNull();
   });
@@ -167,7 +166,7 @@ describe('useFileUpload — upload flow', () => {
     expect(String(result.current.error)).toMatch(/duplicate key/);
   });
 
-  it('reset clears error and progress', async () => {
+  it('reset clears error and uploading state', async () => {
     const { result } = renderHook(() => useFileUpload('test-bucket'));
     const badFile = makeFile({
       name: 'note.txt',
@@ -190,7 +189,6 @@ describe('useFileUpload — upload flow', () => {
     });
 
     expect(result.current.error).toBeNull();
-    expect(result.current.progress).toBe(0);
     expect(result.current.uploading).toBe(false);
   });
 });

--- a/src/hooks/use-file-upload.ts
+++ b/src/hooks/use-file-upload.ts
@@ -8,7 +8,6 @@ const DEFAULT_ALLOWED_MIME_TYPES = ['application/pdf'];
 
 interface UploadState {
   uploading: boolean;
-  progress: number;
   error: string | null;
 }
 
@@ -16,9 +15,10 @@ export function useFileUpload(
   bucketName: string,
   allowedMimeTypes: string[] = DEFAULT_ALLOWED_MIME_TYPES,
 ) {
+  // Note: supabase-js's standard upload exposes no byte-level progress, so
+  // the hook reports a binary uploading flag rather than a fake percentage.
   const [state, setState] = useState<UploadState>({
     uploading: false,
-    progress: 0,
     error: null,
   });
 
@@ -42,11 +42,11 @@ export function useFileUpload(
     async (file: File, path: string): Promise<string> => {
       const validationError = validateFile(file);
       if (validationError) {
-        setState({ uploading: false, progress: 0, error: validationError });
+        setState({ uploading: false, error: validationError });
         throw new Error(validationError);
       }
 
-      setState({ uploading: true, progress: 0, error: null });
+      setState({ uploading: true, error: null });
 
       try {
         const supabase = createClient();
@@ -59,11 +59,11 @@ export function useFileUpload(
 
         if (error) throw error;
 
-        setState({ uploading: false, progress: 100, error: null });
+        setState({ uploading: false, error: null });
         return path;
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Upload failed';
-        setState({ uploading: false, progress: 0, error: message });
+        setState({ uploading: false, error: message });
         throw new Error(message);
       }
     },
@@ -71,7 +71,7 @@ export function useFileUpload(
   );
 
   const reset = useCallback(() => {
-    setState({ uploading: false, progress: 0, error: null });
+    setState({ uploading: false, error: null });
   }, []);
 
   return {


### PR DESCRIPTION
## Summary

Three user flows had dead time with zero visual feedback. This PR makes every long-running step visible (spec: `specs/051-loading-indicators/spec.md`):

1. **Create document** — the dialog used to close as soon as the `createDocument` server action returned, while navigation to the new editor was still in flight, leaving the user staring at the dashboard. Now the dialog stays open with a disabled **"Creating..."** button (Cancel disabled too) until the editor route renders and unmounts it with the navigation.
2. **Open document** — `DocumentCard` fired a bare `router.push()` with no pending state. The click is now wrapped in `useTransition`: a spinner overlay + `aria-busy` shows on the card while the editor route loads, and repeat clicks are ignored.
3. **Upload material** — the indicator vanished the moment the storage upload finished, while `createPersonalFile()` (text extraction + chunking + embedding, 10–30 s for large PDFs) ran in total silence; the progress bar was also fake (supabase-js standard upload has no progress callback — it sat at 0% and jumped to 100). Replaced with an honest two-phase indicator: **"Uploading..."** → **"Processing file..."**, with the button restored on completion or error. `useFileUpload` drops the dead `progress` number.

Root pattern fixed in (1) and (3): a single boolean tracked only the first await of a multi-step async flow; the flows are now modeled as explicit phases.

## Test plan

- [x] TDD: 5 new unit tests written first and watched fail, then minimal implementations (RTL + deferred promises at the supabase/server-action boundaries)
- [x] Unit: 1044/1044 · Integration: 200/200 (fresh local Supabase)
- [x] New E2E (real user flows, `page.route` delays make the transient states deterministically observable): create-dialog pending state until editor renders · card spinner while opening · upload Uploading→Processing→imported — all passing
- [x] Full E2E suite on a freshly-reset DB: 144 passed; remaining failures verified **pre-existing environmental** by running the same specs on an untouched `origin/dev` baseline worktree (identical failures: AI-key specs, canvas local-flaky, clipboard-permission image-paste, etc.)
- [x] `e2e/TEST_REGISTRY.md` updated (feature 051)
- [x] Lint 0 errors · `pnpm format:check` clean · `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)