### PR TITLE
chore(release): promote dev to main — canvas selection-delete & text-clipping fix

### DIFF
--- a/e2e/TEST_REGISTRY.md
+++ b/e2e/TEST_REGISTRY.md
@@ -56,6 +56,7 @@ When adding or modifying a feature, update this registry and write the correspon
 - [x] Add new page manually — ⚠️ SKIPPED IN CI
 - [x] Type mode — multi-paragraph input overflows to new pages (`e2e/canvas-type-mode-flow.spec.ts`)
 - [x] Type mode — long URL wraps at the right edge instead of clipping (`e2e/canvas-type-mode-flow.spec.ts`)
+- [x] Type mode — page text layer clips overflow so spilled/pasted text never renders past the page edge (regression guard for abbe925 overflow-visible) (`e2e/canvas-type-mode-flow.spec.ts`)
 
 ---
 

--- a/e2e/canvas-type-mode-flow.spec.ts
+++ b/e2e/canvas-type-mode-flow.spec.ts
@@ -115,6 +115,28 @@ test.describe('Canvas Editor — Type mode text reflow (issue #118)', () => {
     ).toBeVisible();
   });
 
+  test('the page text layer clips overflow so spilled/pasted text never renders past the page edge', async ({
+    page,
+  }) => {
+    // Regression guard for the abbe925 change that flipped this layer from
+    // overflow-hidden to overflow-visible (to un-clip LaTeX menus, which are
+    // now portaled to document.body instead). With overflow-visible, content
+    // that overflows the fixed-height page — e.g. a large paste before the
+    // reflow settles, or a single un-splittable block — paints OUTSIDE the
+    // page boundary. The text layer must clip.
+    const textLayer = page
+      .locator('[data-page-id]')
+      .first()
+      .locator('[data-text-layer]');
+    await expect(textLayer).toBeAttached();
+
+    const overflow = await textLayer.evaluate(
+      (el) => getComputedStyle(el).overflow,
+    );
+    // 'hidden' or 'clip' both clip; 'visible' is the regression.
+    expect(overflow).not.toBe('visible');
+  });
+
   test('a long URL with no word boundaries wraps inside the page instead of being clipped', async ({
     page,
   }) => {

--- a/src/components/canvas/canvas-page.tsx
+++ b/src/components/canvas/canvas-page.tsx
@@ -766,10 +766,17 @@ export function CanvasPage({
         />
       ))}
 
-      {/* Layer 4: Text content layer — only interactive in text mode */}
+      {/* Layer 4: Text content layer — only interactive in text mode.
+          MUST clip (overflow-hidden): this is the page-level guard that hides
+          any text spilling past the page edge before the overflow handler
+          reflows it to the next page. LaTeX bubble menus / edit panels and the
+          Read-mode Ask AI bar escape this clip via React portals to
+          document.body (see math-node-view.tsx), so clipping here does not
+          re-introduce the menu-clipping issue that abbe925 was fixing. */}
       <div
         ref={textLayerRef}
-        className="absolute inset-0 overflow-visible"
+        data-text-layer
+        className="absolute inset-0 overflow-hidden"
         style={{
           pointerEvents:
             isInteractionMode ||

--- a/src/components/canvas/text-box.tsx
+++ b/src/components/canvas/text-box.tsx
@@ -14,6 +14,7 @@ import { AutoDirection } from '@/lib/editor/rtl-extension';
 import { Indent } from '@/lib/editor/indent-extension';
 import { FontSize } from '@/lib/editor/font-size-extension';
 import { MathExpression } from '@/lib/editor/math-extension';
+import { shouldInterceptBackspaceAtStart } from '@/lib/canvas/cross-page-backspace';
 import type { TextBox as TextBoxData } from '@/types/canvas';
 import type { Editor } from '@tiptap/core';
 
@@ -106,10 +107,12 @@ export function TextBox({
       // the parent (canvas-editor) for cross-page merge.
       handleKeyDown: (view, event) => {
         if (event.key === 'Backspace' && !event.shiftKey) {
-          const { from } = view.state.selection;
-          // Position 1 = start of first block's text content.
-          // Also handle position 0 (before the first block).
-          if (from <= 1) {
+          const { from, empty } = view.state.selection;
+          // Only intercept a COLLAPSED cursor at the very start (position 1 =
+          // offset 0 inside the first block; position 0 = before it). A
+          // non-empty selection that merely starts here — e.g. Ctrl+A
+          // select-all — must fall through to ProseMirror's native delete.
+          if (shouldInterceptBackspaceAtStart({ from, empty })) {
             const cb = onBackspaceAtStartRef.current;
             if (cb) {
               event.preventDefault();

--- a/src/lib/canvas/__tests__/cross-page-backspace.test.ts
+++ b/src/lib/canvas/__tests__/cross-page-backspace.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { shouldInterceptBackspaceAtStart } from '../cross-page-backspace';
+
+describe('shouldInterceptBackspaceAtStart', () => {
+  it('intercepts a collapsed cursor at the very start of the first block', () => {
+    // Empty selection at doc position 1 (offset 0 inside the first block).
+    expect(shouldInterceptBackspaceAtStart({ from: 1, empty: true })).toBe(
+      true,
+    );
+  });
+
+  it('intercepts a collapsed cursor at position 0 (before the first block)', () => {
+    expect(shouldInterceptBackspaceAtStart({ from: 0, empty: true })).toBe(
+      true,
+    );
+  });
+
+  it('does NOT intercept when a non-empty selection starts at the start', () => {
+    // This is the Ctrl+A case: selection spans from 1 to end-of-page. We must
+    // let ProseMirror delete the selection natively instead of swallowing it
+    // and triggering a cross-page merge.
+    expect(shouldInterceptBackspaceAtStart({ from: 1, empty: false })).toBe(
+      false,
+    );
+  });
+
+  it('does NOT intercept a collapsed cursor in the middle of a block', () => {
+    // from > 1 means there is a character before the cursor; ProseMirror's
+    // native joinBackward/delete handles it.
+    expect(shouldInterceptBackspaceAtStart({ from: 5, empty: true })).toBe(
+      false,
+    );
+  });
+
+  it('does NOT intercept a non-empty selection in the middle', () => {
+    expect(shouldInterceptBackspaceAtStart({ from: 5, empty: false })).toBe(
+      false,
+    );
+  });
+});

--- a/src/lib/canvas/cross-page-backspace.ts
+++ b/src/lib/canvas/cross-page-backspace.ts
@@ -1,0 +1,28 @@
+/**
+ * Pure rule for whether a Backspace keystroke inside a page's text box should
+ * be intercepted and handed off to the cross-page merge handler (which pulls
+ * the first block of this page up into the previous page, Word/Docs-style).
+ *
+ * Extracted as a pure function so the guard can be unit-tested without DOM,
+ * ProseMirror, or React — matching cursor-target.ts / text-split.ts.
+ *
+ * Called from text-box.tsx `handleKeyDown`.
+ *
+ * The critical rule is the `empty` check: we must ONLY intercept when the
+ * selection is collapsed (a bare cursor). When the selection is a non-empty
+ * RANGE that merely *starts* at the document start — which is exactly what a
+ * Ctrl+A select-all looks like — Backspace must fall through to ProseMirror's
+ * native "delete the selection" behavior. The original guard checked only
+ * `from <= 1`, so it swallowed every select-all delete (the #2 regression
+ * introduced in commit 7c33153).
+ */
+export function shouldInterceptBackspaceAtStart(selection: {
+  /** `view.state.selection.from` — the lower bound of the selection. */
+  from: number;
+  /** `view.state.selection.empty` — true when the cursor is collapsed. */
+  empty: boolean;
+}): boolean {
+  // Only a collapsed cursor sitting at the very start of the first block.
+  // Position 1 = offset 0 inside the first block; position 0 = before it.
+  return selection.empty && selection.from <= 1;
+}


### PR DESCRIPTION
## Release: `dev` → `main`

Promotes the current `dev` to production. Built as a single promote-commit (`parent=main`, `tree=dev`) to avoid the known dev/main evil-twin history conflict (same approach as #220).

### True payload (net diff `main`→`dev` = 6 files)
`main` already carries the AI usage-analytics work from prior promotions, so the only content genuinely new to prod is the **canvas editor regression fix** (#233):

- `src/components/canvas/text-box.tsx` — Backspace intercept now guards on a **collapsed** cursor, so selection-deletes work again
- `src/components/canvas/canvas-page.tsx` — text layer restored to `overflow-hidden` (no text painting outside the page)
- `src/lib/canvas/cross-page-backspace.ts` (+ unit test) — pure intercept guard
- `e2e/canvas-type-mode-flow.spec.ts` + `e2e/TEST_REGISTRY.md` — overflow-clip regression guard

### Deploy safety
- ✅ **No DB migration** in the payload — purely client-side editor code
- ✅ No env-var or admin changes required
- ⚠️ Deploy is CI-gated (`deploy` job `needs: ci`); watch the `main` CI run and rerun on flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)